### PR TITLE
feat(i18n): add Spanish translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Thaw is currently available in the following languages:
 | **Deutsch**  | Complete |  🇩🇪  | ![100%](https://geps.dev/progress/100) |
 | **Français** | Complete |  🇫🇷  | ![100%](https://geps.dev/progress/100) |
 | **正體中文** | Complete |  🇹🇼  | ![100%](https://geps.dev/progress/100) |
+| **Spanish** | Complete |  🇪🇸/🇲🇽  | ![100%](https://geps.dev/progress/100) |
 
 ### Help Translate Thaw
 

--- a/Thaw/Resources/Localizable.xcstrings
+++ b/Thaw/Resources/Localizable.xcstrings
@@ -22,6 +22,12 @@
             "state" : "translated",
             "value" : "%@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@"
+          }
         }
       }
     },
@@ -45,6 +51,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ 項目"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elemento de %@"
           }
         }
       }
@@ -70,6 +82,12 @@
             "state" : "translated",
             "value" : "%@ 可以在沒有此權限的情況下以有限模式運作。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ puede funcionar en modo limitado sin este permiso."
+          }
         }
       }
     },
@@ -93,6 +111,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ 無法在自動隱藏的選單列中排列項目。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ no puede organizar los elementos de la barra de menús en barras ocultas automáticamente."
           }
         }
       }
@@ -118,6 +142,12 @@
             "state" : "translated",
             "value" : "%@ 無法編輯自動隱藏選單列的外觀。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ no puede editar la apariencia de las barras ocultas automáticamente."
+          }
         }
       }
     },
@@ -141,6 +171,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ 圖示"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Icono de %@"
           }
         }
       }
@@ -166,6 +202,12 @@
             "state" : "translated",
             "value" : "%@ 需要此權限來："
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ necesita este permiso para:"
+          }
         }
       }
     },
@@ -190,6 +232,12 @@
             "state" : "translated",
             "value" : "%@ 需要您的許可來管理選單列。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ necesita tu permiso para administrar la barra de menús."
+          }
         }
       }
     },
@@ -210,6 +258,12 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1"
+          }
+        },
+        "es" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "1"
@@ -238,6 +292,12 @@
             "state" : "translated",
             "value" : "2"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2"
+          }
         }
       }
     },
@@ -258,6 +318,12 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3"
+          }
+        },
+        "es" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "3"
@@ -286,6 +352,12 @@
             "state" : "translated",
             "value" : "絕不收集或儲存任何個人資訊。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se recopila ni almacena ninguna información personal."
+          }
         }
       }
     },
@@ -309,6 +381,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "致謝"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Créditos y licencias"
           }
         }
       }
@@ -334,6 +412,12 @@
             "state" : "translated",
             "value" : "套用"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplicar"
+          }
         }
       }
     },
@@ -357,6 +441,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "根據目前的系統外觀套用不同設定。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplicar ajustes diferentes según la apariencia actual del sistema."
           }
         }
       }
@@ -382,6 +472,12 @@
             "state" : "translated",
             "value" : "套用目前的間距"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplicar el espaciado actual"
+          }
         }
       }
     },
@@ -405,6 +501,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "套用此設定將重新啟動所有含有選單列項目的應用程式。部分應用程式可能需要手動重新啟動。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplicar este ajuste reiniciará todas las apps con elementos en la barra de menús. Es posible que algunas apps deban reiniciarse manualmente."
           }
         }
       }
@@ -430,6 +532,12 @@
             "state" : "translated",
             "value" : "自動檢查更新"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar actualizaciones automáticamente"
+          }
         }
       }
     },
@@ -453,6 +561,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自動下載並安裝更新"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descargar e instalar actualizaciones automáticamente"
           }
         }
       }
@@ -478,6 +592,12 @@
             "state" : "translated",
             "value" : "自動下載更新"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descargar actualizaciones automáticamente"
+          }
         }
       }
     },
@@ -502,6 +622,12 @@
             "state" : "translated",
             "value" : "自動重新隱藏"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ocultar automáticamente"
+          }
         }
       }
     },
@@ -522,6 +648,12 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BETA"
+          }
+        },
+        "es" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "BETA"
@@ -550,6 +682,12 @@
             "state" : "translated",
             "value" : "邊框"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Borde"
+          }
         }
       }
     },
@@ -573,6 +711,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "邊框顏色"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Color del borde"
           }
         }
       }
@@ -598,6 +742,12 @@
             "state" : "translated",
             "value" : "邊框寬度"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grosor del borde"
+          }
         }
       }
     },
@@ -621,6 +771,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
           }
         }
       }
@@ -646,6 +802,12 @@
             "state" : "translated",
             "value" : "自動檢查"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar automáticamente"
+          }
         }
       }
     },
@@ -669,6 +831,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "檢查更新"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar actualizaciones"
           }
         }
       }
@@ -694,6 +862,12 @@
             "state" : "translated",
             "value" : "是否自動檢查更新？"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Buscar actualizaciones automáticamente?"
+          }
         }
       }
     },
@@ -717,6 +891,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "V 形箭頭"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chevron"
           }
         }
       }
@@ -742,6 +922,12 @@
             "state" : "translated",
             "value" : "選擇要在選單列中顯示的自訂圖示。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elige un icono personalizado para mostrar en la barra de menús."
+          }
         }
       }
     },
@@ -765,6 +951,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選擇圖片⋯"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elegir imagen…"
           }
         }
       }
@@ -790,6 +982,12 @@
             "state" : "translated",
             "value" : "點按選單列的空白區域以顯示隱藏的選單列項目。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Haz clic en un área vacía de la barra de menús para mostrar los elementos ocultos de la barra de menús."
+          }
         }
       }
     },
@@ -813,6 +1011,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "點按以顯示隱藏項目，或雙擊顯示永久隱藏項目。右鍵點按開啟 %@ 的設定。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Haz clic para mostrar los elementos ocultos o haz doble clic para ver los siempre ocultos. Haz clic derecho para abrir los ajustes de %@."
           }
         }
       }
@@ -838,6 +1042,12 @@
             "state" : "translated",
             "value" : "繼續"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuar"
+          }
         }
       }
     },
@@ -861,6 +1071,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "以有限模式繼續"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuar en modo limitado"
           }
         }
       }
@@ -886,6 +1102,12 @@
             "state" : "translated",
             "value" : "貢獻"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contribuir"
+          }
         }
       }
     },
@@ -909,6 +1131,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自訂圖示使用動態外觀"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El icono personalizado usa apariencia dinámica."
           }
         }
       }
@@ -934,6 +1162,12 @@
             "state" : "translated",
             "value" : "深色外觀"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo oscuro"
+          }
         }
       }
     },
@@ -957,6 +1191,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "開發版"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desarrollo"
           }
         }
       }
@@ -982,6 +1222,12 @@
             "state" : "translated",
             "value" : "將圖示顯示為單色圖片，動態調整以匹配選單列的外觀。此設定會移除圖示的所有色彩，但可確保在淺色和深色背景下都能一致呈現。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar el icono como una imagen monocromática que se ajusta dinámicamente a la apariencia de la barra de menús. Este ajuste elimina todo el color del icono, pero garantiza una visualización uniforme con fondos claros y oscuros."
+          }
         }
       }
     },
@@ -1005,6 +1251,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不要檢查"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No buscar"
           }
         }
       }
@@ -1030,6 +1282,12 @@
             "state" : "translated",
             "value" : "完成"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listo"
+          }
         }
       }
     },
@@ -1053,6 +1311,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "拖移以將選單列項目排列至不同區域。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arrastra para organizar los elementos de la barra de menús en secciones."
           }
         }
       }
@@ -1078,6 +1342,12 @@
             "state" : "translated",
             "value" : "動態"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dinámico"
+          }
         }
       }
     },
@@ -1101,6 +1371,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "錯誤"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ERROR"
           }
         }
       }
@@ -1126,6 +1402,12 @@
             "state" : "translated",
             "value" : "啟用次要右鍵選單"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Habilitar el menú contextual secundario"
+          }
         }
       }
     },
@@ -1149,6 +1431,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "啟用 %@ 列"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar la barra de %@"
           }
         }
       }
@@ -1174,6 +1462,12 @@
             "state" : "translated",
             "value" : "啟用永久隱藏區域"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar la sección siempre oculta"
+          }
         }
       }
     },
@@ -1197,6 +1491,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "焦點"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enfoque"
           }
         }
       }
@@ -1222,6 +1522,12 @@
             "state" : "translated",
             "value" : "全幅"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completa"
+          }
         }
       }
     },
@@ -1245,6 +1551,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "前往進階設定"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ir a ajustes avanzados"
           }
         }
       }
@@ -1270,6 +1582,12 @@
             "state" : "translated",
             "value" : "漸層"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gradiente"
+          }
         }
       }
     },
@@ -1293,6 +1611,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "授予權限"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Habilitar permiso"
           }
         }
       }
@@ -1318,6 +1642,12 @@
             "state" : "translated",
             "value" : "顯示選單列項目時隱藏應用程式選單"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ocultar los menús de la app al mostrar los elementos de la barra de menús"
+          }
         }
       }
     },
@@ -1341,6 +1671,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "按住預覽"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantener para previsualizar"
           }
         }
       }
@@ -1366,6 +1702,12 @@
             "state" : "translated",
             "value" : "此快速鍵已被 macOS 保留"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El atajo de teclado está reservado por macOS"
+          }
         }
       }
     },
@@ -1387,6 +1729,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "將游標懸停在選單列的空白區域以顯示隱藏的選單列項目。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pasa el cursor sobre un área vacía de la barra de menús para mostrar los elementos ocultos de la barra de menús."
           }
         }
       }
@@ -1412,6 +1760,12 @@
             "state" : "translated",
             "value" : "Ice 圖示"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Icono de Ice"
+          }
         }
       }
     },
@@ -1435,6 +1789,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無法還原圖示位置。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las posiciones de los iconos no se pueden restaurar."
           }
         }
       }
@@ -1460,6 +1820,12 @@
             "state" : "translated",
             "value" : "匯入設定"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importar ajustes"
+          }
         }
       }
     },
@@ -1483,6 +1849,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "匯入失敗。您可以手動設定。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error al importar. Puedes configurar los ajustes manualmente."
           }
         }
       }
@@ -1508,6 +1880,12 @@
             "state" : "translated",
             "value" : "已匯入"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importado"
+          }
         }
       }
     },
@@ -1529,6 +1907,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "也可以透過 ⌘ Command + 拖移來排列選單列中的項目。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los elementos también se pueden organizar manteniendo ⌘ Command y arrastrándolos en la barra de menús."
           }
         }
       }
@@ -1554,6 +1938,12 @@
             "state" : "translated",
             "value" : "上次檢查：%@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Última comprobación: %@"
+          }
         }
       }
     },
@@ -1577,6 +1967,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "左側端蓋"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminación inicial"
           }
         }
       }
@@ -1602,6 +1998,12 @@
             "state" : "translated",
             "value" : "淺色外觀"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo claro"
+          }
         }
       }
     },
@@ -1625,6 +2027,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在載入選單列項目⋯"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cargando elementos de la barra de menús…"
           }
         }
       }
@@ -1650,6 +2058,12 @@
             "state" : "translated",
             "value" : "位置"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ubicación"
+          }
         }
       }
     },
@@ -1673,6 +2087,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在需要時隱藏目前的應用程式選單以騰出更多選單列空間。啟用此設定時，macOS 要求 %@ 在 Dock 中保持可見。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libera espacio en la barra de menús ocultando los menús de la app activa si es necesario. macOS requiere que %@ sea visible en el Dock mientras este ajuste esté activado."
           }
         }
       }
@@ -1698,6 +2118,12 @@
             "state" : "translated",
             "value" : "選單列外觀"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apariencia de la barra de menús"
+          }
         }
       }
     },
@@ -1721,6 +2147,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選單列項目"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elementos de la barra de menús"
           }
         }
       }
@@ -1746,6 +2178,12 @@
             "state" : "translated",
             "value" : "選單列區域"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Secciones de la barra de menús"
+          }
         }
       }
     },
@@ -1769,6 +2207,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選單列形狀"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estilo de la barra de menús"
           }
         }
       }
@@ -1794,6 +2238,12 @@
             "state" : "translated",
             "value" : "選單列項目間距"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espaciado entre elementos de la barra de menús"
+          }
         }
       }
     },
@@ -1817,6 +2267,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選單列項目會在固定時間後重新隱藏。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los elementos de la barra de menús se vuelven a ocultar después de un tiempo fijo."
           }
         }
       }
@@ -1842,6 +2298,12 @@
             "state" : "translated",
             "value" : "選單列項目會透過智慧演算法重新隱藏。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los elementos de la barra de menús se vuelven a ocultar mediante un algoritmo inteligente."
+          }
         }
       }
     },
@@ -1866,6 +2328,12 @@
             "state" : "translated",
             "value" : "當焦點應用程式變更時，選單列項目會重新隱藏。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los elementos de la barra de menús se vuelven a ocultar cuando cambia la app activa."
+          }
         }
       }
     },
@@ -1887,6 +2355,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選單列佈局需要螢幕錄影權限。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La disposición de la barra de menús requiere permisos de grabación de pantalla."
           }
         }
       }
@@ -1912,6 +2386,12 @@
             "state" : "translated",
             "value" : "滑鼠游標"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cursor"
+          }
         }
       }
     },
@@ -1935,6 +2415,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此區域中沒有項目"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay elementos en esta sección"
           }
         }
       }
@@ -1960,6 +2446,12 @@
             "state" : "translated",
             "value" : "未選擇形狀類型"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se ha seleccionado ningún estilo"
+          }
         }
       }
     },
@@ -1983,6 +2475,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ninguno"
           }
         }
       }
@@ -2008,6 +2506,12 @@
             "state" : "translated",
             "value" : "注意：您可能需要登出並重新登入才能正確套用此設定。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nota: es posible que tengas que cerrar sesión y volver a iniciarla para que este ajuste se aplique correctamente."
+          }
         }
       }
     },
@@ -2031,6 +2535,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "好"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         }
       }
@@ -2056,6 +2566,12 @@
             "state" : "translated",
             "value" : "開啟 %@ 設定"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir ajustes de %@"
+          }
         }
       }
     },
@@ -2079,6 +2595,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "其他"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otros"
           }
         }
       }
@@ -2104,6 +2626,12 @@
             "state" : "translated",
             "value" : "權限已授予"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permiso concedido"
+          }
         }
       }
     },
@@ -2127,6 +2655,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "權限"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permisos"
           }
         }
       }
@@ -2152,6 +2686,12 @@
             "state" : "translated",
             "value" : "結束"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salir"
+          }
         }
       }
     },
@@ -2175,6 +2715,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "結束 %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salir de %@"
           }
         }
       }
@@ -2200,6 +2746,12 @@
             "state" : "translated",
             "value" : "錄製快速鍵"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grabar atajo de teclado"
+          }
         }
       }
     },
@@ -2223,6 +2775,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "回報錯誤"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reportar error"
           }
         }
       }
@@ -2248,6 +2806,12 @@
             "state" : "translated",
             "value" : "重置"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer"
+          }
         }
       }
     },
@@ -2271,6 +2835,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重置佈局"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer organización"
           }
         }
       }
@@ -2296,6 +2866,12 @@
             "state" : "translated",
             "value" : "重置選單列外觀"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer apariencia de la barra de menús"
+          }
         }
       }
     },
@@ -2319,6 +2895,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重置選單列佈局"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer disposición de la barra de menús"
           }
         }
       }
@@ -2344,6 +2926,12 @@
             "state" : "translated",
             "value" : "重置選單列佈局？"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Restablecer la disposición de la barra de menús?"
+          }
         }
       }
     },
@@ -2367,6 +2955,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重置為預設間距"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer espaciado predeterminado"
           }
         }
       }
@@ -2392,6 +2986,12 @@
             "state" : "translated",
             "value" : "重置分隔線並將除 %@ 圖示外的所有可移動項目移至隱藏區域，就像全新安裝一樣。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restaura los separadores y mueve todos los elementos movibles, excepto el icono de %@, a Ocultos, como en una instalación nueva."
+          }
         }
       }
     },
@@ -2415,6 +3015,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "還原分隔線預設值，並將除 %@ 圖示外的所有可移動項目移至隱藏區域。如果佈局顯示異常或項目無法載入，請使用此功能。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restaura los separadores y mueve todos los elementos movibles, excepto el icono de %@, a Ocultos. Usa esta opción si la barra de menús se ve rara o si algunos elementos no aparecen."
           }
         }
       }
@@ -2440,6 +3046,12 @@
             "state" : "translated",
             "value" : "在選單列的空白區域右鍵點按以顯示 %@ 選單的精簡版本。如果與其他應用程式發生衝突，請停用此設定。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Haz clic derecho en un área vacía de la barra de menús para mostrar una versión reducida del menú de %@. Desactiva este ajuste si tienes conflictos con otras apps."
+          }
         }
       }
     },
@@ -2463,6 +3075,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "圓角端蓋"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminación redondeada"
           }
         }
       }
@@ -2488,6 +3106,12 @@
             "state" : "translated",
             "value" : "在選單列中捲動或滑動以顯示隱藏的選單列項目。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desplázate o desliza sobre la barra de menús para mostrar los elementos ocultos."
+          }
         }
       }
     },
@@ -2511,6 +3135,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "搜尋選單列項目"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar elementos de la barra de menús"
           }
         }
       }
@@ -2536,6 +3166,12 @@
             "state" : "translated",
             "value" : "搜尋選單列項目⋯"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar elementos de la barra de menús…"
+          }
         }
       }
     },
@@ -2559,6 +3195,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "區域分隔線樣式"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estilo del separador de secciones"
           }
         }
       }
@@ -2584,6 +3226,12 @@
             "state" : "translated",
             "value" : "陰影"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sombra"
+          }
         }
       }
     },
@@ -2607,6 +3255,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "形狀類型"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de forma"
           }
         }
       }
@@ -2632,6 +3286,12 @@
             "state" : "translated",
             "value" : "%@ 是否應自動檢查更新？您可以隨時透過 Thaw 選單列圖示或「設定」→「關於」手動檢查。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Debería %@ buscar actualizaciones automáticamente? Siempre puedes buscarlas manualmente desde el icono de Thaw en la barra de menús o en Ajustes → Acerca de."
+          }
         }
       }
     },
@@ -2655,6 +3315,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示 %@ 圖示"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar icono de %@"
           }
         }
       }
@@ -2680,6 +3346,12 @@
             "state" : "translated",
             "value" : "使用 ⌘ Command + 拖移選單列項目時顯示所有區域"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar todas las secciones al arrastrar elementos con ⌘ Command"
+          }
         }
       }
     },
@@ -2703,6 +3375,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在選單列下方的獨立列中顯示隱藏的選單列項目。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar los elementos ocultos de la barra de menús en una barra separada inferior."
           }
         }
       }
@@ -2728,6 +3406,12 @@
             "state" : "translated",
             "value" : "點按時顯示"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar al hacer clic"
+          }
         }
       }
     },
@@ -2751,6 +3435,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "懸停時顯示"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar al pasar el cursor"
           }
         }
       }
@@ -2776,6 +3466,12 @@
             "state" : "translated",
             "value" : "懸停顯示延遲"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retraso al pasar el cursor"
+          }
         }
       }
     },
@@ -2799,6 +3495,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "捲動時顯示"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar al desplazar"
           }
         }
       }
@@ -2824,6 +3526,12 @@
             "state" : "translated",
             "value" : "智慧"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inteligente"
+          }
         }
       }
     },
@@ -2848,6 +3556,12 @@
             "state" : "translated",
             "value" : "純色"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sólido"
+          }
         }
       }
     },
@@ -2869,6 +3583,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "分段"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dividida"
           }
         }
       }
@@ -2894,6 +3614,12 @@
             "state" : "translated",
             "value" : "方角端蓋"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminación cuadrada"
+          }
         }
       }
     },
@@ -2917,6 +3643,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "穩定版"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estable"
           }
         }
       }
@@ -2942,6 +3674,12 @@
             "state" : "translated",
             "value" : "策略"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estrategia"
+          }
         }
       }
     },
@@ -2965,6 +3703,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已成功匯入 %lld 項設定！"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¡%lld ajustes importados correctamente!"
           }
         }
       }
@@ -2990,6 +3734,12 @@
             "state" : "translated",
             "value" : "支持 %@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apoyar a %@"
+          }
         }
       }
     },
@@ -3013,6 +3763,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "暫時顯示項目延遲"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retraso de los elementos mostrados temporalmente"
           }
         }
       }
@@ -3044,6 +3800,12 @@
             "state" : "translated",
             "value" : "%1$@ 列會置中顯示在 %2$@ 圖示下方。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La barra de %1$@ se centra debajo del icono de %2$@."
+          }
         }
       }
     },
@@ -3067,6 +3829,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ 列會置中顯示在滑鼠游標下方。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La barra de %@ se centra debajo del cursor."
           }
         }
       }
@@ -3092,6 +3860,12 @@
             "state" : "translated",
             "value" : "%1$@ 列需要螢幕錄影權限。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La barra de %@ requiere permisos de grabación de pantalla."
+          }
         }
       }
     },
@@ -3115,6 +3889,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ 列的位置會根據情境動態調整。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La ubicación de la barra de %@ cambia según el contexto."
           }
         }
       }
@@ -3140,6 +3920,12 @@
             "state" : "translated",
             "value" : "在隱藏暫時顯示的選單列項目之前等待的時間。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiempo de espera antes de ocultar los elementos de la barra de menús mostrados temporalmente."
+          }
         }
       }
     },
@@ -3163,6 +3949,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "懸停後顯示前的等待時間。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiempo de espera antes de mostrar al pasar el cursor."
           }
         }
       }
@@ -3188,6 +3980,12 @@
             "state" : "translated",
             "value" : "此操作無法復原。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta acción no se puede deshacer."
+          }
         }
       }
     },
@@ -3211,6 +4009,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "定時"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Con retraso"
           }
         }
       }
@@ -3236,6 +4040,12 @@
             "state" : "translated",
             "value" : "色調"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tinte"
+          }
         }
       }
     },
@@ -3259,6 +4069,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "提示：您也可以在選單列的空白區域右鍵點按來編輯這些設定。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Consejo: También puedes editar estos ajustes haciendo clic derecho en un área vacía de la barra de menús."
           }
         }
       }
@@ -3284,6 +4100,12 @@
             "state" : "translated",
             "value" : "切換應用程式選單"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar/ocultar menús de la aplicación"
+          }
         }
       }
     },
@@ -3307,6 +4129,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切換永久隱藏區域"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar/ocultar la sección siempre oculta"
           }
         }
       }
@@ -3332,6 +4160,12 @@
             "state" : "translated",
             "value" : "切換隱藏區域"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar/ocultar la sección oculta"
+          }
         }
       }
     },
@@ -3355,6 +4189,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "右側端蓋"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminación final"
           }
         }
       }
@@ -3380,6 +4220,12 @@
             "state" : "translated",
             "value" : "輸入快速鍵"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escribir atajo de teclado"
+          }
         }
       }
     },
@@ -3403,6 +4249,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無法顯示選單列項目"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pueden mostrar los elementos de la barra de menús"
           }
         }
       }
@@ -3428,6 +4280,12 @@
             "state" : "translated",
             "value" : "無法載入選單列項目"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pueden cargar los elementos de la barra de menús"
+          }
         }
       }
     },
@@ -3451,6 +4309,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更新頻道"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizar canal"
           }
         }
       }
@@ -3476,6 +4340,12 @@
             "state" : "translated",
             "value" : "使用 %@ 列"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usar la barra de %@"
+          }
         }
       }
     },
@@ -3500,6 +4370,12 @@
             "state" : "translated",
             "value" : "使用動態外觀"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usar apariencia dinámica"
+          }
         }
       }
     },
@@ -3523,6 +4399,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在有瀏海的螢幕上使用內縮形狀"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usar forma recortada alrededor de la muesca en pantallas con notch"
           }
         }
       }
@@ -3554,6 +4436,12 @@
             "state" : "translated",
             "value" : "版本 %1$@ (%2$@)"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version %1$@ (%2$@)"
+          }
         }
       }
     },
@@ -3575,6 +4463,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "我們發現了來自 Ice（原始應用程式）的設定。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se encontraron ajustes de Ice (app original)."
           }
         }
       }
@@ -3600,6 +4494,12 @@
             "state" : "translated",
             "value" : "是否要匯入您現有的設定？"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Deseas importar tu configuración existente?"
+          }
         }
       }
     },
@@ -3623,6 +4523,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "預設"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "predeterminado"
           }
         }
       }
@@ -3648,6 +4554,12 @@
             "state" : "translated",
             "value" : "左鍵點按"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "click izquierdo"
+          }
         }
       }
     },
@@ -3669,6 +4581,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最大"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "máx"
           }
         }
       }
@@ -3694,6 +4612,12 @@
             "state" : "translated",
             "value" : "無"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ninguno"
+          }
         }
       }
     },
@@ -3718,6 +4642,12 @@
             "state" : "translated",
             "value" : "右鍵點按"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "click derecho"
+          }
         }
       }
     },
@@ -3738,6 +4668,12 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "•"
+          }
+        },
+        "es" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "•"


### PR DESCRIPTION
## Summary

- Language(s): Spanish
- Completion status: 100%
- Existing translations modified: No
- Other changes:
  -   Update the README to reflect the new language translation.
- Notes about tone / regional variant:
  -   Used some anglicisms to make actions and items clearer, while keeping a balance between European(español de España, Castellano, etc.) and Latin American Spanish (español latinoamericano).

## Test plan

- [X] Open `Thaw.xcodeproj` in Xcode
- [X] Open `Thaw → Resources → Localizable.xcstrings`
- [X] Confirm the new/updated language shows the expected completion
- [X] Build succeeds without errors
- [X] (Optional) Switch system language to this locale and verify UI strings look correct

