### PR TITLE
Add Pull Request templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -1,0 +1,49 @@
+## What does this PR do?
+
+A brief description of the changes proposed in this pull request.
+
+## PR Type
+
+- [ ] Bugfix
+- [ ] CI/CD related changes
+- [ ] Code style update (formatting, renaming)
+- [ ] Documentation
+- [ ] Feature
+- [ ] i18n/l10n (Translation/Localization)
+- [ ] Refactor
+- [ ] Performance improvement
+- [ ] Test addition or update
+- [ ] Other (please describe):
+
+## Does this PR introduce a breaking change?
+
+- [ ] Yes
+- [ ] No
+
+If yes, please describe the impact and migration path:
+
+## What is the current behavior?
+
+What is happening now?
+Issue Number: (if applicable, otherwise remove this line or write 'N/A')
+
+## What is the new behavior?
+
+What does this PR change or add?
+
+## PR Checklist
+
+- [ ] I’ve built and run the app locally
+- [ ] I’ve checked for console errors or crashes
+- [ ] I've run relevant tests and they pass
+- [ ] I've added or updated tests (if applicable)
+- [ ] I've updated documentation as needed
+- [ ] I've verified localized strings work correctly (if i18n/l10n changes)
+
+## Other information
+
+Screenshots, notes, links to related issues/PRs, or anything useful for reviewers.
+
+### Notes for reviewers
+
+Anything you’d like reviewers to focus on.

--- a/.github/PULL_REQUEST_TEMPLATE/localization.md
+++ b/.github/PULL_REQUEST_TEMPLATE/localization.md
@@ -1,0 +1,15 @@
+## Summary
+
+- Language(s): …
+- Completion status: … (e.g. 100% of keys translated)
+- Existing translations modified: Yes / No
+- Other changes (if any): …
+- Notes about tone / regional variant (optional): …
+
+## Test plan
+
+- [ ] Open `Thaw.xcodeproj` in Xcode
+- [ ] Open `Thaw → Resources → Localizable.xcstrings`
+- [ ] Confirm the new/updated language shows the expected completion
+- [ ] Build succeeds without errors
+- [ ] (Optional) Switch system language to this locale and verify UI strings look correct


### PR DESCRIPTION
## What does this PR do?

> Note: This template is a starting point based on patterns from other repos. I’m happy to adjust it based on your feedback.


Add new Pull Requests Templates to standardize how changes are described and reviewed. Includes:

- A general purpose template
- A specific template for localization/translation (i18n/l10n), in response to the increase in translation PRs.

The localization template is based on [feat(i18n): add zh-Hant translations and menu-related labels #47
](https://github.com/stonerl/Thaw/pull/47)

## PR Type

- [ ] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [X] Documentation
- [ ] Feature
- [X] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path:

## What is the current behavior?

There is no PR template, so contributors describe changes in different ways.

## What is the new behavior?

New PR templates are available, standardizing the descriptions, reviews and approval process. 

## PR Checklist

- [ ] I’ve built and run the app locally
- [ ] I’ve checked for console errors or crashes
- [ ] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [X] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

N/A
