### PR TITLE
ci: add initial CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ on:
 
 jobs:
   lint:
-    if: github.event.pull_request.draft == false
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/ci.yml"
+      - "Package.swift"
+      - "**/*.swift"
+  pull_request:
+    paths:
+      - ".github/workflows/ci.yml"
+      - "Package.swift"
+      - "**/*.swift"
+  workflow_dispatch:
+
+jobs:
+  lint:
+    if: github.event.pull_request.draft == false
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install SwiftLint
+        run: brew install swiftlint
+      - name: Run SwiftLint
+        run: swiftlint --strict
+
+  build:
+    runs-on: macos-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v5
+      # Issues with other Xcode versions, so we need to specify the version explicitly
+      - run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
+      - name: Build
+        run: |
+          xcodebuild -project Thaw.xcodeproj \
+          -scheme Thaw \
+          -destination platform=macOS \
+          -configuration Release \
+          MACOSX_DEPLOYMENT_TARGET=14.0 \
+          CODE_SIGN_IDENTITY="" \
+          CODE_SIGNING_REQUIRED=NO \
+          CODE_SIGNING_ALLOWED=NO \
+          build


### PR DESCRIPTION
## What does this PR do?

Initial setup for CI. It configures a workflow to lint the codebase using SwiftLint and build the application in release mode. 

## PR Type

- [ ]  Bugfix
- [X]  CI/CD related changes
- [ ]  Code style update (formatting, renaming)
- [ ]  Documentation / meta
- [ ]  Feature
- [ ]  i18n/l10n (Translation/Localization)
- [ ]  Refactor
- [ ]  Performance improvement
- [ ]  Test addition or update
- [ ]  Other (please describe):

## Does this PR introduce a breaking change?

- [ ]  Yes
- [x]  No

## What is the current behavior?

Currently, there’s no automated CI. PRs and commits are automatically linted, but not built.

## What is the new behavior?

- A new GitHub Actions workflow `ci.yml` is triggered on pushes to main and pull requests.
- The workflow includes two jobs:
  - Lint: Runs swiftlint --strict to ensure code quality.
  - Build: Builds the project using xcodebuild with a custom configuration.
- The build job now depends on the lint job passing.

## PR Checklist

- [ ]  I’ve built and run the app locally
- [ ]  I’ve checked for console errors or crashes
- [ ]  I've run relevant tests and they pass
- [ ]  I've added or updated tests (if applicable)
- [ ]  I've updated documentation/meta as needed
- [ ]  I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

1. There were issues with certain Xcode versions. Currently, the workflow is restricted to Xcode 26.2. I’m not sure if these issues are limited to the workflow, but every version below 16.4 had problems building the project.
2. The workflow is configured to run on macOS runners to ensure compatibility with the required Xcode environment and Apple Silicon performance. As per the GitHub documentation, using macOS runners for a public repository does not incur any additional costs.