### PR TITLE
i18n: add missing Traditional Chinese (zh-Hant) translations

### DIFF
--- a/Thaw/Resources/Localizable.xcstrings
+++ b/Thaw/Resources/Localizable.xcstrings
@@ -6961,6 +6961,12 @@
             "state" : "translated",
             "value" : "노치가 있는 디스플레이에서만 가능합니다."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅在有相機區域的顯示器上"
+          }
         }
       }
     },
@@ -10659,6 +10665,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ 바는 노치가 있는 디스플레이에서만 사용됩니다. 다른 디스플레이에서는 메뉴 막대에 아이콘이 표시됩니다."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅在有相機區域的顯示器上使用 %@ 列。在其他顯示器上，於選單列中顯示圖像。"
           }
         }
       }


### PR DESCRIPTION
  ## Summary
  - Add 2 missing zh-Hant translations for notch display settings
  - Uses Apple Taiwan official terminology (相機區域, 圖像, 選單列)

  ## Strings added
  | Key | Translation |
  |-----|------------|
  | `Only on displays with notch` | 僅在有相機區域的顯示器上 |
  | `Use %@ Bar only on displays with a notch. On other displays, show icons in the menu bar.` | 僅在有相機區域的顯示器上使用 %@ 列。在其他顯示器上，於選單列中顯示圖像。 |

  ## Notes
  - zh-Hant coverage: 205/207 → 207/207 (100%)
  - Terminology reference: [Apple Support (zh-tw)](https://support.apple.com/zh-tw/102125)