### PR TITLE
fix: add sleep to busy-wait loop in waitForMoveEventResponse

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -1353,6 +1353,7 @@ extension MenuBarItemManager {
                 if origin != initialOrigin {
                     return origin
                 }
+                try await Task.sleep(for: .milliseconds(10))
             }
         }
         let timeoutTask = Task(timeout: timeout) {


### PR DESCRIPTION
  ## Summary
  - Add 10ms sleep to the polling loop in `waitForMoveEventResponse` to prevent 100% CPU usage during menu bar item move operations

  ## Problem
  The `while true` loop continuously calls `getCurrentBounds` (a Window Server IPC call) with no delay between iterations. This causes a CPU spike for the entire duration of each move
  operation.

  ## Fix
  Add `try await Task.sleep(for: .milliseconds(10))` — converts busy-wait into polling with sleep. 100 checks/second is more than sufficient for detecting item movement without
  perceptible delay.
