### PR TITLE
i18n: added FR translations

### DIFF
--- a/Thaw/Resources/Localizable.xcstrings
+++ b/Thaw/Resources/Localizable.xcstrings
@@ -8496,6 +8496,12 @@
             "value" : "Solo en pantallas con notch"
           }
         },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seulement sur les écrans avec une encoche"
+          }
+        },
         "hu" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13033,6 +13039,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Usa %@ Bar solo en pantallas con notch. En otras pantallas, muestra los íconos en la barra de menús."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utiliser la « %@ Bar » uniquement sur les écrans avec une encoche. Sur les autres écrans, afficher les icônes dans la barre des menus."
           }
         },
         "hu" : {


### PR DESCRIPTION
## Summary

- Language(s): FR
- Completion status: 100% of keys translated
- Existing translations modified: No

## Extra
During the review, I noticed that "seconds" was not translatable yet.

<img width="917" height="774" alt="Thaw Seconds" src="https://github.com/user-attachments/assets/ac1fe6e7-3370-467e-83ed-b4fed14b6320" />
