### PR TITLE
i18n: add zh-Hant translations for seconds pluralization

### DIFF
--- a/Thaw/Resources/Localizable.xcstrings
+++ b/Thaw/Resources/Localizable.xcstrings
@@ -784,6 +784,18 @@
               }
             }
           }
+        },
+        "zh-Hant" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lf 秒"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -840,6 +852,18 @@
                 "stringUnit" : {
                   "state" : "translated",
                   "value" : "%lld secondi"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hant" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld 秒"
                 }
               }
             }


### PR DESCRIPTION
  ## Summary
  - Add Traditional Chinese (zh-Hant) translations for the two new time unit pluralization keys introduced in 22c7976
    - `%lf seconds` → `%lf 秒`
    - `%lld seconds` → `%lld 秒`
  - zh-Hant now at 209/209 (100%) coverage

  ## Test plan
  - [ ] Verify slider displays "秒" correctly in Traditional Chinese locale
  - [ ] Verify rehide interval label displays "秒" correctly