### PR TITLE
fix: prevent stale warning for debug-only localized string

### DIFF
--- a/Thaw/Main/Updates.swift
+++ b/Thaw/Main/Updates.swift
@@ -27,6 +27,10 @@ final class UpdatesManager: NSObject, ObservableObject {
     /// Tracks whether the updater has been started.
     private var hasStartedUpdater = false
 
+    private var debugUpdateMessage: String {
+        String(localized: "Checking for updates is not supported in debug mode.")
+    }
+
     /// The underlying updater controller.
     private(set) lazy var updaterController = SPUStandardUpdaterController(
         startingUpdater: false,
@@ -110,7 +114,7 @@ final class UpdatesManager: NSObject, ObservableObject {
         #if DEBUG
             // Checking for updates hangs in debug mode.
             let alert = NSAlert()
-            alert.messageText = String(localized: "Checking for updates is not supported in debug mode.")
+            alert.messageText = debugUpdateMessage
             alert.runModal()
         #else
             guard let appState else {


### PR DESCRIPTION
## What does this PR do?

Fixes a stale localization warning triggered by a `String(localized:)` call that is only used in debug builds.

## PR Type

- [x] Bugfix

## Does this PR introduce a breaking change?

- [x] No

## What is the current behavior?

The localized string for the debug-only "Checking for updates is not supported in debug mode." alert was being flagged as stale when building in non-debug configurations, because the string extractor registered the key but it was never reachable in release builds.

## What is the new behavior?

The string is moved into a computed property (`debugUpdateMessage`) that is only referenced inside a `#if DEBUG` block. The extractor now correctly skips it in non-debug builds, eliminating the stale warning.

## PR Checklist

- [X] I've built and run the app locally
- [X] I've checked for console errors or crashes
- [ ] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [X] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

No functional change, debug behavior is identical. Release builds are unaffected. 

### Notes for reviewers

Please verify the stale warning no longer appears in your environment. I tested using both the **Run** and **Profile** build configurations in Xcode and the warning was gone in both cases.