### PR TITLE
fix(deps): raise Sparkle minimum version to 2.8.1

### DIFF
--- a/Thaw.xcodeproj/project.pbxproj
+++ b/Thaw.xcodeproj/project.pbxproj
@@ -576,7 +576,7 @@
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.5.2;
+				minimumVersion = 2.8.1;
 			};
 		};
 		1750618F2B1543DD003144CD /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */ = {


### PR DESCRIPTION
## Why
- Ensure dependency resolution never falls below Sparkle 2.8.1.
- Security context requested in review: include CVE-2025-5057 as a tracking reference.
- For Sparkle specifically, relevant 2025 disclosed issue is CVE-2025-0509 (affected: versions before 2.6.4); setting minimum to 2.8.1 keeps resolution above that affected range.

## How
- Updated the Sparkle SwiftPM requirement in Thaw.xcodeproj/project.pbxproj from 2.5.2 to 2.8.1.
- Kept Package.resolved unchanged since it already resolves to Sparkle 2.8.1.

## Tests
- xcodebuild -project Thaw.xcodeproj -scheme Thaw -configuration Debug CODE_SIGNING_ALLOWED=NO -quiet build (passed)