### PR TITLE
perf: replace NSStringFromRect with direct CGRect comparison in Equatable/Hashable

### DIFF
--- a/Shared/Utilities/WindowInfo.swift
+++ b/Shared/Utilities/WindowInfo.swift
@@ -191,7 +191,7 @@ extension WindowInfo: Equatable {
     static func == (lhs: WindowInfo, rhs: WindowInfo) -> Bool {
         lhs.windowID == rhs.windowID &&
             lhs.ownerPID == rhs.ownerPID &&
-            NSStringFromRect(lhs.bounds) == NSStringFromRect(rhs.bounds) &&
+            lhs.bounds == rhs.bounds &&
             lhs.layer == rhs.layer &&
             lhs.title == rhs.title &&
             lhs.ownerName == rhs.ownerName &&
@@ -205,7 +205,10 @@ extension WindowInfo: Hashable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(windowID)
         hasher.combine(ownerPID)
-        hasher.combine(NSStringFromRect(bounds))
+        hasher.combine(bounds.origin.x)
+        hasher.combine(bounds.origin.y)
+        hasher.combine(bounds.size.width)
+        hasher.combine(bounds.size.height)
         hasher.combine(layer)
         hasher.combine(title)
         hasher.combine(ownerName)

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItem.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItem.swift
@@ -337,7 +337,7 @@ extension MenuBarItem: Equatable {
             lhs.windowID == rhs.windowID &&
             lhs.ownerPID == rhs.ownerPID &&
             lhs.sourcePID == rhs.sourcePID &&
-            NSStringFromRect(lhs.bounds) == NSStringFromRect(rhs.bounds) &&
+            lhs.bounds == rhs.bounds &&
             lhs.title == rhs.title &&
             lhs.isOnScreen == rhs.isOnScreen
     }
@@ -351,7 +351,10 @@ extension MenuBarItem: Hashable {
         hasher.combine(windowID)
         hasher.combine(ownerPID)
         hasher.combine(sourcePID)
-        hasher.combine(NSStringFromRect(bounds))
+        hasher.combine(bounds.origin.x)
+        hasher.combine(bounds.origin.y)
+        hasher.combine(bounds.size.width)
+        hasher.combine(bounds.size.height)
         hasher.combine(title)
         hasher.combine(isOnScreen)
     }


### PR DESCRIPTION
  ## Summary

  - Replace `NSStringFromRect()` string comparison with direct `CGRect` equality in `MenuBarItem` and `WindowInfo` `Equatable` conformances
  - Replace `NSStringFromRect()` string hashing with direct `CGFloat` component hashing in `Hashable` conformances
  - Eliminates unnecessary `NSString` allocation and floating-point formatting on every equality check and hash computation

  ## Motivation

  `MenuBarItem` and `WindowInfo` are frequently compared in Combine pipelines (`removeDuplicates()`), Set operations, and dictionary lookups. Converting `CGRect` to `NSString`
   on every comparison is orders of magnitude slower than direct numeric comparison. `CGRect` already conforms to `Equatable`, and `CGFloat` already conforms to `Hashable`.

  ## Files changed

  - `Thaw/MenuBar/MenuBarItems/MenuBarItem.swift` — `Equatable` and `Hashable`
  - `Shared/Utilities/WindowInfo.swift` — `Equatable` and `Hashable`

  ## Test plan

  - [ ] Build and run the app
  - [ ] Verify menu bar items display and toggle correctly
  - [ ] Verify IceBar and search panel work as expected