### PR TITLE
perf: reuse computed shapePath for border drawing instead of recomputing

### DIFF
--- a/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
+++ b/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
@@ -941,25 +941,7 @@ private final class MenuBarOverlayPanelContentView: NSView {
                     context.restoreGraphicsState()
                 }
 
-                let borderPath =
-                    switch fullConfiguration.shapeKind {
-                    case .noShape:
-                        NSBezierPath(rect: drawableBounds)
-                    case .full:
-                        pathForFullShape(
-                            in: drawableBounds,
-                            info: fullConfiguration.fullShapeInfo,
-                            isInset: fullConfiguration.isInset,
-                            screen: overlayPanel.owningScreen
-                        )
-                    case .split:
-                        pathForSplitShape(
-                            in: drawableBounds,
-                            info: fullConfiguration.splitShapeInfo,
-                            isInset: fullConfiguration.isInset,
-                            screen: overlayPanel.owningScreen
-                        )
-                    }
+                let borderPath = shapePath
 
                 // HACK: Insetting a path to get an "inside" stroke is surprisingly
                 // difficult. We can fake the correct line width by doubling it, as


### PR DESCRIPTION
  ## Summary

  - Reuse the already-computed `shapePath` when drawing the border in `MenuBarOverlayPanel.draw(_:)`, instead of recomputing the exact same path a second time
  - The duplicated computation includes expensive `NSBezierPath.union()` operations (via `pathForFullShape` / `pathForSplitShape`) that run on every draw call when borders are
   enabled

  ## Files changed

  - `Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift` — replaced 18-line duplicate switch block with `let borderPath = shapePath`

  ## Test plan

  - [ ] Build and run the app
  - [ ] Enable menu bar border in appearance settings
  - [ ] Verify border renders correctly with all shape kinds (no shape, full, split)
  - [ ] Verify on both notch and non-notch displays if available
