### PR TITLE
fix: eliminate KVO subscription accumulation in publisherForWindow

### DIFF
--- a/Thaw/Main/AppState.swift
+++ b/Thaw/Main/AppState.swift
@@ -379,17 +379,10 @@ final class AppState: ObservableObject {
 
     /// Returns a publisher for the window with the given identifier.
     func publisherForWindow(_ id: IceWindowIdentifier) -> some Publisher<NSWindow?, Never> {
-        NSApp.publisher(for: \.windows).mergeMap { window in
-            window.publisher(for: \.identifier)
-                .map { [weak window] identifier in
-                    guard identifier?.rawValue == id.rawValue else {
-                        return nil
-                    }
-                    return window
-                }
-                .first { $0 != nil }
-                .replaceEmpty(with: nil)
-        }
+        NSApp.publisher(for: \.windows)
+            .map { windows in
+                windows.first { $0.identifier?.rawValue == id.rawValue }
+            }
     }
 
     /// Opens the window with the given identifier.


### PR DESCRIPTION
  ## Summary

  - Replace `mergeMap` + per-window KVO subscriptions with a simple `map` + array scan in `publisherForWindow`
  - The previous implementation created a new KVO observer on `\.identifier` for every window in `NSApp.windows` on every array change, and never cancelled old subscriptions —
   causing unbounded observer accumulation
  - The new implementation simply scans the windows array on each change, which is O(n) on a small array (~10 windows) and creates zero long-lived subscriptions

  ## Files changed

  - `Thaw/Main/AppState.swift` — `publisherForWindow(_:)`

  ## Test plan

  - [ ] Build and run the app
  - [ ] Open and close the settings window multiple times
  - [ ] Verify settings window detection still works (settings-dependent features respond correctly)
  - [ ] Monitor memory usage in Activity Monitor — should no longer grow with repeated window open/close cycles
