### PR TITLE
fix: eliminate data race in image cache saveToDisk

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -114,10 +114,10 @@ final class MenuBarItemImageCache: ObservableObject {
 
         guard let url = Self.cacheFileURL else { return }
 
-        Task.detached(priority: .background) { [weak self] in
-            guard let self else { return }
+        let snapshot = images
 
-            let cacheData = self.images.map { tag, image -> (String, Data)? in
+        Task.detached(priority: .background) {
+            let cacheData = snapshot.map { tag, image -> (String, Data)? in
                 let nsImage = NSImage(cgImage: image.cgImage, size: image.scaledSize)
                 guard let tiffData = nsImage.tiffRepresentation,
                       let bitmap = NSBitmapImageRep(data: tiffData),
@@ -128,7 +128,7 @@ final class MenuBarItemImageCache: ObservableObject {
                 return (tagString, pngData)
             }.compactMap { $0 }
 
-            guard cacheData.count == self.images.count else { return }
+            guard cacheData.count == snapshot.count else { return }
 
             do {
                 let directoryURL = url.deletingLastPathComponent()


### PR DESCRIPTION
  ## Summary

  - Snapshot `images` dictionary on the calling thread before entering the detached background task
  - Previously, `Task.detached` captured `[weak self]` and accessed `self.images` from a background thread while the main thread could simultaneously mutate it — a read/write
  data race that could cause crashes or corrupted reads
  - Also removes the unnecessary `[weak self]` capture since the task now operates entirely on the snapshot

  ## Files changed

  - `Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift` — `saveToDisk()`

  ## Test plan

  - [ ] Build and run the app
  - [ ] Trigger cache save (activate/deactivate app several times)
  - [ ] Verify disk cache is written correctly (check `~/Library/Caches/com.stonerl.Thaw/`)
  - [ ] Run with Thread Sanitizer enabled in Xcode to confirm no data race warnings
