### PR TITLE
perf(rehide): add time-based throttle to mouseMoved event monitor

### DIFF
--- a/Thaw/MenuBar/MenuBarSection.swift
+++ b/Thaw/MenuBar/MenuBarSection.swift
@@ -280,6 +280,14 @@ final class MenuBarSection {
             }
         case .timed:
             rehideMonitor = EventMonitor.universal(for: .mouseMoved) { [weak self] event in
+                // Throttle: process at most ~20fps regardless of mouse polling rate.
+                enum Context {
+                    static var lastTime: TimeInterval = 0
+                }
+                let now = CACurrentMediaTime()
+                guard now - Context.lastTime > 0.05 else { return event }
+                Context.lastTime = now
+
                 guard
                     let self,
                     let screen = NSScreen.main


### PR DESCRIPTION
  ## Summary

  The timed rehide strategy uses an `EventMonitor.universal(for: .mouseMoved)` to detect when the cursor leaves the menu bar area. Previously, the handler ran on **every**
  mouse-moved event without any throttling — potentially hundreds of invocations per second on the main thread.

  This PR adds a `CACurrentMediaTime()`-based throttle that caps processing at ~20fps (50ms interval), which is more than sufficient for detecting whether the cursor is above
  or below the menu bar.

  ## Changes

  - `Thaw/MenuBar/MenuBarSection.swift` — added early return in the `mouseMoved` handler when less than 50ms has elapsed since the last processed event

  ## Design decisions

  - **Time-based over count-based:** A count-based approach (`eventCount % N`) depends on mouse hardware polling rate (125Hz–8000Hz), giving inconsistent results across
  devices. Time-based throttling guarantees consistent behavior.
  - **50ms / ~20fps:** The handler only compares `mouseLocation.y` against `screen.visibleFrame.maxY` — a coarse spatial check that doesn't benefit from sub-50ms precision.

  ## Test plan

  - [ ] Build and run the app
  - [ ] Enable auto-rehide with "timed" strategy
  - [ ] Show the hidden section, move mouse below menu bar → verify rehide timer fires
  - [ ] Move mouse back into menu bar → verify timer cancels
  - [ ] Test with trackpad and external mouse