### PR TITLE
fix(cache): retain memory pressure dispatch source to prevent premature deallocation

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -87,6 +87,11 @@ final class MenuBarItemImageCache: ObservableObject {
     /// The currently running cache update task, if any.
     private var currentUpdateTask: Task<Void, Never>?
 
+    deinit {
+        memoryPressureSource?.cancel()
+        currentUpdateTask?.cancel()
+    }
+
     // MARK: Setup
 
     /// Sets up the cache.


### PR DESCRIPTION
  ## Summary
  - Fix `DispatchSourceMemoryPressure` in `MenuBarItemImageCache` being created as a local variable
    inside a `DispatchQueue.main.async` block and never stored — the source was immediately deallocated,
    so the memory pressure handler never fired
  - Store the source in an instance property and cancel any previous one on reconfiguration to prevent duplicates
  - Remove the unnecessary `DispatchQueue.main.async` wrapper since `configureCancellables()` is already `@MainActor`
  - Add `deinit` to cancel the dispatch source and in-flight update task for proper cleanup

  ## Test plan
  - [ ] Build and run the app
  - [ ] Simulate memory pressure (`sudo memory_pressure -l critical`) and verify the cache evicts images
  - [ ] Verify no leaks in Instruments (Allocations / Leaks template)
