### PR TITLE
perf(hover): cancel stale hover tasks to prevent unbounded accumulation

### DIFF
--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -30,6 +30,9 @@ final class HIDEventManager: ObservableObject {
     /// valid and attempts to recreate it if the Mach port was invalidated.
     private var healthCheckTimer: Timer?
 
+    /// The currently pending show-on-hover delay task.
+    private var hoverTask: Task<Void, any Error>?
+
     /// The number of times the manager has been told to stop.
     private var disableCount = 0
 
@@ -469,6 +472,8 @@ extension HIDEventManager {
 
         let delay = appState.settings.advanced.showOnHoverDelay
 
+        hoverTask?.cancel()
+
         if hiddenSection.isHidden {
             guard
                 isMouseInsideEmptyMenuBarSpace(
@@ -478,7 +483,8 @@ extension HIDEventManager {
             else {
                 return
             }
-            Task {
+            hoverTask = Task {
+                defer { hoverTask = nil }
                 try await Task.sleep(for: .seconds(delay))
                 // Make sure the mouse is still inside.
                 guard
@@ -498,7 +504,8 @@ extension HIDEventManager {
             else {
                 return
             }
-            Task {
+            hoverTask = Task {
+                defer { hoverTask = nil }
                 try await Task.sleep(for: .seconds(delay))
                 // Make sure the mouse is still outside.
                 guard


### PR DESCRIPTION
  ## Summary
  - Track the current show-on-hover delay task in a `hoverTask` property
  - Cancel any pending task before creating a new one on each mouse-move event
  - Clean up the reference with `defer { hoverTask = nil }` when the task completes

  Previously, every ~5th mouse-move event in the menu bar area spawned a new
  `Task` with a sleep delay, and none were cancelled. This caused unbounded
  task accumulation during rapid mouse movement.

  ## Test plan
  - [ ] Enable "Show on Hover" in settings
  - [ ] Move mouse rapidly in and out of the menu bar area
  - [ ] Verify sections show/hide correctly without delay stacking
  - [ ] Verify no excessive CPU usage during rapid mouse movement