### PR TITLE
fix(hotkey): remove invalid @EnvironmentObject from ObservableObject class

### DIFF
--- a/Thaw/UI/Views/HotkeyRecorder.swift
+++ b/Thaw/UI/Views/HotkeyRecorder.swift
@@ -120,8 +120,6 @@ struct HotkeyRecorder<Label: View>: View {
 
 @MainActor
 private final class HotkeyRecorderModel: ObservableObject {
-    @EnvironmentObject private var appState: AppState
-
     @Published private(set) var isRecording = false
 
     @Published var isPresentingSystemReservedError = false


### PR DESCRIPTION
  ## Summary
  - Remove unused `@EnvironmentObject private var appState: AppState` from
    `HotkeyRecorderModel`, which is an `ObservableObject` class — not a `View`
  - `@EnvironmentObject` only works in SwiftUI `View` types; in a plain class
    SwiftUI never injects the value, so accessing it would crash at runtime

  ## Test plan
  - [ ] Build successfully
  - [ ] Open Settings > Hotkeys pane and verify hotkey recording works
