### PR TITLE
perf(layout-bar): filter and debounce image cache subscriptions

### DIFF
--- a/Thaw/MenuBar/LayoutBar/LayoutBarContainer.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarContainer.swift
@@ -92,6 +92,7 @@ final class LayoutBarContainer: NSView {
                 .store(in: &c)
 
             appState.imageCache.$images
+                .debounce(for: .milliseconds(50), scheduler: DispatchQueue.main)
                 .sink { [weak self] _ in
                     guard let self else {
                         return

--- a/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
@@ -91,13 +91,7 @@ final class LayoutBarItemView: NSView {
                 .map { images -> MenuBarItemImageCache.CapturedImage? in images[tag] }
 
             imageForTag
-                .removeDuplicates(by: { (old: MenuBarItemImageCache.CapturedImage?, new: MenuBarItemImageCache.CapturedImage?) in
-                    guard let old, let new else { return old == nil && new == nil }
-                    return old.scale == new.scale
-                        && old.cgImage.width == new.cgImage.width
-                        && old.cgImage.height == new.cgImage.height
-                        && old.cgImage.dataProvider?.data == new.cgImage.dataProvider?.data
-                })
+                .removeDuplicates(by: MenuBarItemImageCache.CapturedImage.isVisuallyEqual)
                 .sink { [weak self] image in
                     guard let self else {
                         return

--- a/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
@@ -86,12 +86,23 @@ final class LayoutBarItemView: NSView {
         var c = Set<AnyCancellable>()
 
         if let appState {
-            appState.imageCache.$images
-                .sink { [weak self] images in
+            let tag = item.tag
+            let imageForTag = appState.imageCache.$images
+                .map { images -> MenuBarItemImageCache.CapturedImage? in images[tag] }
+
+            imageForTag
+                .removeDuplicates(by: { (old: MenuBarItemImageCache.CapturedImage?, new: MenuBarItemImageCache.CapturedImage?) in
+                    guard let old, let new else { return old == nil && new == nil }
+                    return old.scale == new.scale
+                        && old.cgImage.width == new.cgImage.width
+                        && old.cgImage.height == new.cgImage.height
+                        && old.cgImage.dataProvider?.data == new.cgImage.dataProvider?.data
+                })
+                .sink { [weak self] image in
                     guard let self else {
                         return
                     }
-                    self.cachedImage = images[item.tag]
+                    self.cachedImage = image
                 }
                 .store(in: &c)
         }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -32,6 +32,25 @@ final class MenuBarItemImageCache: ObservableObject {
         var nsImage: NSImage {
             NSImage(cgImage: cgImage, size: scaledSize)
         }
+
+        /// Returns whether two optional captured images have equivalent visual content.
+        ///
+        /// Uses pointer equality on `CGImage` as a fast path, falling back to
+        /// dimension and pixel-data comparison when instances differ.
+        static func isVisuallyEqual(_ old: CapturedImage?, _ new: CapturedImage?) -> Bool {
+            guard let old, let new else { return old == nil && new == nil }
+            if old.cgImage === new.cgImage { return true }
+            guard old.scale == new.scale,
+                  old.cgImage.width == new.cgImage.width,
+                  old.cgImage.height == new.cgImage.height else {
+                return false
+            }
+            guard let oldData = old.cgImage.dataProvider?.data,
+                  let newData = new.cgImage.dataProvider?.data else {
+                return false
+            }
+            return oldData == newData
+        }
     }
 
     /// The result of an image capture operation.


### PR DESCRIPTION
 ## Summary
  - **LayoutBarItemView**: Each item view previously subscribed to the entire
    `imageCache.$images` dictionary and triggered `setFrameSize` + `needsDisplay`
    on every mutation, even when its own image hadn't changed. Now extracts only
    its own tag via `.map` and uses `.removeDuplicates(by:)` with pixel-data
    comparison to skip updates when the image content is identical.
  - **LayoutBarContainer**: A single cache update cycle mutates the `$images`
    dictionary 3-4 times (filter, cleanup, merge, eviction), causing 3-4
    consecutive `layoutArrangedViews()` calls. Added `.debounce(for: 50ms)` to
    coalesce these into a single relayout.

  ### Before
  With 30 items visible: 30 items x 3-4 mutations = 90-120 sink invocations per
  cache update cycle, each triggering frame resize and redraw.

  ### After
  Only items whose image pixel data actually changed trigger `setFrameSize` +
  `needsDisplay`, and relayout runs exactly once per update cycle.

  ### Note on `removeDuplicates`
  `CapturedImage` has auto-synthesized `Hashable` based on `CGImage` pointer
  identity, which means `.removeDuplicates()` would be a no-op (new captures
  always produce new `CGImage` instances). The custom comparator compares
  `scale`, dimensions, and `dataProvider?.data` for true value equality.

  ## Test plan
  - [ ] Open Settings > Menu Bar Layout — verify items display correctly
  - [ ] Show/hide sections — verify layout bar updates without visual glitches
  - [ ] Drag items to reorder — verify smooth drag-and-drop behavior
  - [ ] Switch between spaces — verify images update correctly
