### PR TITLE
feat(ci): add XCStrings localization validation workflow

### DIFF
--- a/.github/workflows/xcstrings-validation.yml
+++ b/.github/workflows/xcstrings-validation.yml
@@ -7,25 +7,22 @@ on:
   workflow_dispatch:
 
 jobs:
-  lint:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v5
-      - name: Install SwiftLint
-        run: brew install swiftlint
-      - name: Run SwiftLint
-        run: swiftlint --strict
-
   validate:
-    runs-on: macos-latest
+    # Using ubuntu-slim since we only need Python for validation and it has a smaller footprint than macOS
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v5
       - name: Validate XCStrings
+        shell: bash
         run: |
-          find . -name "*.xcstrings" -print0 | while IFS= read -r -d '' file; do
+          set -euo pipefail
+          found=false
+          while IFS= read -r -d '' file; do
+            found=true
             echo "Validating $file"
-            if ! plutil -lint "$file"; then
-              echo "Validation failed for $file"
-              exit 1
-            fi
-          done
+            python3 -m json.tool "$file" > /dev/null
+          done < <(find . -name "*.xcstrings" -print0)
+
+          if ! $found; then
+            echo "No .xcstrings files found."
+          fi

--- a/.github/workflows/xcstrings-validation.yml
+++ b/.github/workflows/xcstrings-validation.yml
@@ -1,0 +1,31 @@
+name: Validate Localization Files
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "**/*.xcstrings"
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install SwiftLint
+        run: brew install swiftlint
+      - name: Run SwiftLint
+        run: swiftlint --strict
+
+  validate:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Validate XCStrings
+        run: |
+          find . -name "*.xcstrings" -print0 | while IFS= read -r -d '' file; do
+            echo "Validating $file"
+            if ! plutil -lint "$file"; then
+              echo "Validation failed for $file"
+              exit 1
+            fi
+          done

--- a/Thaw/Resources/Localizable.xcstrings
+++ b/Thaw/Resources/Localizable.xcstrings
@@ -20,7 +20,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@
+            "value" : "%@"
           }
         },
         "hu" : {
@@ -71,7 +71,7 @@
             "value" : "%@"
           }
         },
-        zh-Hans" : {
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@"

--- a/Thaw/Resources/Localizable.xcstrings
+++ b/Thaw/Resources/Localizable.xcstrings
@@ -20,7 +20,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@"
+            "value" : "%@
           }
         },
         "hu" : {
@@ -71,7 +71,7 @@
             "value" : "%@"
           }
         },
-        "zh-Hans" : {
+        zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@"


### PR DESCRIPTION
## What does this PR do?

Adds a GitHub Actions workflow that automatically validates `.xcstrings` localization files on every pull request targeting `main` that touches those files. Validation is done using Python's built-in `json.tool` to ensure the files are valid JSON, since `.xcstrings` files are JSON-based.

## PR Type

- [X] CI/CD related changes
- [X] i18n/l10n (Translation/Localization)

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## What is the current behavior?

Malformed or invalid `.xcstrings` files can be merged without any automated check catching the issue.

## What is the new behavior?

A new workflow (`.github/workflows/xcstrings-validation.yml`) runs on pull requests that modify `*.xcstrings` files and on manual dispatch. It finds all `.xcstrings` files in the repository and validates each one using `python3 -m json.tool`. The job runs on `ubuntu-slim` to keep the footprint small, since no macOS toolchain is needed for JSON validation.