### PR TITLE
perf(icebar): show panel instantly and animate menu bar icons at ~30fps

### DIFF
--- a/Thaw/MenuBar/IceBar/IceBar.swift
+++ b/Thaw/MenuBar/IceBar/IceBar.swift
@@ -30,6 +30,9 @@ final class IceBarPanel: NSPanel {
     /// Storage for internal observers.
     private var cancellables = Set<AnyCancellable>()
 
+    /// Background cache task started when the panel is shown.
+    private var cacheTask: Task<Void, Never>?
+
     /// Creates a new Ice Bar panel.
     init() {
         super.init(
@@ -168,25 +171,14 @@ final class IceBarPanel: NSPanel {
 
         hotkeyLocationOverride = triggeredByHotkey && appState.settings.general.iceBarLocationOnHotkey
 
-        // Rehide any temporarily shown items as soon as the IceBar opens.
-        await appState.itemManager.rehideTemporarilyShownItems(force: true)
-
         // IMPORTANT: We must set the navigation state and current section
         // before updating the caches.
         appState.navigationState.isIceBarPresented = true
         currentSection = section
 
-        let cacheTask = Task(timeout: .seconds(1)) {
-            await appState.itemManager.cacheItemsIfNeeded()
-            await appState.imageCache.updateCache()
-        }
-
-        do {
-            try await cacheTask.value
-        } catch {
-            diagLog.error("Cache update failed when showing \(Constants.displayName)BarPanel - \(error)")
-        }
-
+        // Show the panel immediately with whatever cached data we have.
+        // The SwiftUI view observes itemManager and imageCache, so it
+        // will re-render automatically as the background updates land.
         contentView = IceBarHostingView(
             appState: appState,
             colorManager: colorManager,
@@ -205,6 +197,18 @@ final class IceBarPanel: NSPanel {
         colorManager.updateAllProperties(with: frame, screen: screen)
 
         orderFrontRegardless()
+
+        // Rehide temporarily shown items and refresh caches in the
+        // background. Ordering is preserved: rehide moves items back
+        // to their correct sections before the cache is rebuilt.
+        // The task is cancelled in close() to avoid holding appState.
+        cacheTask?.cancel()
+        cacheTask = Task { [weak appState] in
+            guard let appState else { return }
+            await appState.itemManager.rehideTemporarilyShownItems(force: true)
+            await appState.itemManager.cacheItemsIfNeeded()
+            await appState.imageCache.updateCache()
+        }
     }
 
     /// Hides the panel.
@@ -220,6 +224,8 @@ final class IceBarPanel: NSPanel {
 
     override func close() {
         CustomTooltipPanel.shared.dismiss()
+        cacheTask?.cancel()
+        cacheTask = nil
         contentView = nil
         orderOut(nil)
         super.close()
@@ -361,6 +367,20 @@ private struct IceBarContentView: View {
             cacheGracePeriodActive = true
             try? await Task.sleep(for: .milliseconds(600))
             cacheGracePeriodActive = false
+        }
+        .task {
+            // Refresh captured images at ~30fps so animated menu bar
+            // icons (e.g. Google Drive sync spinner) stay up-to-date.
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .milliseconds(33))
+                guard !Task.isCancelled else { break }
+                let currentItems = items
+                guard !currentItems.isEmpty else { continue }
+                await imageCache.refreshImages(
+                    of: currentItems,
+                    scale: screen.backingScaleFactor
+                )
+            }
         }
     }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -500,6 +500,62 @@ final class MenuBarItemImageCache: ObservableObject {
         return individualResult
     }
 
+    /// Lightweight image refresh for the IceBar.
+    ///
+    /// Performs a single composite capture and crops individual items,
+    /// skipping full cache management (LRU, failure tracking, transparency
+    /// checks, cleanup). Designed for high-frequency refresh (~30fps).
+    nonisolated func refreshImages(
+        of items: [MenuBarItem],
+        scale: CGFloat
+    ) async {
+        var windowIDs = [CGWindowID]()
+        var storage = [CGWindowID: (MenuBarItem, CGRect)]()
+        var boundsUnion = CGRect.null
+
+        for item in items {
+            guard let bounds = Bridging.getWindowBounds(for: item.windowID) else {
+                continue
+            }
+            windowIDs.append(item.windowID)
+            storage[item.windowID] = (item, bounds)
+            boundsUnion = boundsUnion.union(bounds)
+        }
+
+        guard !windowIDs.isEmpty else { return }
+
+        guard let compositeImage = ScreenCapture.captureWindows(
+            with: windowIDs,
+            option: captureOption
+        ) else { return }
+
+        let expectedWidth = boundsUnion.width * scale
+        let expectedHeight = boundsUnion.height * scale
+        guard CGFloat(compositeImage.width) == expectedWidth,
+              CGFloat(compositeImage.height) == expectedHeight else { return }
+
+        var newImages = [MenuBarItemTag: CapturedImage]()
+        for windowID in windowIDs {
+            guard let (item, bounds) = storage[windowID] else { continue }
+            let cropRect = CGRect(
+                x: (bounds.origin.x - boundsUnion.origin.x) * scale,
+                y: (bounds.origin.y - boundsUnion.origin.y) * scale,
+                width: bounds.width * scale,
+                height: bounds.height * scale
+            )
+            guard let image = compositeImage.cropping(to: cropRect) else {
+                continue
+            }
+            newImages[item.tag] = CapturedImage(cgImage: image, scale: scale)
+        }
+
+        guard !newImages.isEmpty else { return }
+
+        await MainActor.run { [newImages] in
+            self.images.merge(newImages) { _, new in new }
+        }
+    }
+
     /// Captures the images of the menu bar items in the given section and returns
     /// a dictionary containing the images, keyed by their menu bar item tags.
     private func captureImages(


### PR DESCRIPTION
## What does this PR do?

Show the IceBar immediately using whatever is in the current cache rather than waiting up to 1 s for a synchronous cache update. Cache maintenance and a ~30 fps image refresh loop now run in the background so animated menu bar icons (e.g. Google Drive sync spinner) stay live while the panel is open. Closes #151 

## PR Type

- [ ] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [x] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What is the current behavior?

When the IceBar opens, it blocks for up to 1 s waiting for a synchronous cache update (rehide, `cacheItemsIfNeeded`, `updateCache`) before the panel becomes visible. Animated menu bar icons are captured once and remain frozen.

## What is the new behavior?

- The panel opens instantly with the current cache; the SwiftUI view re-renders automatically as background updates land.
- Cache maintenance (rehide temporarily-shown items → `cacheItemsIfNeeded` → `updateCache`) runs in a background `Task` (`cacheTask`) that is cancelled in `close()` to avoid retaining `appState`.
- A new `refreshImages(of:scale:)` method on `MenuBarItemImageCache` performs a lightweight composite capture + crop at ~30 fps via a `.task` modifier in `IceBarContentView`, keeping animated icons live.

## PR Checklist

- [x] I've built and run the app locally
- [x] I've checked for console errors or crashes
- [ ] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

### Notes for reviewers

- `refreshImages` intentionally skips LRU, failure tracking, transparency checks, and cleanup — it is designed for high-frequency use only while the IceBar is visible.
- The `cacheTask` property ensures at most one background cache job runs at a time; a new `show` call cancels any in-flight task before starting a fresh one.