### PR TITLE
refactor: extract shared per-display Ice Bar config builder

### DIFF
--- a/Thaw/Settings/Models/DisplayIceBarConfiguration.swift
+++ b/Thaw/Settings/Models/DisplayIceBarConfiguration.swift
@@ -6,7 +6,7 @@
 //  Copyright (Thaw) © 2026 Toni Förster
 //  Licensed under the GNU GPLv3
 
-import Foundation
+import Cocoa
 
 /// Per-display configuration for the Ice Bar.
 struct DisplayIceBarConfiguration: Codable, Equatable {
@@ -30,5 +30,24 @@ struct DisplayIceBarConfiguration: Codable, Equatable {
     /// Returns a new configuration with the `iceBarLocation` replaced.
     func withIceBarLocation(_ value: IceBarLocation) -> DisplayIceBarConfiguration {
         DisplayIceBarConfiguration(useIceBar: useIceBar, iceBarLocation: value)
+    }
+
+    /// Builds per-display configurations for all connected screens.
+    static func buildConfigurations(
+        onlyOnNotched: Bool,
+        location: IceBarLocation
+    ) -> [String: DisplayIceBarConfiguration] {
+        var configs = [String: DisplayIceBarConfiguration]()
+        for screen in NSScreen.screens {
+            guard let uuid = Bridging.getDisplayUUIDString(for: screen.displayID) else {
+                continue
+            }
+            let enabled = onlyOnNotched ? screen.hasNotch : true
+            configs[uuid] = DisplayIceBarConfiguration(
+                useIceBar: enabled,
+                iceBarLocation: location
+            )
+        }
+        return configs
     }
 }

--- a/Thaw/Settings/Models/DisplayIceBarConfiguration.swift
+++ b/Thaw/Settings/Models/DisplayIceBarConfiguration.swift
@@ -6,7 +6,7 @@
 //  Copyright (Thaw) © 2026 Toni Förster
 //  Licensed under the GNU GPLv3
 
-import Cocoa
+import AppKit
 
 /// Per-display configuration for the Ice Bar.
 struct DisplayIceBarConfiguration: Codable, Equatable {
@@ -33,6 +33,7 @@ struct DisplayIceBarConfiguration: Codable, Equatable {
     }
 
     /// Builds per-display configurations for all connected screens.
+    @MainActor
     static func buildConfigurations(
         onlyOnNotched: Bool,
         location: IceBarLocation

--- a/Thaw/Utilities/IceSettingsImporter.swift
+++ b/Thaw/Utilities/IceSettingsImporter.swift
@@ -102,17 +102,10 @@ struct IceSettingsImporter {
         let location = IceBarLocation(rawValue: locationRaw) ?? .dynamic
         let onlyOnNotched = iceSettings["UseIceBarOnlyOnNotchedDisplay"] as? Bool ?? false
 
-        var configs = [String: DisplayIceBarConfiguration]()
-        for screen in NSScreen.screens {
-            guard let uuid = Bridging.getDisplayUUIDString(for: screen.displayID) else {
-                continue
-            }
-            let enabled = onlyOnNotched ? screen.hasNotch : true
-            configs[uuid] = DisplayIceBarConfiguration(
-                useIceBar: enabled,
-                iceBarLocation: location
-            )
-        }
+        let configs = DisplayIceBarConfiguration.buildConfigurations(
+            onlyOnNotched: onlyOnNotched,
+            location: location
+        )
 
         guard !configs.isEmpty else { return 0 }
 

--- a/Thaw/Utilities/Migration.swift
+++ b/Thaw/Utilities/Migration.swift
@@ -407,23 +407,10 @@ extension MigrationManager {
             return .success
         }
 
-        var configs = [String: DisplayIceBarConfiguration]()
-
-        for screen in NSScreen.screens {
-            guard let uuid = Bridging.getDisplayUUIDString(for: screen.displayID) else {
-                continue
-            }
-            let enabled: Bool
-            if useOnlyOnNotched {
-                enabled = screen.hasNotch
-            } else {
-                enabled = true
-            }
-            configs[uuid] = DisplayIceBarConfiguration(
-                useIceBar: enabled,
-                iceBarLocation: iceBarLocation
-            )
-        }
+        let configs = DisplayIceBarConfiguration.buildConfigurations(
+            onlyOnNotched: useOnlyOnNotched,
+            location: iceBarLocation
+        )
 
         do {
             let data = try encoder.encode(configs)


### PR DESCRIPTION
  Deduplicate the per-display configuration loop that appeared in both
  Migration.swift and IceSettingsImporter.swift by extracting it into
  DisplayIceBarConfiguration.buildConfigurations(onlyOnNotched:location:).

  - Add @MainActor static factory method on DisplayIceBarConfiguration
  - Replace inline loops in both call sites
  - Change import from Foundation to AppKit (for NSScreen)