### PR TITLE
perf: reduce ~72% main thread timer wakeups for better battery life

### DIFF
--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -214,12 +214,13 @@ final class HIDEventManager: ObservableObject {
         // when accessibility permissions change. If it becomes invalid,
         // ensureValid() will recreate it.
         healthCheckTimer?.invalidate()
-        healthCheckTimer = Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { [weak self] _ in
+        healthCheckTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
             guard let self else { return }
             Task { @MainActor in
                 self.performHealthCheck()
             }
         }
+        healthCheckTimer?.tolerance = 5
     }
 
     /// Checks the health of event monitors and taps, and attempts
@@ -231,7 +232,7 @@ final class HIDEventManager: ObservableObject {
         // due to a cancelled Task or unexpected error. Force recovery.
         if !isEnabled, disableCount > 0, let lastStop = lastStopTimestamp {
             let elapsed = ContinuousClock.now - lastStop
-            if elapsed > .seconds(10) {
+            if elapsed > .seconds(30) {
                 Self.diagLog.error(
                     """
                     Event manager stuck in disabled state for \

--- a/Thaw/Main/AppState.swift
+++ b/Thaw/Main/AppState.swift
@@ -62,6 +62,9 @@ final class AppState: ObservableObject {
     /// Track open windows to prevent duplicates
     private var openWindows = Set<IceWindowIdentifier>()
 
+    /// The background task for periodic memory monitoring.
+    private var memoryMonitoringTask: Task<Void, Never>?
+
     /// Track last known screen count to detect disconnects.
     private var lastKnownScreenCount = NSScreen.screens.count
 
@@ -116,25 +119,27 @@ final class AppState: ObservableObject {
         updatesManager.startUpdaterIfNeeded()
     }
 
-    /// Starts periodic memory monitoring to track all memory usage
+    /// Starts periodic memory monitoring to track all memory usage.
     private func startMemoryMonitoring() {
-        Task {
+        memoryMonitoringTask?.cancel()
+        memoryMonitoringTask = Task {
             let formatter = ISO8601DateFormatter()
-            while !Task.isCancelled {
-                let memoryUsage = getMemoryInfo()
-                let timestamp = formatter.string(from: Date())
+            do {
+                while true {
+                    let memoryUsage = getMemoryInfo()
+                    let timestamp = formatter.string(from: Date())
 
-                // Always log memory usage, not just high usage
-                diagLog.info("Memory usage at \(timestamp): \(memoryUsage / 1024 / 1024)MB")
+                    // Always log memory usage, not just high usage
+                    diagLog.info("Memory usage at \(timestamp): \(memoryUsage / 1024 / 1024)MB")
 
-                // Log warnings for specific conditions
-                let memoryWarningThreshold: Int64 = 500 * 1024 * 1024 // 500MB
-                if memoryUsage > memoryWarningThreshold {
-                    diagLog.warning("High memory usage detected: \(memoryUsage / 1024 / 1024)MB")
-                }
+                    // Log warnings for specific conditions
+                    let memoryWarningThreshold: Int64 = 500 * 1024 * 1024 // 500MB
+                    if memoryUsage > memoryWarningThreshold {
+                        diagLog.warning("High memory usage detected: \(memoryUsage / 1024 / 1024)MB")
+                    }
 
-                // Log component sizes for debugging
-                await MainActor.run {
+                    // Log component sizes for debugging — no MainActor.run needed
+                    // as AppState is already @MainActor isolated.
                     let imageCount = imageCache.images.count
                     let windowCount = openWindows.count
 
@@ -144,9 +149,11 @@ final class AppState: ObservableObject {
                     if windowCount > 5 {
                         diagLog.warning("Many open windows: \(windowCount)")
                     }
-                }
 
-                try? await Task.sleep(for: .seconds(300)) // Check every 5 minutes
+                    try await Task.sleep(for: .seconds(300))
+                }
+            } catch {
+                // CancellationError — task was cancelled, exit cleanly.
             }
         }
     }
@@ -246,7 +253,8 @@ final class AppState: ObservableObject {
 
         publisherForWindow(.settings)
             .removeNil()
-            .flatMap { $0.publisher(for: \.isVisible) }
+            .map { $0.publisher(for: \.isVisible) }
+            .switchToLatest()
             .replaceEmpty(with: false)
             .throttle(for: 0.1, scheduler: DispatchQueue.main, latest: true)
             .removeDuplicates()

--- a/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
+++ b/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
@@ -247,7 +247,7 @@ final class MenuBarOverlayPanel: NSPanel {
 
         // Continually update the desktop wallpaper. Ideally, we would set up an observer
         // for a wallpaper change notification, but macOS doesn't post one anymore.
-        Timer.publish(every: 30, on: .main, in: .default)
+        Timer.publish(every: 120, tolerance: 15, on: .main, in: .default)
             .autoconnect()
             .sink { [weak self] _ in
                 guard let self, self.isOnActiveSpace else {
@@ -257,7 +257,7 @@ final class MenuBarOverlayPanel: NSPanel {
             }
             .store(in: &c)
 
-        Timer.publish(every: 10, on: .main, in: .default)
+        Timer.publish(every: 60, tolerance: 10, on: .main, in: .default)
             .autoconnect()
             .sink { [weak self] _ in
                 guard let self, self.isOnActiveSpace else {

--- a/Thaw/Permissions/Permission.swift
+++ b/Thaw/Permissions/Permission.swift
@@ -71,7 +71,7 @@ class Permission: ObservableObject, Identifiable {
 
     /// Sets up the internal observers for the permission.
     private func configureCancellables() {
-        timerCancellable = Timer.publish(every: 1, on: .main, in: .default)
+        timerCancellable = Timer.publish(every: 3, tolerance: 0.5, on: .main, in: .default)
             .autoconnect()
             .merge(with: Just(.now))
             .sink { [weak self] _ in


### PR DESCRIPTION
  ## Summary

  - Gate always-on timers behind visibility checks so they only fire when their UI is
  actually shown (IceBar color timer, settings average color timer)
  - Increase fallback polling intervals where event-driven triggers already cover >99%
  of cases (wallpaper capture, app menu frame, EventTap health check)
  - Add `tolerance` to all timers to allow macOS to coalesce wakeups and keep the CPU
  in low-power states longer
  - Store memory monitoring `Task` handle for proper cancellation and remove redundant
  `MainActor.run` in already-`@MainActor` context

  ## Details

  | Change | File | Saved (wakeups/min) |
  |--------|------|---------------------|
  | IceBar color 5s timer → only when visible | `IceBarColorManager.swift` | ~12 |
  | App menu frame 10s → 60s + tolerance | `MenuBarOverlayPanel.swift` | ~5 |
  | EventTap health check 10s → 30s + tolerance | `HIDEventManager.swift` | ~4 |
  | Wallpaper capture 30s → 120s + tolerance | `MenuBarOverlayPanel.swift` | ~1.5 |
  | Average color 60s timer → only when settings visible | `MenuBarManager.swift` | ~1
  |
  | Permission check 1s → 3s + tolerance | `Permission.swift` | ~0 (onboarding only) |
  | Memory monitor task storage + remove redundant MainActor.run | `AppState.swift` |
  ~0 (quality fix) |

  **Estimated total: ~24 wakeups/min (single display), ~32 wakeups/min (dual display) —
   ~72% reduction**

  ## Test plan

  - [ ] Launch without permissions → grant accessibility → confirm detected within 3-5s
  - [ ] Open IceBar → confirm colors update in real time; close → confirm wakeups drop
  (Activity Monitor)
  - [ ] Open Settings → confirm average color preview displays; close → confirm no
  periodic timer running
  - [ ] Set shaped menu bar → switch apps/spaces → confirm overlay updates immediately;
   change wallpaper → confirm updates within ~2 min
  - [ ] Verify EventTap recovery: if mouse-moved tap is invalidated, health check
  recovers within 30-60s
  - [ ] `sudo powermetrics --samplers tasks` before/after to measure actual wakeup
  reduction