### PR TITLE
perf(events): replace per-event Window Server IPC with reactive bounds cache

### DIFF
--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -729,13 +729,7 @@ extension HIDEventManager {
         // Find the specific window under the cursor using the cached bounds lookup.
         // This avoids per-event IPC calls to the Window Server.
         let entries = windowBoundsLock.withLock { $0 }
-        var hoveredID: CGWindowID?
-        for entry in entries {
-            if entry.bounds.contains(mouseLocation) {
-                hoveredID = entry.windowID
-                break
-            }
-        }
+        let hoveredID = entries.first(where: { $0.bounds.contains(mouseLocation) })?.windowID
 
         guard let hoveredID else {
             dismissMenuBarTooltip()


### PR DESCRIPTION
  ## Summary

  - Replace ~600-900 Window Server IPC calls/sec (`Bridging.getWindowBounds` +
  `getMenuBarWindowList`) during mouse movement with an in-memory lookup table rebuilt
  reactively from `itemCache`
  - Protect the lookup table with `OSAllocatedUnfairLock` for thread safety between the
   CGEventTap callback and Combine-driven writes
  - Remove the static mutable `Context` cache in `isMouseInsideMenuBarItem` (stale 0.5s
   TTL cache replaced by always-fresh reactive data)

  ## How it works

  Instead of querying the Window Server on every 5th mouse-move event, the bounds
  lookup table is rebuilt automatically when:
  1. `itemCache` changes (menu bar items added/removed/repositioned)
  2. Any section's control item state changes (show/hide transitions via `MergeMany` +
  debounce)
  3. Display configuration changes (lookup cleared, cache rebuilt shortly after)

  ## Test plan

  - [ ] Move mouse across menu bar — tooltips appear correctly
  - [ ] Show on hover — hidden items reveal on hover, dismiss on leave
  - [ ] Toggle sections (click control items) — hover/tooltip still works after layout
  shift
  - [ ] Connect/disconnect external display — no stale bounds or crashes
  - [ ] Monitor `powermetrics` — confirm no per-event `WindowServer` IPC during mouse
  movement
