### PR TITLE
perf: reduce IceBar refresh loop CPU/GPU overhead

### DIFF
--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -729,13 +729,7 @@ extension HIDEventManager {
         // Find the specific window under the cursor using the cached bounds lookup.
         // This avoids per-event IPC calls to the Window Server.
         let entries = windowBoundsLock.withLock { $0 }
-        var hoveredID: CGWindowID?
-        for entry in entries {
-            if entry.bounds.contains(mouseLocation) {
-                hoveredID = entry.windowID
-                break
-            }
-        }
+        let hoveredID = entries.first(where: { $0.bounds.contains(mouseLocation) })?.windowID
 
         guard let hoveredID else {
             dismissMenuBarTooltip()


### PR DESCRIPTION
  ## Summary

  - Reduce IceBar image refresh rate from ~30fps to ~5fps (33ms → 200ms sleep
  interval), cutting GPU composites and CGImage crops by ~83%
  - Add image diffing via `CapturedImage.isVisuallyEqual` to skip `@Published` updates
  when pixels haven't changed, eliminating unnecessary SwiftUI view invalidations for
  static icons
  - Add composite-level and per-item transparency checks to `refreshImages`, matching
  `compositeCapture` behavior and preventing transparent images from overwriting valid
  cached ones
  - Remove redundant height validation (consistent with `compositeCapture` which only
  checks width)
  - Add `Task.isCancelled` check before `MainActor.run` to avoid writing stale data
  from cancelled tasks

  ## Performance Impact

  | Metric | Before | After | Improvement |
  |--------|--------|-------|-------------|
  | GPU composite | 30/sec | 5/sec | **-83%** |
  | CGImage crop | ~30×N/sec | ~5×N/sec | **-83%** |
  | SwiftUI view invalidation | 30/sec | ~0/sec (static icons) | **~-100%** |

  ## Note on Refresh Rate

  The 5fps refresh rate is sufficient for most animated menu bar icons (sync spinners,
  badge updates). If users report visual stutter for fast-animating third-party items
  (e.g., real-time network speed monitors), this value can be increased to 10fps
  (100ms) as a compromise.

  ## Test Plan

  - [ ] Open IceBar → confirm all item images display correctly with no blank/missing
  icons
  - [ ] Test with animated menu bar icons (e.g., Google Drive syncing, Dropbox) →
  confirm animation is still visible
  - [ ] Test with static icons → confirm no flickering or unnecessary redraws
  - [ ] Monitor CPU usage in Activity Monitor with IceBar open → expect significant
  reduction
  - [ ] Revoke screen recording permission while IceBar is open → confirm no
  transparent images replace valid ones