### PR TITLE
perf(tooltip): eliminate Window Server IPC call for tooltip positioning

### DIFF
--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -773,6 +773,10 @@ extension HIDEventManager {
             }
             try Task.checkCancellation()
 
+            // Re-read from the lock to pick up any cache rebuilds during the delay.
+            let freshEntries = windowBoundsLock.withLock { $0 }
+            let positionBounds = freshEntries.first(where: { $0.windowID == hoveredID })?.bounds ?? cachedBounds
+
             // Look up the item from the cache by window ID.
             let allItems = appState.itemManager.itemCache.managedItems
             let displayName: String
@@ -791,8 +795,8 @@ extension HIDEventManager {
             // convert to AppKit (bottom-left origin) for the panel.
             guard let primaryScreen = NSScreen.screens.first else { return }
             let appKitOrigin = CGPoint(
-                x: cachedBounds.midX,
-                y: primaryScreen.frame.height - cachedBounds.maxY
+                x: positionBounds.midX,
+                y: primaryScreen.frame.height - positionBounds.maxY
             )
 
             CustomTooltipPanel.shared.show(


### PR DESCRIPTION
 ## Summary

  - Remove redundant `Bridging.getWindowBounds(for:)` IPC call in the menu bar tooltip
  handler, reusing the cached window bounds already available from hit-testing
  - After the tooltip delay, re-read bounds from the lock (not IPC) to pick up any
  cache rebuilds that occurred during the sleep, with a fallback to the pre-delay
  snapshot

  ## Details

  The tooltip handler was calling `CGSGetScreenRectForWindow` (via
  `Bridging.getWindowBounds`) to fetch window bounds for positioning, even though the
  same bounds were already cached in `windowBoundsLock` from the periodic cache
  rebuild. This IPC round-trip to the Window Server is unnecessary.

  Now the flow is:
  1. Hit-test uses cached entries to find `hoveredEntry` (unchanged)
  2. Capture `cachedBounds` from the entry before entering the async `Task`
  3. After the delay, re-read from the lock to get the freshest cached bounds
  4. Fall back to `cachedBounds` if the entry is gone (window closed during delay)

  The `?? cachedBounds` fallback is intentional — if the window disappeared, the
  subsequent `displayName` lookup (lines 779–787) will also fail to match and return
  early, so the tooltip won't actually display stale content.

  ## Test plan

  - [ ] Hover over menu bar items — tooltip appears correctly positioned
  - [ ] Hover rapidly between items — old tooltip dismissed, new one appears
  - [ ] Toggle hidden section while tooltip delay is pending — tooltip still positions
  correctly
  - [ ] Set tooltip delay to 0 — tooltip appears immediately