### PR TITLE
fix: prevent CheckedContinuation double-resume crash and potential hang

### DIFF
--- a/Thaw/MenuBar/Spacing/MenuBarItemSpacingManager.swift
+++ b/Thaw/MenuBar/Spacing/MenuBarItemSpacingManager.swift
@@ -117,7 +117,7 @@ final class MenuBarItemSpacingManager {
                     // Failsafe: if KVO doesn't fire after force terminate, resume anyway to prevent hang
                     try? await Task.sleep(for: .seconds(1))
                     cancellable?.cancel()
-                    if didResume.withLock({ let old = $0; $0 = true; return !old }) {
+                    if didResume.tryClaimOnce() {
                         continuation.resume()
                     }
                 }
@@ -134,7 +134,7 @@ final class MenuBarItemSpacingManager {
                 MenuBarItemSpacingManager.diagLog.debug(
                     "Application \"\(app.logString)\" terminated successfully"
                 )
-                if didResume.withLock({ let old = $0; $0 = true; return !old }) {
+                if didResume.tryClaimOnce() {
                     continuation.resume()
                 }
             }

--- a/Thaw/Utilities/Extensions.swift
+++ b/Thaw/Utilities/Extensions.swift
@@ -7,6 +7,7 @@
 //  Licensed under the GNU GPLv3
 
 import Combine
+import os.lock
 import SwiftUI
 
 // MARK: - Bundle
@@ -696,6 +697,21 @@ extension NSStatusItem {
         }
         self.menu = menu
         button?.performClick(nil)
+    }
+}
+
+// MARK: - OSAllocatedUnfairLock
+
+extension OSAllocatedUnfairLock where State == Bool {
+    /// Atomically sets the value to `true` and returns whether this call
+    /// was the first to do so. Useful for ensuring a continuation or
+    /// callback is invoked exactly once across competing code paths.
+    func tryClaimOnce() -> Bool {
+        withLock { claimed in
+            let wasUnclaimed = !claimed
+            claimed = true
+            return wasUnclaimed
+        }
     }
 }
 


### PR DESCRIPTION
  ## Summary

  - Add `OSAllocatedUnfairLock<Bool>` guard to `postEventWithBarrier` and
  `scrombleEvent` so only one of the EventTap callback or `onCancel` handler can resume
   the continuation — prevents trap on double-resume
  - Add `defer` block in `cacheItemsRegardless` to guarantee
  `backgroundCacheContinuation` is resumed on all early-return paths (self nil,
  skipRecentMoveCheck, missing control items) — prevents permanent hang in
  `resetLayoutToFreshState`
  - For relocate paths that spawn a retry Task, transfer the continuation out before
  returning so `defer` is a no-op and the spawned Task resumes after retry completes
  (preserves original timing)
  - Extract `tryClaimOnce()` extension on `OSAllocatedUnfairLock<Bool>` to replace the
  repeated `withLock({ let old = $0; ... })` idiom across 6 call sites

  ## Details

  **Double-resume crash:** `postEventWithBarrier` and `scrombleEvent` both use
  `withCheckedThrowingContinuation` where the EventTap callback (exit event) and the
  `withTaskCancellationHandler`'s `onCancel` could race to resume the same
  continuation. `CheckedContinuation` traps on double-resume. The fix follows the
  existing pattern in `MenuBarItemSpacingManager`.

  **Hang:** `backgroundCacheContinuation` is set by `resetLayoutToFreshState` and
  expected to be resumed when `cacheItemsRegardless` completes. However, multiple
  early-return paths in that function never called `resume()`, leaving the caller
  suspended forever.

  ## Test plan

  - [ ] Move menu bar items between sections — verify no crash during drag operations
  - [ ] Trigger layout reset (e.g. toggle hidden section rapidly) — verify app does not
   hang
  - [ ] Verify tooltip, hover, and click behaviors remain functional after changes