### PR TITLE
chore: repository hygiene

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.rtf linguist-vendored
+*.xcstrings linguist-language=JSON

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 .DS_Store
 build/
 xcuserdata/
+.build/
+DerivedData/
+*.ipa
+*.dSYM
+.idea/
+.vscode/

--- a/FREQUENT_ISSUES.md
+++ b/FREQUENT_ISSUES.md
@@ -1,37 +1,37 @@
 # Frequent Issues <!-- omit in toc -->
 
-- [~Items are moved to the always-hidden section~](#items-are-moved-to-the-always-hidden-section)
-- [Ice removed an item](#ice-removed-an-item)
-- [Ice does not remember the order of items](#ice-does-not-remember-the-order-of-items)
-- [How do I solve the `Ice cannot arrange menu bar items in automatically hidden menu bars` error?](#how-do-i-solve-the-ice-cannot-arrange-menu-bar-items-in-automatically-hidden-menu-bars-error)
+- [Items are moved to the always-hidden section](#items-are-moved-to-the-always-hidden-section)
+- [Thaw removed an item](#thaw-removed-an-item)
+- [Thaw does not remember the order of items](#thaw-does-not-remember-the-order-of-items)
+- [How do I solve the `Thaw cannot arrange menu bar items in automatically hidden menu bars` error?](#how-do-i-solve-the-thaw-cannot-arrange-menu-bar-items-in-automatically-hidden-menu-bars-error)
 
-## ~Items are moved to the always-hidden section~
+## Items are moved to the always-hidden section
 
-~By default, macOS adds new items to the far left of the menu bar, which is also the location of Ice's always-hidden section. Most apps are configured
+~By default, macOS adds new items to the far left of the menu bar, which is also the location of Thaw's always-hidden section. Most apps are configured
 to remember the positions of their items, but some are not. macOS treats the items of these apps as new items each time they appear. This results in
 these items appearing in the always-hidden section, even if they have been previously been moved.~
 
-~Ice does not currently manage individual items, and in fact cannot, as of the current release. Once issues
-[#6](https://github.com/jordanbaird/Ice/issues/6) and [#26](https://github.com/jordanbaird/Ice/issues/26) are implemented, Ice will be able to
+~Thaw does not currently manage individual items, and in fact cannot, as of the current release. Once issues
+[#6](https://github.com/jordanbaird/Thaw/issues/6) and [#26](https://github.com/jordanbaird/Thaw/issues/26) are implemented, Thaw will be able to
 monitor the items in the menu bar, and move the ones it recognizes to their previous locations, even if macOS rearranges them.~
 
 This issue should be resolved with commit: [1d77308](https://github.com/stonerl/Thaw/commit/1d77308e330afc8235884931e86574eccf9d3924)
 
-## Ice removed an item
+## Thaw removed an item
 
-Ice does not have the ability to move or remove items. It likely got placed in the always-hidden section by macOS. Option + click the Ice icon to show
+Thaw does not have the ability to move or remove items. It likely got placed in the always-hidden section by macOS. Option + click the Thaw icon to show
 the always-hidden section, then Command + drag the item into a different section.
 
-## Ice does not remember the order of items
+## Thaw does not remember the order of items
 
-This is not a bug, but a missing feature. It is being tracked in [#26](https://github.com/jordanbaird/Ice/issues/26).
+This is not a bug, but a missing feature. It is being tracked in [#26](https://github.com/jordanbaird/Thaw/issues/26).
 
-## How do I solve the `Ice cannot arrange menu bar items in automatically hidden menu bars` error?
+## How do I solve the `Thaw cannot arrange menu bar items in automatically hidden menu bars` error?
 
 1. Open `System Settings` on your Mac
 2. Go to `Control Center`
 3. Select `Never` as shown in the image below
-4. Update your `Menu Bar Items` in `Ice`
+4. Update your `Menu Bar Items` in `Thaw`
 5. Return `Automatically hide and show the menu bar` to your preferred settings
 
 ![Disable Menu Bar Hiding](https://github.com/user-attachments/assets/74c1fde6-d310-4fe3-9f2b-703d8ccb636a)

--- a/LICENSE
+++ b/LICENSE
@@ -631,8 +631,9 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    Ice - A powerful menu bar manager for macOS
-    Copyright (C) 2024 Jordan Baird
+    Thaw - A powerful menu bar manager for macOS
+    Copyright (C) 2024 Jordan Baird (Ice)
+    Copyright (C) 2026 Toni Förster (Thaw)
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -652,7 +653,10 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    Ice Copyright (C) 2024 Jordan Baird
+    Thaw - A powerful menu bar manager for macOS
+    Copyright (C) 2024 Jordan Baird (Ice)
+    Copyright (C) 2026 Toni Förster (Thaw)
+
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Thaw is a powerful menu bar management tool. While its primary function is hidin
 ![Banner](https://github.com/user-attachments/assets/4423085c-4e4b-4f3d-ad0f-90a217c03470)
 
 [![Download](https://img.shields.io/badge/download-latest-brightgreen?style=flat-square)](https://github.com/stonerl/Thaw/releases/latest)
+[![CI](https://img.shields.io/github/actions/workflow/status/stonerl/Thaw/ci.yml?style=flat-square)](https://github.com/stonerl/Thaw/actions/workflows/ci.yml)
 ![Platform](https://img.shields.io/badge/platform-macOS-blue?style=flat-square)
 ![Requirements](https://img.shields.io/badge/requirements-macOS%2014%2B-fa4e49?style=flat-square)
 [![Sponsor](https://img.shields.io/badge/Sponsor%20%E2%9D%A4%EF%B8%8F-8A2BE2?style=flat-square)](https://github.com/sponsors/stonerl)


### PR DESCRIPTION
## What does this PR do?

Cleans up repository-level files following the project rename from **Ice** to **Thaw**. Specifically:

- Updates `LICENSE` to reflect the new project name (Thaw) and current year.
- Replaces all remaining "Ice" references in `FREQUENT_ISSUES.md` with "Thaw".
- Expands `.gitignore` to cover additional build artifacts and IDE-specific files.
- Adds a `.gitattributes` rule to detect `.xcstrings` files as JSON for better diffs and tooling support.
- Adds a CI status badge to `README.md`.

## PR Type

- [X] Documentation

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What is the current behavior?

Several repository-level files still reference the old project name "Ice". The `.gitignore` is missing common build artifact and IDE entries. `.xcstrings` files are not recognised as JSON by GitHub's diff renderer.
## What is the new behavior?

- All top-level repository files consistently use the "Thaw" project name.
- `.gitignore` covers Xcode derived data, `.DS_Store`, SPM build artefacts, and IDE folders (`*.xcworkspace/xcuserdata`, `.idea/`, etc.).
- `.xcstrings` files are rendered as JSON in pull-request diffs.
- A CI badge in `README.md` reflects the current build status at a glance.

## PR Checklist

- [ ] I've built and run the app locally
- [ ] I've checked for console errors or crashes
- [ ] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [x] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)