### PR TITLE
perf(icebar): skip input pause when clicking temporarily shown items

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -1702,12 +1702,14 @@ extension MenuBarItemManager {
     /// - Parameters:
     ///   - item: The menu bar item to click.
     ///   - mouseButton: The mouse button to click the item with.
-    func click(item: MenuBarItem, with mouseButton: CGMouseButton) async throws {
+    func click(item: MenuBarItem, with mouseButton: CGMouseButton, skipInputPause: Bool = false) async throws {
         guard let appState else {
             throw EventError.cannotComplete
         }
 
-        try await waitForUserToPauseInput()
+        if !skipInputPause {
+            try await waitForUserToPauseInput()
+        }
 
         MenuBarItemManager.diagLog.info(
             """
@@ -2104,7 +2106,7 @@ extension MenuBarItemManager {
         let idsBeforeClick = Set(Bridging.getWindowList(option: .onScreen))
 
         do {
-            try await click(item: clickItem, with: mouseButton)
+            try await click(item: clickItem, with: mouseButton, skipInputPause: true)
         } catch {
             MenuBarItemManager.diagLog.error("Error clicking item: \(error)")
             return


### PR DESCRIPTION
## What does this PR do?

Eliminates a redundant `waitForUserToPauseInput()` delay when clicking menu bar items from the Ice Bar, reducing perceived latency by 100-500ms+.

## PR Type

- [ ] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [x] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What is the current behavior?

When clicking an item in the Ice Bar, `temporarilyShow()` moves the item to the visible section, waits for its position to settle (up to 250ms), adds a 25ms processing buffer, then calls `click()`. Inside `click()`, `waitForUserToPauseInput()` polls every 50ms until the mouse has been inactive for 50ms — adding another 100-500ms+ of delay that is redundant since the position has already stabilized.

## What is the new behavior?

`click()` now accepts a `skipInputPause` parameter (defaulting to `false` so all existing callers are unaffected). `temporarilyShow()` passes `skipInputPause: true` when clicking, bypassing the redundant input pause. This mirrors the existing pattern used by `move()`, which already accepts and uses `skipInputPause`.

## PR Checklist

- [x] I've built and run the app locally
- [x] I've checked for console errors or crashes
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

## Other information

### Notes for reviewers

The change is minimal — two call sites in `MenuBarItemManager.swift`. The `skipInputPause` pattern already exists on `move()` (line 1525) and is used by `temporarilyShow()` when moving items. This PR extends the same pattern to `click()`.