### PR TITLE
perf: centralize 5fps image refresh loop into MenuBarItemImageCache

### DIFF
--- a/Thaw/MenuBar/IceBar/IceBar.swift
+++ b/Thaw/MenuBar/IceBar/IceBar.swift
@@ -370,21 +370,6 @@ private struct IceBarContentView: View {
             try? await Task.sleep(for: .seconds(2))
             loadingTimedOut = true
         }
-        .task {
-            // Refresh captured images at ~5fps so animated menu bar
-            // icons (e.g. Google Drive sync spinner) stay up-to-date
-            // while keeping CPU/GPU usage low.
-            while !Task.isCancelled {
-                try? await Task.sleep(for: .milliseconds(200))
-                guard !Task.isCancelled else { break }
-                let currentItems = items
-                guard !currentItems.isEmpty else { continue }
-                await imageCache.refreshImages(
-                    of: currentItems,
-                    scale: screen.backingScaleFactor
-                )
-            }
-        }
     }
 
     private static let diagLog = DiagLog(category: "IceBar.Content")

--- a/Thaw/MenuBar/Search/MenuBarSearchPanel.swift
+++ b/Thaw/MenuBar/Search/MenuBarSearchPanel.swift
@@ -447,24 +447,6 @@ private struct MenuBarSearchContentView: View {
         .task {
             searchFieldIsFocused = true
         }
-        .task {
-            // Refresh captured images at ~5fps so animated menu bar
-            // icons (e.g. Google Drive sync spinner) stay up-to-date
-            // while keeping CPU/GPU usage low.
-            guard let screen = NSScreen.screens.first(where: { $0.displayID == displayID }) else { return }
-            while !Task.isCancelled {
-                try? await Task.sleep(for: .milliseconds(200))
-                guard !Task.isCancelled else { break }
-                for section in MenuBarSection.Name.allCases {
-                    let sectionItems = itemManager.itemCache.managedItems(for: section)
-                    guard !sectionItems.isEmpty else { continue }
-                    await imageCache.refreshImages(
-                        of: sectionItems,
-                        scale: screen.backingScaleFactor
-                    )
-                }
-            }
-        }
         .onChange(of: model.searchText, initial: true) {
             updateDisplayedItems()
             selectFirstDisplayedItem()

--- a/Thaw/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift
@@ -112,25 +112,6 @@ struct MenuBarLayoutSettingsPane: View {
                 diagLog.error("Menu bar layout failed to load items after 3s timeout. cacheItems: \(itemManager.itemCache.managedItems.count), images: \(appState.imageCache.images.count), displayID: \(self.itemManager.itemCache.displayID.map { "\($0)" } ?? "nil")")
             }
         }
-        .task {
-            // Refresh captured images at ~5fps so animated menu bar
-            // icons (e.g. Google Drive sync spinner) stay up-to-date
-            // while keeping CPU/GPU usage low.
-            let displayID = itemManager.itemCache.displayID ?? Bridging.getActiveMenuBarDisplayID() ?? CGMainDisplayID()
-            guard let screen = NSScreen.screens.first(where: { $0.displayID == displayID }) else { return }
-            while !Task.isCancelled {
-                try? await Task.sleep(for: .milliseconds(200))
-                guard !Task.isCancelled else { break }
-                for section in MenuBarSection.Name.allCases {
-                    let sectionItems = itemManager.itemCache.managedItems(for: section)
-                    guard !sectionItems.isEmpty else { continue }
-                    await appState.imageCache.refreshImages(
-                        of: sectionItems,
-                        scale: screen.backingScaleFactor
-                    )
-                }
-            }
-        }
     }
 
     private var resetControls: some View {


### PR DESCRIPTION
## What does this PR do?

  Centralizes the 5fps image refresh loop into `MenuBarItemImageCache`, replacing three independent per-view loops that caused duplicate Window Server screen captures when
  multiple panels were open simultaneously.

  ## PR Type

  - [x] Performance improvement
  - [x] Refactor

  ## Does this PR introduce a breaking change?

  - [x] No

  ## What is the current behavior?

  Three SwiftUI views (`IceBarContentView`, `MenuBarSearchContentView`, `MenuBarLayoutSettingsPane.layoutBars`) each run their own independent `while !Task.isCancelled {
  sleep(200ms); refreshImages(...) }` loop. When multiple views are visible simultaneously (e.g. IceBar + Search), this causes duplicate Window Server IPC screen captures — up
   to 15 captures/sec instead of the intended 5.

  ## What is the new behavior?

  A single centralized refresh loop in `MenuBarItemImageCache` that:

  - **Starts** when any consumer view becomes visible (`isIceBarPresented`, `isSearchPresented`, or settings layout pane)
  - **Stops** when no consumer views are visible
  - **Determines sections dynamically**: IceBar → current section only; Search/Layout → all sections
  - **Runs one capture per 200ms tick** regardless of how many views are open

  ### Files changed

  | File | Change |
  |------|--------|
  | `MenuBarItemImageCache.swift` | Added `liveRefreshTask`, `startLiveRefreshIfNeeded()`, `runLiveRefreshLoop(appState:)`, and Combine observer on navigation state |
  | `IceBar.swift` | Removed `.task { while ... refreshImages ... }` from `IceBarContentView` |
  | `MenuBarSearchPanel.swift` | Removed `.task { while ... refreshImages ... }` from `MenuBarSearchContentView` |
  | `MenuBarLayoutSettingsPane.swift` | Removed `.task { while ... refreshImages ... }` from `layoutBars` |

  ## PR Checklist

  - [x] I've built and run the app locally
  - [ ] I've checked for console errors or crashes
  - [ ] I've run relevant tests and they pass
  - [ ] I've added or updated tests (if applicable)
  - [x] I've updated documentation as needed
  - [ ] I've verified localized strings work correctly (if i18n/l10n changes)

  ## Other information

  The Combine observer watches `isIceBarPresented`, `isSearchPresented`, `isSettingsPresented`, `settingsNavigationIdentifier`, and `isAppFrontmost` with a 50ms debounce. The
  loop uses `continue` (not `break`) when no consumer is visible mid-iteration, avoiding a race with `IceBarPanel.close()` where `currentSection` is nilled before
  `isIceBarPresented` is set to `false`.

  ## Notes for reviewers

  - The settings layout path now requires `isAppFrontmost` — an intentional optimization since the pane is invisible when Thaw is not frontmost. The old per-view loop had no
  such guard.
  - The loop does **not** self-clean `liveRefreshTask = nil` on exit to avoid a race where an old task's cleanup overwrites a newly assigned task reference. Cleanup is handled
   entirely by `startLiveRefreshIfNeeded()` via the Combine observer.
  - Verify: open IceBar → animated icons refresh; open Search → refresh; open Settings > Menu Bar Layout → refresh; open multiple simultaneously → CPU usage stays flat vs.
  before.