### PR TITLE
fix: prevent infinite reorder loop in restoreSavedItemOrder

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -2680,6 +2680,9 @@ extension MenuBarItemManager {
     ) async -> Bool {
         guard !savedSectionOrder.isEmpty else { return false }
 
+        // Don't attempt another restore while a previous restore's recache is in flight.
+        guard !isRestoringItemOrder else { return false }
+
         // Don't restore while suppressing relocations (first launch / reset).
         guard !suppressNextNewLeftmostItemRelocation else { return false }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -819,6 +819,10 @@ extension MenuBarItemManager {
                     await self?.cacheItemsRegardless(skipRecentMoveCheck: true)
                     self?.isRestoringItemOrder = false
                     continuation?.resume()
+                    // Pick up items that appeared during the lock period
+                    // (e.g. a second app launching concurrently).
+                    try? await Task.sleep(for: .milliseconds(300))
+                    await self?.cacheItemsIfNeeded()
                 }
                 return
             }


### PR DESCRIPTION
  ## Summary

  - Fixes infinite loop where `restoreSavedItemOrder` repeatedly moves items, schedules
   a recache, and the recache triggers another restore because macOS hasn't settled the
   moves within 300ms
  - Adds `guard !isRestoringItemOrder else { return false }` so the post-restore
  recache skips re-entry into the restore logic and falls through to normal caching

  Fixes https://github.com/stonerl/Thaw/pull/192#issuecomment-3943339264

  ## Root cause

  1. `restoreSavedItemOrder()` detects out-of-order items, moves them, returns `true`
  2. `isRestoringItemOrder = true` is set, recache scheduled after 300ms
  3. Recache calls `cacheItemsRegardless` → calls `restoreSavedItemOrder` again
  4. macOS hasn't fully settled the moves yet, so items still appear "out of order"
  5. Restore triggers again → schedules another recache → infinite loop

  ## Test plan

  - [ ] Rearrange items via Layout Bar → quit/relaunch Thaw → verify order restored
  without looping
  - [ ] Check diagnostic logs: "Restored saved item order; scheduling recache" should
  appear at most once per app restart, not continuously
  - [ ] Verify "Reset Layout" still clears saved order correctly
