### PR TITLE
fix(menubar): only restore item order when window IDs change

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -805,7 +805,11 @@ extension MenuBarItemManager {
                 return
             }
 
-            let didRestoreOrder = await restoreSavedItemOrder(items, controlItems: controlItems)
+            let didRestoreOrder = await restoreSavedItemOrder(
+                items,
+                controlItems: controlItems,
+                previousWindowIDs: previousWindowIDs
+            )
 
             if didRestoreOrder {
                 // Keep isRestoringItemOrder true through the recache to prevent
@@ -2677,10 +2681,15 @@ extension MenuBarItemManager {
     /// diverge from the saved order (e.g. after an app like Stats.app restarts
     /// and its items appear in a different order).
     ///
+    /// Only triggers when the set of window IDs has changed (items were
+    /// recreated by an app restart), not when items were merely repositioned
+    /// (user drag). This prevents undoing the user's manual reordering.
+    ///
     /// Returns `true` if any items were moved.
     private func restoreSavedItemOrder(
         _ items: [MenuBarItem],
-        controlItems: ControlItemPair
+        controlItems: ControlItemPair,
+        previousWindowIDs: [CGWindowID]
     ) async -> Bool {
         guard !savedSectionOrder.isEmpty else { return false }
 
@@ -2689,6 +2698,14 @@ extension MenuBarItemManager {
 
         // Don't restore while suppressing relocations (first launch / reset).
         guard !suppressNextNewLeftmostItemRelocation else { return false }
+
+        // Only restore when the window ID set has changed, indicating items
+        // were recreated (app restart). When items are merely repositioned
+        // (user drag-and-drop), the IDs stay the same and we must not undo
+        // the user's arrangement.
+        let currentWindowIDSet = Set(items.map(\.windowID))
+        let previousWindowIDSet = Set(previousWindowIDs)
+        guard currentWindowIDSet != previousWindowIDSet else { return false }
 
         // Don't interfere with items that are currently temporarily shown.
         let activelyShownTags = Set(temporarilyShownItemContexts.map {

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -2703,7 +2703,7 @@ extension MenuBarItemManager {
         // were recreated (app restart). When items are merely repositioned
         // (user drag-and-drop), the IDs stay the same and we must not undo
         // the user's arrangement.
-        let currentWindowIDSet = Set(items.map(\.windowID))
+        let currentWindowIDSet = Set(items.lazy.map(\.windowID))
         let previousWindowIDSet = Set(previousWindowIDs)
         guard currentWindowIDSet != previousWindowIDSet else { return false }
 


### PR DESCRIPTION

  ## Summary

  - Prevents `restoreSavedItemOrder` from undoing user's manual item reordering (drag
  in LayoutBar or Cmd+drag in menu bar)
  - Adds a window ID set comparison: restore only triggers when items were recreated
  (app restart → new window IDs), not when merely repositioned (user drag → same window
   IDs)

  Fixes item reordering being reverted as reported in
  https://github.com/stonerl/Thaw/pull/193#issuecomment-3943565473.

  ## Root cause

  `restoreSavedItemOrder()` runs in the cache pipeline **before** `saveSectionOrder()`.
   When a user drags items to reorder them, the next cache cycle detects the new
  positions don't match the (stale) saved order and moves everything back — causing
  items to "jump back to their original position."

  ## How the fix works

  macOS assigns new `CGWindowID` values when an app recreates its menu bar items (e.g.
  after restart). User drag-and-drop only repositions existing windows — their IDs stay
   the same.

  By comparing `Set(currentWindowIDs) != Set(previousWindowIDs)`, we precisely
  distinguish:
  - **App restart** (IDs changed) → restore saved order ✓
  - **User drag** (IDs unchanged) → skip restore, let `saveSectionOrder` persist new
  arrangement ✓

  ## Test plan

  - [ ] Reorder items via LayoutBar drag → verify order persists (not reverted)
  - [ ] Reorder items via Cmd+drag in menu bar → verify order persists
  - [ ] Quit and relaunch Stats.app → verify items restored to saved positions
  - [ ] Reset Layout → verify no restore attempted (savedSectionOrder cleared)
  - [ ] Launch a new menu bar app → verify existing item order not disrupted