### PR TITLE
fix(menubar): use subset check to ignore transient duplicate windows during restore

### DIFF
--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -542,6 +542,17 @@ extension HIDEventManager {
     private func handleMenuBarItemDragStop() {
         if isDraggingMenuBarItem {
             isDraggingMenuBarItem = false
+
+            // Record the external move so caching is suppressed for 1s and order
+            // restoration is suppressed for 2s,
+            // then schedule a cache update to pick up the user's new item positions.
+            if let appState {
+                appState.itemManager.recordExternalMoveOperation()
+                Task { [weak appState] in
+                    try? await Task.sleep(for: .milliseconds(500))
+                    await appState?.itemManager.cacheItemsRegardless(skipRecentMoveCheck: true)
+                }
+            }
         }
     }
 

--- a/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
@@ -83,13 +83,8 @@ final class LayoutBarPaddingView: NSView {
     }
 
     override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
-        defer {
-            DispatchQueue.main.async {
-                self.container.canSetArrangedViews = true
-            }
-        }
-
         guard let draggingSource = sender.draggingSource as? LayoutBarItemView else {
+            container.canSetArrangedViews = true
             return false
         }
 
@@ -108,11 +103,15 @@ final class LayoutBarPaddingView: NSView {
             container.updateArrangedViewsForDrag(with: sender, phase: .exited)
             draggingSource.hasContainer = false
 
+            container.canSetArrangedViews = true
             return false
         }
 
+        var willMove = false
+
         if let index = arrangedViews.firstIndex(of: draggingSource) {
             if arrangedViews.count == 1 {
+                willMove = true
                 Task {
                     // dragging source is the only view in the layout bar, so we
                     // need to find a target item
@@ -123,20 +122,29 @@ final class LayoutBarPaddingView: NSView {
                     case .alwaysHidden: items.first(matching: .alwaysHiddenControlItem)
                     }
                     if let targetItem {
-                        move(item: draggingSource.item, to: .leftOfItem(targetItem))
+                        self.move(item: draggingSource.item, to: .leftOfItem(targetItem))
                     } else {
                         Self.diagLog.error("No target item for layout bar drag")
+                        self.container.canSetArrangedViews = true
                     }
                 }
             } else if arrangedViews.indices.contains(index + 1) {
+                willMove = true
                 // we have a view to the right of the dragging source
                 let targetItem = arrangedViews[index + 1].item
                 move(item: draggingSource.item, to: .leftOfItem(targetItem))
             } else if arrangedViews.indices.contains(index - 1) {
+                willMove = true
                 // we have a view to the left of the dragging source
                 let targetItem = arrangedViews[index - 1].item
                 move(item: draggingSource.item, to: .rightOfItem(targetItem))
             }
+        }
+
+        // Only re-enable view updates here if no move was initiated.
+        // When a move IS initiated, the move() Task re-enables after stabilization.
+        if !willMove {
+            container.canSetArrangedViews = true
         }
 
         return true
@@ -160,6 +168,7 @@ final class LayoutBarPaddingView: NSView {
                     if self.isStabilizing {
                         self.isStabilizing = false
                         self.showOverlay(false)
+                        self.container.canSetArrangedViews = true
                     }
                 }
                 guard let appState else { return }
@@ -184,6 +193,13 @@ final class LayoutBarPaddingView: NSView {
             await MainActor.run {
                 self.isStabilizing = false
                 self.showOverlay(false)
+                // Re-enable view updates now that stabilization is complete,
+                // and force a refresh since updates were blocked during the move.
+                self.container.canSetArrangedViews = true
+                if let appState = self.container.appState {
+                    let items = appState.itemManager.itemCache.managedItems(for: self.container.section)
+                    self.container.setArrangedViews(items: items)
+                }
             }
         }
     }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItem.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItem.swift
@@ -356,18 +356,22 @@ extension MenuBarItem {
         }
 
         // Final pass: assign instance indices to allow individual identification
-        // of items with the same (namespace, title).
-        var counts = [String: Int]()
+        // of items with the same (namespace, title). Sort by windowID within each
+        // group so that indices are stable regardless of item position changes
+        // (e.g. dragging between sections). This prevents image cache collisions
+        // caused by instanceIndex values swapping between cache cycles.
+        var groups = [String: [Int]]()
         for i in 0 ..< items.count {
             let key = "\(items[i].tag.namespace):\(items[i].tag.title)"
-            let index = counts[key, default: 0]
-            counts[key] = index + 1
-            if index > 0 {
-                // Re-create the item with the correct instance index.
-                if let sourcePID = items[i].sourcePID {
-                    items[i] = MenuBarItem(uncheckedItemWindow: windows[i], sourcePID: sourcePID, instanceIndex: index)
+            groups[key, default: []].append(i)
+        }
+        for (_, indices) in groups where indices.count > 1 {
+            let sorted = indices.sorted { items[$0].windowID < items[$1].windowID }
+            for (instanceIndex, itemIndex) in sorted.enumerated() where instanceIndex > 0 {
+                if let sourcePID = items[itemIndex].sourcePID {
+                    items[itemIndex] = MenuBarItem(uncheckedItemWindow: windows[itemIndex], sourcePID: sourcePID, instanceIndex: instanceIndex)
                 } else {
-                    items[i] = MenuBarItem(uncheckedItemWindow: windows[i], instanceIndex: index)
+                    items[itemIndex] = MenuBarItem(uncheckedItemWindow: windows[itemIndex], instanceIndex: instanceIndex)
                 }
             }
         }
@@ -382,17 +386,23 @@ extension MenuBarItem {
     @MainActor
     private static func getMenuBarItemsLegacyMethod(on display: CGDirectDisplayID?, option: ListOption) -> [MenuBarItem] {
         let windows = getMenuBarItemWindows(on: display, option: option)
-        var counts = [String: Int]()
-        return windows.map { window in
-            let item = MenuBarItem(uncheckedItemWindow: window)
-            let key = "\(item.tag.namespace):\(item.tag.title)"
-            let index = counts[key, default: 0]
-            counts[key] = index + 1
-            if index > 0 {
-                return MenuBarItem(uncheckedItemWindow: window, instanceIndex: index)
-            }
-            return item
+        var items = windows.map { MenuBarItem(uncheckedItemWindow: $0) }
+
+        // Assign instance indices sorted by windowID for stability across
+        // position changes (same approach as the experimental path).
+        var groups = [String: [Int]]()
+        for i in 0 ..< items.count {
+            let key = "\(items[i].tag.namespace):\(items[i].tag.title)"
+            groups[key, default: []].append(i)
         }
+        for (_, indices) in groups where indices.count > 1 {
+            let sorted = indices.sorted { items[$0].windowID < items[$1].windowID }
+            for (instanceIndex, itemIndex) in sorted.enumerated() where instanceIndex > 0 {
+                items[itemIndex] = MenuBarItem(uncheckedItemWindow: windows[itemIndex], instanceIndex: instanceIndex)
+            }
+        }
+
+        return items
     }
 
     /// Creates and returns a list of menu bar items for the given display.

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -2699,6 +2699,12 @@ extension MenuBarItemManager {
         // Don't restore while suppressing relocations (first launch / reset).
         guard !suppressNextNewLeftmostItemRelocation else { return false }
 
+        // Don't restore when we recently performed our own move operations
+        // (user drag in the Layout Bar, internal relocations, etc.). External
+        // app restarts never go through our move() path, so their cache cycles
+        // will have no recent move timestamp.
+        guard !lastMoveOperationOccurred(within: .seconds(2)) else { return false }
+
         // Only restore when previous window IDs have disappeared, indicating
         // an app restarted (old windows destroyed, new ones created). During
         // move operations macOS can briefly report duplicate windows for the

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -2699,13 +2699,16 @@ extension MenuBarItemManager {
         // Don't restore while suppressing relocations (first launch / reset).
         guard !suppressNextNewLeftmostItemRelocation else { return false }
 
-        // Only restore when the window ID set has changed, indicating items
-        // were recreated (app restart). When items are merely repositioned
-        // (user drag-and-drop), the IDs stay the same and we must not undo
-        // the user's arrangement.
+        // Only restore when previous window IDs have disappeared, indicating
+        // an app restarted (old windows destroyed, new ones created). During
+        // move operations macOS can briefly report duplicate windows for the
+        // same item, which adds transient IDs to the current set. Checking
+        // for removed IDs (rather than any set difference) avoids false
+        // positives from these duplicates and from user drag-and-drop, which
+        // only repositions existing windows without removing any.
         let currentWindowIDSet = Set(items.lazy.map(\.windowID))
         let previousWindowIDSet = Set(previousWindowIDs)
-        guard currentWindowIDSet != previousWindowIDSet else { return false }
+        guard !previousWindowIDSet.isSubset(of: currentWindowIDSet) else { return false }
 
         // Don't interfere with items that are currently temporarily shown.
         let activelyShownTags = Set(temporarilyShownItemContexts.map {

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -343,6 +343,12 @@ final class MenuBarItemManager: ObservableObject {
         }
         return timestamp.duration(to: .now) <= duration
     }
+
+    /// Records that a move operation occurred outside of Thaw's own `move()` function
+    /// (e.g. the user cmd+dragged an item directly on the menu bar).
+    func recordExternalMoveOperation() {
+        lastMoveOperationTimestamp = .now
+    }
 }
 
 // MARK: - Item Cache
@@ -710,6 +716,11 @@ extension MenuBarItemManager {
 
             guard skipRecentMoveCheck || !lastMoveOperationOccurred(within: .seconds(1)) else {
                 MenuBarItemManager.diagLog.debug("Skipping menu bar item cache due to recent item movement")
+                return
+            }
+
+            guard !(appState?.isDraggingMenuBarItem ?? false) else {
+                MenuBarItemManager.diagLog.debug("Skipping menu bar item cache: user is cmd-dragging")
                 return
             }
 


### PR DESCRIPTION
 ## Summary

  - Fixes erratic item movement during drag operations caused by macOS briefly creating
   duplicate windows for the same menu bar item during move operations
  - Changes `restoreSavedItemOrder` guard from `currentWindowIDSet !=
  previousWindowIDSet` to `!previousWindowIDSet.isSubset(of: currentWindowIDSet)` —
  only triggers restore when previous IDs have **disappeared** (app restart), not when
  IDs were merely **added** (transient duplicates)

  Fixes erratic reordering reported in
  https://github.com/stonerl/Thaw/pull/197#issuecomment-3944793342.

  ## Root cause

  macOS can briefly report two windows for the same menu bar item during or shortly
  after a `move()` operation ([documented in codebase](https://github.com/stonerl/Thaw/blob/dd917a7/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift#L607-L611)). The  previous `!=` set comparison detected these transient duplicate IDs as "changes,"  incorrectly triggering order restoration that would undo the user's drag.

  ## How the fix works

  | Scenario | previous ⊂ current? | Restore? |
  |---|---|---|
  | User drag (same IDs) | yes | skip ✓ |
  | Drag + transient duplicate (extra ID) | yes | skip ✓ |
  | App restart (old IDs gone, new ones created) | no | trigger ✓ |
  | New app launched (only adds IDs) | yes | skip ✓ |
  | Item removed (app quit) | no | trigger, but downstream filtering detects order is
  unchanged → no-op ✓ |

  ## Test plan

  - [ ] Reorder items via LayoutBar drag → verify smooth movement, no jumping/erratic
  behavior
  - [ ] Reorder items via Cmd+drag in menu bar → verify order persists
  - [ ] Quit and relaunch Stats.app → verify items restored to saved positions
  - [ ] Launch a new menu bar app → verify existing item order not disrupted
  - [ ] Reset Layout → verify no restore attempted