### PR TITLE
fix(events): include unmanaged menu bar items in bounds lookup

### DIFF
--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -221,13 +221,32 @@ final class HIDEventManager: ObservableObject {
     }
 
     /// Rebuilds the window bounds lookup table from the current item cache.
+    ///
+    /// Includes ALL menu bar item windows (both managed and unmanaged) so that
+    /// clicks on unmanaged items like Clock and Control Center are correctly
+    /// detected as being on a menu bar item, not on empty space.
     private func rebuildWindowBoundsLookup(from cache: MenuBarItemManager.ItemCache) {
+        // Start with managed items whose bounds are already known.
         let items = cache.managedItems
+        var knownWindowIDs = Set<CGWindowID>()
         var buffer = [(windowID: CGWindowID, bounds: CGRect)]()
         buffer.reserveCapacity(items.count)
         for item in items where item.isOnScreen {
             buffer.append((windowID: item.windowID, bounds: item.bounds))
+            knownWindowIDs.insert(item.windowID)
         }
+
+        // Query all on-screen menu bar item windows and add any that aren't
+        // already covered by the managed items (e.g. Clock, Control Center).
+        let allWindowIDs = Bridging.getMenuBarWindowList(option: [
+            .onScreen, .activeSpace, .itemsOnly,
+        ])
+        for windowID in allWindowIDs where !knownWindowIDs.contains(windowID) {
+            if let bounds = Bridging.getWindowBounds(for: windowID) {
+                buffer.append((windowID: windowID, bounds: bounds))
+            }
+        }
+
         let entries = buffer
         windowBoundsLock.withLock { $0 = entries }
     }


### PR DESCRIPTION
  ## Summary

  Fixes #200

  - Commit `b546218` introduced a performance optimization that cached window bounds to
   avoid per-event Window Server IPC calls, but the cache only included **managed
  items** (items assigned to Thaw's visible/hidden/always-hidden sections)
  - Unmanaged items like Clock, Control Center, and Notification Center were excluded
  from the cache, causing clicks on them to be misidentified as clicks on empty menu
  bar space, which incorrectly triggered the hidden section
  - The fix extends `rebuildWindowBoundsLookup` to also query all on-screen menu bar
  windows via `Bridging.getMenuBarWindowList()` and include unmanaged items in the
  cache, while preserving the performance optimization (IPC calls only happen during
  cache rebuilds, not per mouse event)

  ## Test plan

  - [ ] Click on Clock — hidden section should NOT trigger
  - [ ] Click on Control Center — hidden section should NOT trigger
  - [ ] Click on Notification Center — hidden section should NOT trigger
  - [ ] Click on empty menu bar space — hidden section should still trigger as expected
  - [ ] Verify show-on-hover still works correctly
  - [ ] Test with notifications present in Notification Center
  - [ ] Test on single and multi-monitor setups