### PR TITLE
fix(xpc): reduce memory usage in MenuBarItemService PID cache

### DIFF
--- a/MenuBarItemService/SourcePIDCache.swift
+++ b/MenuBarItemService/SourcePIDCache.swift
@@ -103,14 +103,15 @@ final class SourcePIDCache {
             return bar
         }
 
-        /// Resets cached accessibility state so the app will be
-        /// re-queried on the next scan. Called during cleanup to:
-        /// - Release stale AXUIElement Mach port references
-        /// - Discover apps that register status items after launch
-        func resetCachedState() {
+        /// Resets the negative cache so the app will be re-checked
+        /// on the next scan. Called during cleanup to discover apps
+        /// that register status items after launch. Preserves a
+        /// valid `_extrasMenuBar` to avoid unnecessary AX re-queries.
+        func resetNegativeCache() {
             lock.withLock {
-                _extrasMenuBar = nil
-                _checkedWithNoResult = false
+                if _extrasMenuBar == nil {
+                    _checkedWithNoResult = false
+                }
             }
         }
     }
@@ -236,7 +237,7 @@ final class SourcePIDCache {
         // Reset negative caches outside the state lock so we don't
         // hold the unfair lock while acquiring per-app locks.
         for app in reusedApps {
-            app.resetCachedState()
+            app.resetNegativeCache()
         }
     }
 

--- a/MenuBarItemService/SourcePIDCache.swift
+++ b/MenuBarItemService/SourcePIDCache.swift
@@ -103,14 +103,14 @@ final class SourcePIDCache {
             return bar
         }
 
-        /// Resets the negative cache so the app will be re-checked on the
-        /// next scan. Called during cleanup to discover apps that register
-        /// status items after launch.
-        func resetNegativeCache() {
+        /// Resets cached accessibility state so the app will be
+        /// re-queried on the next scan. Called during cleanup to:
+        /// - Release stale AXUIElement Mach port references
+        /// - Discover apps that register status items after launch
+        func resetCachedState() {
             lock.withLock {
-                if _extrasMenuBar == nil {
-                    _checkedWithNoResult = false
-                }
+                _extrasMenuBar = nil
+                _checkedWithNoResult = false
             }
         }
     }
@@ -236,7 +236,7 @@ final class SourcePIDCache {
         // Reset negative caches outside the state lock so we don't
         // hold the unfair lock while acquiring per-app locks.
         for app in reusedApps {
-            app.resetNegativeCache()
+            app.resetCachedState()
         }
     }
 

--- a/MenuBarItemService/SourcePIDCache.swift
+++ b/MenuBarItemService/SourcePIDCache.swift
@@ -169,6 +169,12 @@ final class SourcePIDCache {
 
     /// Performs cleanup of the cache state.
     private func performCleanup() {
+        autoreleasepool {
+            performCleanupBody()
+        }
+    }
+
+    private func performCleanupBody() {
         let runningApps = NSWorkspace.shared.runningApplications
         SourcePIDCache.diagLog.debug("Performing PID cache cleanup")
 

--- a/MenuBarItemService/SourcePIDCache.swift
+++ b/MenuBarItemService/SourcePIDCache.swift
@@ -31,7 +31,9 @@ final class SourcePIDCache {
     /// identifier and extras menu bar.
     private final class CachedApplication {
         private let runningApp: NSRunningApplication
-        private var extrasMenuBar: UIElement?
+        private let lock = NSLock()
+        private var _extrasMenuBar: UIElement?
+        private var _checkedWithNoResult = false
 
         /// The app's process identifier.
         var processIdentifier: pid_t {
@@ -41,12 +43,12 @@ final class SourcePIDCache {
         /// A Boolean value indicating whether the app's extras menu
         /// bar has been successfully created and stored.
         var hasExtrasMenuBar: Bool {
-            extrasMenuBar != nil
+            lock.withLock { _extrasMenuBar != nil }
         }
 
         /// A Boolean value indicating whether the app is in a valid
         /// state for making accessibility calls.
-        var isValidForAccessibility: Bool {
+        private var isValidForAccessibility: Bool {
             // These checks help prevent blocking that can occur when
             // calling AX APIs while the app is an invalid state.
             runningApp.isFinishedLaunching &&
@@ -66,18 +68,46 @@ final class SourcePIDCache {
         /// When the element is first created, it gets stored for efficient
         /// access on subsequent calls.
         func getOrCreateExtrasMenuBar() -> UIElement? {
-            if let extrasMenuBar {
-                return extrasMenuBar
+            // Fast path: check cached state under the lock first.
+            let (hasCached, isNegative) = lock.withLock {
+                (_extrasMenuBar, _checkedWithNoResult)
             }
+            if let bar = hasCached {
+                return bar
+            }
+            if isNegative {
+                return nil
+            }
+
+            guard isValidForAccessibility else {
+                // Transient condition (still launching, unresponsive, or
+                // terminated). Do NOT set negative cache — retry next scan.
+                return nil
+            }
+
+            // Slow path: AX API calls performed outside the lock to
+            // avoid holding it during blocking IPC.
             guard
-                isValidForAccessibility,
                 let app = AXHelpers.application(for: runningApp),
                 let bar = AXHelpers.extrasMenuBar(for: app)
             else {
+                // App is reachable but has no extras menu bar.
+                lock.withLock { _checkedWithNoResult = true }
                 return nil
             }
-            extrasMenuBar = bar
+            lock.withLock { _extrasMenuBar = bar }
             return bar
+        }
+
+        /// Resets the negative cache so the app will be re-checked on the
+        /// next scan. Called during cleanup to discover apps that register
+        /// status items after launch.
+        func resetNegativeCache() {
+            lock.withLock {
+                if _extrasMenuBar == nil {
+                    _checkedWithNoResult = false
+                }
+            }
         }
     }
 
@@ -201,6 +231,7 @@ final class SourcePIDCache {
                 if let app = appMappings[pid] {
                     // Prefer the cached app, as it may have already done
                     // the work to initialize its extras menu bar.
+                    app.resetNegativeCache()
                     result.apps.append(app)
                 } else {
                     // App wasn't in the cache, so it must be new.
@@ -270,31 +301,38 @@ final class SourcePIDCache {
         var appsWithBar = 0
         var totalChildrenChecked = 0
         var totalMatchesFound = 0
+        var unresolvedWindows = Set(allWindows.map(\.windowID))
 
         for app in apps {
-            appsChecked += 1
-            guard let bar = app.getOrCreateExtrasMenuBar() else {
-                continue
+            if unresolvedWindows.isEmpty {
+                break
             }
-            appsWithBar += 1
-            let children = AXHelpers.children(for: bar)
-            for child in children {
-                totalChildrenChecked += 1
-                guard AXHelpers.isEnabled(child),
-                      let childFrame = AXHelpers.frame(for: child)
-                else {
-                    continue
+            appsChecked += 1
+            autoreleasepool {
+                guard let bar = app.getOrCreateExtrasMenuBar() else {
+                    return
                 }
+                appsWithBar += 1
+                let children = AXHelpers.children(for: bar)
+                for child in children {
+                    totalChildrenChecked += 1
+                    guard AXHelpers.isEnabled(child),
+                          let childFrame = AXHelpers.frame(for: child)
+                    else {
+                        continue
+                    }
 
-                let childCenter = childFrame.center
+                    let childCenter = childFrame.center
 
-                // Match this child to ANY window in our list.
-                if let matchedWindow = allWindows.first(where: {
-                    $0.bounds.center.distance(to: childCenter) <= 1
-                }) {
-                    totalMatchesFound += 1
-                    let pid = app.processIdentifier
-                    state.withLock { $0.pids[matchedWindow.windowID] = pid }
+                    // Match this child to ANY window in our list.
+                    if let matchedWindow = allWindows.first(where: {
+                        $0.bounds.center.distance(to: childCenter) <= 1
+                    }) {
+                        totalMatchesFound += 1
+                        unresolvedWindows.remove(matchedWindow.windowID)
+                        let pid = app.processIdentifier
+                        state.withLock { $0.pids[matchedWindow.windowID] = pid }
+                    }
                 }
             }
         }

--- a/MenuBarItemService/SourcePIDCache.swift
+++ b/MenuBarItemService/SourcePIDCache.swift
@@ -92,7 +92,11 @@ final class SourcePIDCache {
                 let bar = AXHelpers.extrasMenuBar(for: app)
             else {
                 // App is reachable but has no extras menu bar.
-                lock.withLock { _checkedWithNoResult = true }
+                lock.withLock {
+                    if _extrasMenuBar == nil {
+                        _checkedWithNoResult = true
+                    }
+                }
                 return nil
             }
             lock.withLock { _extrasMenuBar = bar }
@@ -116,33 +120,6 @@ final class SourcePIDCache {
         var apps = [CachedApplication]()
         var pids = [CGWindowID: pid_t]()
 
-        /// Returns the latest bounds of the given window after ensuring
-        /// that the bounds are stable (a.k.a. not currently changing).
-        ///
-        /// This method blocks until stable bounds can be determined, or
-        /// until retrieving the bounds for the window fails.
-        private func stableBounds(for window: WindowInfo) -> CGRect? {
-            var cachedBounds = window.bounds
-
-            for n in 1 ... 5 {
-                guard let currentBounds = window.currentBounds() else {
-                    // Failure here means the window probably doesn't
-                    // exist anymore.
-                    SourcePIDCache.diagLog.debug("stableBounds: currentBounds() returned nil for windowID \(window.windowID) on attempt \(n) — window may no longer exist")
-                    return nil
-                }
-                if currentBounds == cachedBounds {
-                    return currentBounds
-                }
-                cachedBounds = currentBounds
-                // Compute the sleep interval from the current attempt.
-                Thread.sleep(forTimeInterval: TimeInterval(n) / 100)
-            }
-
-            SourcePIDCache.diagLog.warning("stableBounds: bounds did not stabilize after 5 attempts for windowID \(window.windowID), last bounds=\(NSStringFromRect(cachedBounds))")
-            return nil
-        }
-
         /// Reorders the cached apps so that those that are confirmed
         /// to have an extras menu bar are first in the array.
         mutating func partitionApps() {
@@ -158,11 +135,6 @@ final class SourcePIDCache {
             }
 
             apps = lhs + rhs
-        }
-
-        /// Updates the cached process identifier for the given window.
-        mutating func updatePID(for _: WindowInfo) {
-            // This method is now empty as the logic has moved to the thread-safe `pid(for:)`.
         }
     }
 
@@ -203,7 +175,7 @@ final class SourcePIDCache {
         let windowIDs = Bridging.getMenuBarWindowList(option: .itemsOnly)
         let currentAppPids = Set(runningApps.map(\.processIdentifier))
 
-        state.withLock { state in
+        let reusedApps = state.withLock { state -> [CachedApplication] in
             // Clean up entries for terminated apps to prevent memory leaks
             let oldAppPids = Set(state.apps.map(\.processIdentifier))
             let terminatedPids = oldAppPids.subtracting(currentAppPids)
@@ -224,6 +196,10 @@ final class SourcePIDCache {
                 }
             }
 
+            // Collect reused apps to reset their negative caches after
+            // releasing the lock.
+            var reused = [CachedApplication]()
+
             // Create a new state that matches the current running apps.
             state = runningApps.reduce(into: State()) { result, app in
                 let pid = app.processIdentifier
@@ -231,7 +207,7 @@ final class SourcePIDCache {
                 if let app = appMappings[pid] {
                     // Prefer the cached app, as it may have already done
                     // the work to initialize its extras menu bar.
-                    app.resetNegativeCache()
+                    reused.append(app)
                     result.apps.append(app)
                 } else {
                     // App wasn't in the cache, so it must be new.
@@ -247,6 +223,14 @@ final class SourcePIDCache {
             if !terminatedPids.isEmpty {
                 SourcePIDCache.diagLog.info("Cleaned up PID cache entries for terminated processes: \(terminatedPids)")
             }
+
+            return reused
+        }
+
+        // Reset negative caches outside the state lock so we don't
+        // hold the unfair lock while acquiring per-app locks.
+        for app in reusedApps {
+            app.resetNegativeCache()
         }
     }
 


### PR DESCRIPTION
  ## Summary

  - Add negative caching to skip repeated AX API calls for the ~95% of running apps
  that don't have menu bar items, avoiding 200-400+ wasted calls per batch scan
  - Wrap batch scan loop in `autoreleasepool` to free AXUIElement CF objects per
  iteration instead of letting them accumulate across all apps
  - Add early termination to stop iterating apps once all menu bar windows have been
  resolved
  - Add per-`CachedApplication` `NSLock` to prevent data races between scan and cleanup
   paths
  - Remove dead code (`stableBounds(for:)`, `updatePID(for:)`)

  ## Context

  The `MenuBarItemService` XPC service was being killed by macOS after ~42 minutes due
  to excessive memory growth. XPC services have tight memory limits (typically
  50-80MB). The service resolves source PIDs for menu bar items on macOS 26+ via the
  Accessibility API, which creates CF-bridged objects on every call.

  Three factors contributed to unbounded growth:
  1. **No negative caching** — every cache miss re-queried all ~200-400 running
  processes via AX, even though only ~20-30 have menu bar items
  2. **No autoreleasepool** — `AXUIElement` CF objects created in the GCD-dispatched
  batch loop accumulated until thread pool drain
  3. **No early exit** — the loop always iterated ALL apps even after every window was
  matched

  ## Test plan

  - [ ] Build and run on macOS 26
  - [ ] Verify menu bar items are correctly identified (source PIDs resolved)
  - [ ] Monitor XPC service memory in Activity Monitor — should stabilize at a much
  lower baseline
  - [ ] Quit and relaunch a menu bar app (e.g. Stats, Bartender) to verify negative
  cache reset discovers newly-registered status items
  - [ ] Leave running for 1+ hours to confirm service is no longer killed