### PR TITLE
Update language flags in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ Thaw is currently available in the following languages:
 
 | Language                   | Status   | Flag  | Completion                             |
 | :------------------------- | :------- | :---: | :------------------------------------- |
-| **English**                | Base     |  🇺🇸   | ![100%](https://geps.dev/progress/100) |
+| **English**                | Base     |  🇬🇧/🇺🇸   | ![100%](https://geps.dev/progress/100) |
 | **Bahasa Indonesia**       | Complete |  🇮🇩   | ![100%](https://geps.dev/progress/100) |
-| **Deutsch**                | Complete |  🇩🇪   | ![100%](https://geps.dev/progress/100) |
+| **Deutsch**                | Complete |  🇩🇪/🇦🇹   | ![100%](https://geps.dev/progress/100) |
 | **Español**                | Complete | 🇪🇸/🇲🇽 | ![100%](https://geps.dev/progress/100) |
 | **Français**               | Complete |  🇫🇷   | ![100%](https://geps.dev/progress/100) |
 | **Italiano**               | Complete |  🇮🇹   | ![100%](https://geps.dev/progress/100) |
 | **Magyar**                 | Complete |  🇭🇺   | ![100%](https://geps.dev/progress/100) |
-| **Nederlands**             | Complete |  🇳🇱   | ![100%](https://geps.dev/progress/100) |
+| **Nederlands**             | Complete |  🇳🇱/🇧🇪   | ![100%](https://geps.dev/progress/100) |
 | **Português (Brasil)(\*)** | Complete |  🇧🇷   | ![100%](https://geps.dev/progress/100) |
 | **Русский(\*)**            | Complete |  🇷🇺   | ![100%](https://geps.dev/progress/100) |
 | **简体中文**               | Complete |  🇨🇳   | ![100%](https://geps.dev/progress/100) |


### PR DESCRIPTION
I updated the flags in the table, because I saw Spain and Mexico's flags being split, and noticed that English had the American flag only, same goes for dutch (in Belgium a bit more than half of us speak dutch)

You can make this change yourself too (or not) if I don't deserve to be in the contributors list for just this PR, i don't care.

Anyway, thanks for this project, because I loved Ice