### PR TITLE
fix(xpc): add autoreleasepool coverage to prevent memory leak in MenuBarItemService

### DIFF
--- a/MenuBarItemService/SourcePIDCache.swift
+++ b/MenuBarItemService/SourcePIDCache.swift
@@ -250,6 +250,16 @@ final class SourcePIDCache {
     /// Returns the cached process identifier for the given window,
     /// updating the cache if needed.
     func pid(for window: WindowInfo) -> pid_t? {
+        // Wrap the entire request in an autoreleasepool. This XPC service
+        // has no NSApplication, so autoreleased ObjC/CF objects from
+        // WindowInfo creation, AX API calls, and CGS bridging would
+        // otherwise accumulate on the GCD thread until process exit.
+        autoreleasepool {
+            pidBody(for: window)
+        }
+    }
+
+    private func pidBody(for window: WindowInfo) -> pid_t? {
         if let pid = state.withLock({ $0.pids[window.windowID] }) {
             SourcePIDCache.diagLog.debug("SourcePIDCache.pid: cache hit for windowID \(window.windowID) -> PID \(pid)")
             return pid

--- a/MenuBarItemService/main.swift
+++ b/MenuBarItemService/main.swift
@@ -10,4 +10,14 @@ import Foundation
 
 SourcePIDCache.shared.start()
 Listener.shared.activate()
-RunLoop.current.run()
+
+// Run the RunLoop in a loop that drains an autoreleasepool every
+// 60 seconds. Without NSApplication there is no automatic pool
+// management, so ObjC/CF objects autoreleased on the main thread
+// (Combine pipeline, Timer callbacks, KVO notifications) would
+// accumulate indefinitely.
+while true {
+    autoreleasepool {
+        _ = RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 60))
+    }
+}


### PR DESCRIPTION
  ## Summary

  The `MenuBarItemService` XPC service was being killed by macOS after ~3 hours
  due to unbounded memory growth. Unlike a normal app with `NSApplication`, this
  XPC service has no automatic autorelease pool management, causing ObjC/CF
  objects to accumulate indefinitely.

  This commit adds two missing autoreleasepool scopes:

  - **`pid(for:)` request handler** — wraps the entire XPC request path so
    temporary objects from WindowInfo creation, AX API bridging, and CGS calls
    are drained after each request returns to GCD.
  - **Main RunLoop** — replaces `RunLoop.current.run()` with a loop that drains
    an autoreleasepool every 60 seconds, covering objects autoreleased on the
    main thread by Combine, Timer, and KVO callbacks.

  ## Test plan

  - [ ] Run the app for 3+ hours and verify the XPC service is not terminated
  - [ ] Monitor XPC service memory in Activity Monitor — should stabilize rather
        than grow linearly
  - [ ] Verify menu bar item source PID resolution still works correctly