### PR TITLE
fix: prevent memory leaks from probe windows and strong AppState captures

### DIFF
--- a/Thaw/MenuBar/Appearance/MenuBarAppearanceManager.swift
+++ b/Thaw/MenuBar/Appearance/MenuBarAppearanceManager.swift
@@ -67,7 +67,7 @@ final class MenuBarAppearanceManager: ObservableObject {
                     return
                 }
                 while let panel = overlayPanels.popFirst() {
-                    panel.orderOut(self)
+                    panel.close()
                 }
                 if Set(overlayPanels.map { $0.owningScreen }) != Set(NSScreen.screens) {
                     configureOverlayPanels(with: configuration)

--- a/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
+++ b/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
@@ -518,6 +518,9 @@ final class MenuBarOverlayPanel: NSPanel {
     override func close() {
         missionControlProbeWindow.close()
         super.close()
+        #if DEBUG
+        diagLog.debug("Overlay panel closed. Active windows: \(NSApplication.shared.windows.count)")
+        #endif
     }
 
     override func isAccessibilityElement() -> Bool {

--- a/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
+++ b/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
@@ -515,6 +515,11 @@ final class MenuBarOverlayPanel: NSPanel {
         }
     }
 
+    override func close() {
+        missionControlProbeWindow.close()
+        super.close()
+    }
+
     override func isAccessibilityElement() -> Bool {
         return false
     }

--- a/Thaw/MenuBar/MenuBarSection.swift
+++ b/Thaw/MenuBar/MenuBarSection.swift
@@ -333,17 +333,17 @@ final class MenuBarSection {
                 try? await Task.sleep(for: .seconds(interval))
                 guard !Task.isCancelled, let self, let appState else { return }
                 // Don't rehide while the mouse is inside the menu bar or IceBar.
-                if await self.isMouseInsideActiveArea() {
-                    await self.startRehideChecks()
+                if self.isMouseInsideActiveArea() {
+                    self.startRehideChecks()
                     return
                 }
                 // Check if any menu bar item has a menu open before hiding.
                 if await appState.itemManager.isAnyMenuBarItemMenuOpen() {
                     // Restart the task to check again later.
-                    await self.startRehideChecks()
+                    self.startRehideChecks()
                     return
                 }
-                await self.hide()
+                self.hide()
             }
         case .timed:
             rehideMonitor = EventMonitor.universal(for: .mouseMoved) { [weak self, weak appState] event in
@@ -373,8 +373,8 @@ final class MenuBarSection {
                             try? await Task.sleep(for: .seconds(interval))
                             guard !Task.isCancelled, let self, let appState else { return }
                             // Don't rehide while the mouse is inside the menu bar or IceBar.
-                            if await self.isMouseInsideActiveArea() {
-                                await self.startRehideChecks()
+                            if self.isMouseInsideActiveArea() {
+                                self.startRehideChecks()
                                 return
                             }
                             // Check if any menu bar item has a menu open before hiding.
@@ -383,7 +383,7 @@ final class MenuBarSection {
                                 await self.restartTimedRehideTimer()
                                 return
                             }
-                            await self.hide()
+                            self.hide()
                         }
                     }
                 } else {
@@ -416,8 +416,8 @@ final class MenuBarSection {
             try? await Task.sleep(for: .seconds(interval))
             guard !Task.isCancelled, let self, let appState else { return }
             // Don't rehide while the mouse is inside the menu bar or IceBar.
-            if await self.isMouseInsideActiveArea() {
-                await self.startRehideChecks()
+            if self.isMouseInsideActiveArea() {
+                self.startRehideChecks()
                 return
             }
             // Check if any menu bar item has a menu open before hiding.
@@ -426,7 +426,7 @@ final class MenuBarSection {
                 await self.restartTimedRehideTimer()
                 return
             }
-            await self.hide()
+            self.hide()
         }
     }
 

--- a/Thaw/MenuBar/MenuBarSection.swift
+++ b/Thaw/MenuBar/MenuBarSection.swift
@@ -330,7 +330,7 @@ final class MenuBarSection {
             rehideTimer = .scheduledTimer(
                 withTimeInterval: appState.settings.general.rehideInterval,
                 repeats: false
-            ) { [weak self] _ in
+            ) { [weak self, weak appState] _ in
                 Task {
                     // Don't rehide while the mouse is inside the menu bar or IceBar.
                     if await self?.isMouseInsideActiveArea() == true {
@@ -338,7 +338,7 @@ final class MenuBarSection {
                         return
                     }
                     // Check if any menu bar item has a menu open before hiding.
-                    if await appState.itemManager.isAnyMenuBarItemMenuOpen() {
+                    if await appState?.itemManager.isAnyMenuBarItemMenuOpen() == true {
                         // Restart the timer to check again later.
                         await self?.startRehideChecks()
                         return
@@ -347,7 +347,7 @@ final class MenuBarSection {
                 }
             }
         case .timed:
-            rehideMonitor = EventMonitor.universal(for: .mouseMoved) { [weak self] event in
+            rehideMonitor = EventMonitor.universal(for: .mouseMoved) { [weak self, weak appState] event in
                 // Throttle: process at most ~20fps regardless of mouse polling rate.
                 enum Context {
                     static var lastTime: TimeInterval = 0
@@ -358,6 +358,7 @@ final class MenuBarSection {
 
                 guard
                     let self,
+                    let appState,
                     let screen = NSScreen.main
                 else {
                     return event
@@ -371,7 +372,7 @@ final class MenuBarSection {
                         rehideTimer = .scheduledTimer(
                             withTimeInterval: appState.settings.general.rehideInterval,
                             repeats: false
-                        ) { [weak self] _ in
+                        ) { [weak self, weak appState] _ in
                             guard let self else { return }
                             Task {
                                 // Don't rehide while the mouse is inside the menu bar or IceBar.
@@ -380,7 +381,7 @@ final class MenuBarSection {
                                     return
                                 }
                                 // Check if any menu bar item has a menu open before hiding.
-                                if await appState.itemManager.isAnyMenuBarItemMenuOpen() {
+                                if await appState?.itemManager.isAnyMenuBarItemMenuOpen() == true {
                                     self.diagLog.debug("Open menu detected - restarting timed rehide timer")
                                     await self.restartTimedRehideTimer()
                                     return
@@ -417,7 +418,7 @@ final class MenuBarSection {
         rehideTimer = .scheduledTimer(
             withTimeInterval: appState.settings.general.rehideInterval,
             repeats: false
-        ) { [weak self] _ in
+        ) { [weak self, weak appState] _ in
             guard let self else { return }
             Task {
                 // Don't rehide while the mouse is inside the menu bar or IceBar.
@@ -426,7 +427,7 @@ final class MenuBarSection {
                     return
                 }
                 // Check if any menu bar item has a menu open before hiding.
-                if await appState.itemManager.isAnyMenuBarItemMenuOpen() {
+                if await appState?.itemManager.isAnyMenuBarItemMenuOpen() == true {
                     self.diagLog.debug("Open menu still detected - restarting timed rehide timer again")
                     await self.restartTimedRehideTimer()
                     return

--- a/Thaw/MenuBar/MenuBarSection.swift
+++ b/Thaw/MenuBar/MenuBarSection.swift
@@ -54,10 +54,10 @@ final class MenuBarSection {
     /// The shared app state.
     private weak var appState: AppState?
 
-    /// A timer that manages rehiding the section.
-    private var rehideTimer: Timer?
+    /// A task that manages rehiding the section.
+    private var rehideTask: Task<Void, Never>?
 
-    /// An event monitor that handles starting the rehide timer when the mouse
+    /// An event monitor that handles starting the rehide task when the mouse
     /// is outside of the menu bar.
     private var rehideMonitor: EventMonitor?
 
@@ -313,7 +313,7 @@ final class MenuBarSection {
 
     /// Starts running checks to determine when to rehide the section.
     private func startRehideChecks() {
-        rehideTimer?.invalidate()
+        rehideTask?.cancel()
         rehideMonitor?.stop()
 
         guard
@@ -326,26 +326,24 @@ final class MenuBarSection {
         switch appState.settings.general.rehideStrategy {
         case .smart:
             // Smart rehide strategy uses the rehide interval as a fallback
-            // to the click-based rehide checks.
-            rehideTimer = .scheduledTimer(
-                withTimeInterval: appState.settings.general.rehideInterval,
-                repeats: false
-            ) { [weak self, weak appState] _ in
-                guard let self, let appState else { return }
-                Task {
-                    // Don't rehide while the mouse is inside the menu bar or IceBar.
-                    if await self.isMouseInsideActiveArea() {
-                        await self.startRehideChecks()
-                        return
-                    }
-                    // Check if any menu bar item has a menu open before hiding.
-                    if await appState.itemManager.isAnyMenuBarItemMenuOpen() {
-                        // Restart the timer to check again later.
-                        await self.startRehideChecks()
-                        return
-                    }
-                    await self.hide()
+            // to the click-based rehide checks. Task.sleep replaces Timer so
+            // cancellation is automatic when the task is reassigned or cancelled.
+            let interval = appState.settings.general.rehideInterval
+            rehideTask = Task { [weak self, weak appState] in
+                try? await Task.sleep(for: .seconds(interval))
+                guard !Task.isCancelled, let self, let appState else { return }
+                // Don't rehide while the mouse is inside the menu bar or IceBar.
+                if await self.isMouseInsideActiveArea() {
+                    await self.startRehideChecks()
+                    return
                 }
+                // Check if any menu bar item has a menu open before hiding.
+                if await appState.itemManager.isAnyMenuBarItemMenuOpen() {
+                    // Restart the task to check again later.
+                    await self.startRehideChecks()
+                    return
+                }
+                await self.hide()
             }
         case .timed:
             rehideMonitor = EventMonitor.universal(for: .mouseMoved) { [weak self, weak appState] event in
@@ -369,31 +367,28 @@ final class MenuBarSection {
                     appState.hidEventManager.isMouseInsideIceBar(appState: appState)
 
                 if !mouseInActiveArea {
-                    if rehideTimer == nil {
-                        rehideTimer = .scheduledTimer(
-                            withTimeInterval: appState.settings.general.rehideInterval,
-                            repeats: false
-                        ) { [weak self, weak appState] _ in
-                            guard let self, let appState else { return }
-                            Task {
-                                // Don't rehide while the mouse is inside the menu bar or IceBar.
-                                if await self.isMouseInsideActiveArea() {
-                                    await self.startRehideChecks()
-                                    return
-                                }
-                                // Check if any menu bar item has a menu open before hiding.
-                                if await appState.itemManager.isAnyMenuBarItemMenuOpen() {
-                                    self.diagLog.debug("Open menu detected - restarting timed rehide timer")
-                                    await self.restartTimedRehideTimer()
-                                    return
-                                }
-                                await self.hide()
+                    if rehideTask == nil {
+                        let interval = appState.settings.general.rehideInterval
+                        rehideTask = Task { @MainActor [weak self, weak appState] in
+                            try? await Task.sleep(for: .seconds(interval))
+                            guard !Task.isCancelled, let self, let appState else { return }
+                            // Don't rehide while the mouse is inside the menu bar or IceBar.
+                            if await self.isMouseInsideActiveArea() {
+                                await self.startRehideChecks()
+                                return
                             }
+                            // Check if any menu bar item has a menu open before hiding.
+                            if await appState.itemManager.isAnyMenuBarItemMenuOpen() {
+                                self.diagLog.debug("Open menu detected - restarting timed rehide task")
+                                await self.restartTimedRehideTimer()
+                                return
+                            }
+                            await self.hide()
                         }
                     }
                 } else {
-                    rehideTimer?.invalidate()
-                    rehideTimer = nil
+                    rehideTask?.cancel()
+                    rehideTask = nil
                 }
                 return event
             }
@@ -404,7 +399,7 @@ final class MenuBarSection {
         }
     }
 
-    /// Restarts the timed rehide timer (used when a menu is detected).
+    /// Restarts the timed rehide task (used when a menu is detected).
     @MainActor
     private func restartTimedRehideTimer() async {
         guard
@@ -415,34 +410,31 @@ final class MenuBarSection {
             return
         }
 
-        rehideTimer?.invalidate()
-        rehideTimer = .scheduledTimer(
-            withTimeInterval: appState.settings.general.rehideInterval,
-            repeats: false
-        ) { [weak self, weak appState] _ in
-            guard let self, let appState else { return }
-            Task {
-                // Don't rehide while the mouse is inside the menu bar or IceBar.
-                if await self.isMouseInsideActiveArea() {
-                    await self.startRehideChecks()
-                    return
-                }
-                // Check if any menu bar item has a menu open before hiding.
-                if await appState.itemManager.isAnyMenuBarItemMenuOpen() {
-                    self.diagLog.debug("Open menu still detected - restarting timed rehide timer again")
-                    await self.restartTimedRehideTimer()
-                    return
-                }
-                await self.hide()
+        rehideTask?.cancel()
+        let interval = appState.settings.general.rehideInterval
+        rehideTask = Task { [weak self, weak appState] in
+            try? await Task.sleep(for: .seconds(interval))
+            guard !Task.isCancelled, let self, let appState else { return }
+            // Don't rehide while the mouse is inside the menu bar or IceBar.
+            if await self.isMouseInsideActiveArea() {
+                await self.startRehideChecks()
+                return
             }
+            // Check if any menu bar item has a menu open before hiding.
+            if await appState.itemManager.isAnyMenuBarItemMenuOpen() {
+                self.diagLog.debug("Open menu still detected - restarting timed rehide task again")
+                await self.restartTimedRehideTimer()
+                return
+            }
+            await self.hide()
         }
     }
 
     /// Stops running checks to determine when to rehide the section.
     private func stopRehideChecks() {
-        rehideTimer?.invalidate()
+        rehideTask?.cancel()
         rehideMonitor?.stop()
-        rehideTimer = nil
+        rehideTask = nil
         rehideMonitor = nil
     }
 }

--- a/Thaw/MenuBar/MenuBarSection.swift
+++ b/Thaw/MenuBar/MenuBarSection.swift
@@ -331,19 +331,20 @@ final class MenuBarSection {
                 withTimeInterval: appState.settings.general.rehideInterval,
                 repeats: false
             ) { [weak self, weak appState] _ in
+                guard let self, let appState else { return }
                 Task {
                     // Don't rehide while the mouse is inside the menu bar or IceBar.
-                    if await self?.isMouseInsideActiveArea() == true {
-                        await self?.startRehideChecks()
+                    if await self.isMouseInsideActiveArea() {
+                        await self.startRehideChecks()
                         return
                     }
                     // Check if any menu bar item has a menu open before hiding.
-                    if await appState?.itemManager.isAnyMenuBarItemMenuOpen() == true {
+                    if await appState.itemManager.isAnyMenuBarItemMenuOpen() {
                         // Restart the timer to check again later.
-                        await self?.startRehideChecks()
+                        await self.startRehideChecks()
                         return
                     }
-                    await self?.hide()
+                    await self.hide()
                 }
             }
         case .timed:
@@ -373,7 +374,7 @@ final class MenuBarSection {
                             withTimeInterval: appState.settings.general.rehideInterval,
                             repeats: false
                         ) { [weak self, weak appState] _ in
-                            guard let self else { return }
+                            guard let self, let appState else { return }
                             Task {
                                 // Don't rehide while the mouse is inside the menu bar or IceBar.
                                 if await self.isMouseInsideActiveArea() {
@@ -381,7 +382,7 @@ final class MenuBarSection {
                                     return
                                 }
                                 // Check if any menu bar item has a menu open before hiding.
-                                if await appState?.itemManager.isAnyMenuBarItemMenuOpen() == true {
+                                if await appState.itemManager.isAnyMenuBarItemMenuOpen() {
                                     self.diagLog.debug("Open menu detected - restarting timed rehide timer")
                                     await self.restartTimedRehideTimer()
                                     return
@@ -419,7 +420,7 @@ final class MenuBarSection {
             withTimeInterval: appState.settings.general.rehideInterval,
             repeats: false
         ) { [weak self, weak appState] _ in
-            guard let self else { return }
+            guard let self, let appState else { return }
             Task {
                 // Don't rehide while the mouse is inside the menu bar or IceBar.
                 if await self.isMouseInsideActiveArea() {
@@ -427,7 +428,7 @@ final class MenuBarSection {
                     return
                 }
                 // Check if any menu bar item has a menu open before hiding.
-                if await appState?.itemManager.isAnyMenuBarItemMenuOpen() == true {
+                if await appState.itemManager.isAnyMenuBarItemMenuOpen() {
                     self.diagLog.debug("Open menu still detected - restarting timed rehide timer again")
                     await self.restartTimedRehideTimer()
                     return


### PR DESCRIPTION
## Summary

- **`MenuBarOverlayPanel`**: Override `close()` to also close `missionControlProbeWindow`. Previously, when panels were recreated on screen configuration changes, the old 1×1 invisible probe windows were never closed, accumulating in the Window Server.

- **`MenuBarSection`**: Add `[weak appState]` to all rehide timer and monitor closures (smart timer, timed monitor, timed inner timer, `restartTimedRehideTimer`). The closures were previously capturing a locally-bound `guard let appState` as a strong reference, creating unintended ownership of `AppState` for the closure's lifetime.

## Changes

- `Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift` — `close()` override
- `Thaw/MenuBar/MenuBarSection.swift` — 4 closure capture list fixes

## Test plan

- [ ] Open and close IceBar repeatedly — no memory growth in Instruments Allocations
- [ ] Connect/disconnect external display — verify no `NSPanel` accumulation
- [ ] Enable auto-rehide (smart + timed strategies), trigger show/hide cycles — verify correct rehide behaviour still works
- [ ] Monitor memory in Xcode Memory Graph after extended use
