### PR TITLE
fix: restore menu bar section for apps with dynamic item titles

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/DynamicItemOverrides.swift
+++ b/Thaw/MenuBar/MenuBarItems/DynamicItemOverrides.swift
@@ -1,0 +1,34 @@
+//
+//  DynamicItemOverrides.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+/// Namespace-only matching overrides for apps that generate dynamic menu bar item titles.
+///
+/// Apps like Dato or Raycast's calendar plugin change their menu bar item text on
+/// every appearance (e.g. "Meeting at 2pm", "Standup at 3pm"). Exact
+/// `namespace:title` matching fails for these items because the title is never
+/// the same twice. Registering a namespace here opts the app into a fallback
+/// that matches by bundle ID alone, so the user's preferred section is
+/// preserved regardless of the displayed text.
+///
+/// ## Adding a new app
+/// If users report that a specific app's item always resets to the wrong section
+/// after each appearance, add its bundle ID to `knownDynamicNamespaces`.
+enum DynamicItemOverrides {
+    /// Bundle identifiers of apps known to display dynamic menu bar item titles.
+    private static let knownDynamicNamespaces: Set<String> = [
+        "com.p0deje.Dato",                       // Dato — calendar & world clock entries
+        "com.raycast.macos",                     // Raycast — calendar plugin items
+        "com.flexibits.fantastical2.mac",        // Fantastical — upcoming event label
+        "com.flexibits.fantastical2.mac.setapp", // Fantastical (Setapp) — upcoming event label
+    ]
+
+    /// Returns `true` if the given namespace belongs to a known dynamic app.
+    static func isDynamic(_ namespace: String) -> Bool {
+        knownDynamicNamespaces.contains(namespace)
+    }
+}

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -2857,12 +2857,32 @@ extension MenuBarItemManager {
         MenuBarItemManager.diagLog.debug("restoreItemsToSavedSections: waiting for menu bar to settle...")
         try? await Task.sleep(for: .milliseconds(500))
 
-        // Build lookup for saved sections.
+        // Build two lookups from savedSectionOrder:
+        // 1. uniqueIdentifier → saved section (exact match)
+        // 2. namespace string → saved section (fallback for dynamic-title apps)
+        //
+        // A namespace that appears in more than one section is ambiguous; we
+        // remove it from the fallback map so we never guess wrong.
         var savedSectionForItem = [String: MenuBarSection.Name]()
+        var savedSectionByNamespace = [String: MenuBarSection.Name]()
+        var ambiguousNamespaces = Set<String>()
         for (sectionKeyString, identifiers) in savedSectionOrder {
             guard let section = sectionName(for: sectionKeyString) else { continue }
             for identifier in identifiers {
                 savedSectionForItem[identifier] = section
+                // Extract namespace (everything before the first ":").
+                let ns = String(identifier.prefix(while: { $0 != ":" }))
+                if ambiguousNamespaces.contains(ns) {
+                    // Already known to span multiple sections — skip.
+                    continue
+                }
+                if let existing = savedSectionByNamespace[ns], existing != section {
+                    // Namespace spans multiple sections — invalidate fallback.
+                    savedSectionByNamespace.removeValue(forKey: ns)
+                    ambiguousNamespaces.insert(ns)
+                } else {
+                    savedSectionByNamespace[ns] = section
+                }
             }
         }
 
@@ -2883,20 +2903,24 @@ extension MenuBarItemManager {
 
             guard let currentSection = context.findSection(for: item) else { continue }
 
-            // Check both full uniqueIdentifier and base identifier (without instanceIndex)
-            // since instanceIndex may change after app restart.
-            let baseIdentifier = "\(item.tag.namespace):\(item.tag.title)"
-            let savedSection = savedSectionForItem[item.uniqueIdentifier] ?? savedSectionForItem[baseIdentifier]
-            guard let targetSection = savedSection else {
-                MenuBarItemManager.diagLog.debug("restoreItemsToSavedSections: \(item.uniqueIdentifier) (base: \(baseIdentifier)) not in saved sections, skipping")
+            // Prefer exact match; fall back to namespace-only match for apps whose
+            // item titles change on every appearance (e.g. Dato calendar events).
+            let namespaceString = item.tag.namespace.description
+            let savedSection: MenuBarSection.Name
+            if let exact = savedSectionForItem[item.uniqueIdentifier] {
+                savedSection = exact
+            } else if DynamicItemOverrides.isDynamic(namespaceString),
+                      let fallback = savedSectionByNamespace[namespaceString] {
+                savedSection = fallback
+            } else {
                 continue
             }
-            MenuBarItemManager.diagLog.debug("restoreItemsToSavedSections: checking \(item.uniqueIdentifier) - currentSection=\(currentSection.logString), targetSection=\(targetSection.logString)")
-            guard currentSection != targetSection else { continue }
+
+            guard currentSection != savedSection else { continue }
 
             // Item is in the wrong section — move it.
             let destination: MoveDestination
-            switch targetSection {
+            switch savedSection {
             case .visible:
                 destination = .rightOfItem(controlItems.hidden)
             case .hidden:
@@ -2914,7 +2938,7 @@ extension MenuBarItemManager {
             }
 
             MenuBarItemManager.diagLog.info(
-                "Restoring \(item.logString) from \(currentSection.logString) to \(targetSection.logString)"
+                "Restoring \(item.logString) from \(currentSection.logString) to \(savedSection.logString)"
             )
 
             do {
@@ -2923,12 +2947,12 @@ extension MenuBarItemManager {
                 MenuBarItemManager.diagLog.debug("Move completed successfully for restore")
             } catch let error as EventError {
                 MenuBarItemManager.diagLog.error(
-                    "Failed to restore \(item.logString) to \(targetSection.logString): \(error.errorDescription ?? error.description)"
+                    "Failed to restore \(item.logString) to \(savedSection.logString): \(error.errorDescription ?? error.description)"
                 )
                 continue
             } catch {
                 MenuBarItemManager.diagLog.error(
-                    "Failed to restore \(item.logString) to \(targetSection.logString): \(error)"
+                    "Failed to restore \(item.logString) to \(savedSection.logString): \(error)"
                 )
                 continue
             }
@@ -2946,6 +2970,11 @@ extension MenuBarItemManager {
     /// Only triggers when the set of window IDs has changed (items were
     /// recreated by an app restart), not when items were merely repositioned
     /// (user drag). This prevents undoing the user's manual reordering.
+    ///
+    /// - Note: For apps with dynamic item titles (see `DynamicItemOverrides`),
+    ///   this function restores the **section** but not the intra-section order,
+    ///   because the saved position key includes the old title which no longer
+    ///   matches the new item.
     ///
     /// Returns `true` if any items were moved.
     private func restoreSavedItemOrder(

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -2871,7 +2871,7 @@ extension MenuBarItemManager {
             for identifier in identifiers {
                 savedSectionForItem[identifier] = section
                 // Extract namespace (everything before the first ":").
-                let ns = String(identifier.prefix(while: { $0 != ":" }))
+                let ns = identifier.split(separator: ":", maxSplits: 1).first.map(String.init) ?? identifier
                 if ambiguousNamespaces.contains(ns) {
                     // Already known to span multiple sections — skip.
                     continue


### PR DESCRIPTION
## Problem

Apps like Dato, Raycast's calendar plugin, and Fantastical change their
menu bar item title on every appearance (e.g. "Meeting at 2pm" →
"Standup at 3pm"). Because the restore lookup uses `namespace:title` as
a key, every app restart creates a new, unknown key — the item never
matches and always resets to the visible section.

Fixes #220

## Solution

Adds a two-level lookup in `restoreItemsToSavedSections`:

1. **Exact match** — `namespace:title` as before (unchanged for all
   normal apps).
2. **Namespace fallback** — for apps registered in `DynamicItemOverrides`,
   fall back to a bundle-ID-only match so the saved section is preserved
   regardless of the current title.

**Ambiguity guard:** if the same bundle ID appears in more than one
section across the saved layout, the namespace fallback is invalidated —
we never guess wrong when the user has intentionally split an app's items
across sections.

## Changes

### New file: `DynamicItemOverrides.swift`
A caseless enum namespace listing bundle IDs of apps known to use
dynamic titles. Currently includes:
- `com.p0deje.Dato`
- `com.raycast.macos`
- `com.flexibits.fantastical2.mac`
- `com.flexibits.fantastical2.mac.setapp` (Setapp variant)

> To add support for another app, simply add its bundle ID to
> `knownDynamicNamespaces`. No other changes are needed.

### `MenuBarItemManager.swift`
- Builds a `savedSectionByNamespace` dict alongside the existing
  `savedSectionForItem` dict; namespaces that span multiple sections are
  tracked in `ambiguousNamespaces` and excluded from the fallback.
- Replaces the `guard let … ?? …` ternary with an explicit `if let`
  chain for readability.
- Documents the known limitation in `restoreSavedItemOrder`: section is
  restored for dynamic-title items, but not intra-section order (the
  saved key no longer matches the new title).

## Known limitation

For dynamic-title items, only the **section** is restored. The
intra-section position is not restored because the saved key
(`namespace:title`) no longer matches the new item after a title change.
This is noted in the doc comment on `restoreSavedItemOrder`.

## Testing

- [ ] Dato calendar events stay in their saved section after app restart
- [ ] Raycast calendar items stay in their saved section after app restart  
- [ ] Normal (static-title) items are unaffected
- [ ] App with items spread across multiple sections: namespace fallback
      is disabled for that app (ambiguity guard fires)
