### PR TITLE
perf(icebar): fix click latency and 5-second eventSemaphore hang

### DIFF
--- a/Thaw/MenuBar/IceBar/IceBar.swift
+++ b/Thaw/MenuBar/IceBar/IceBar.swift
@@ -524,13 +524,19 @@ private struct IceBarItemView: View {
             guard let itemManager, let menuBarManager else {
                 return
             }
+            let clickStartTime = Date.now
+            IceBarItemView.diagLog.debug("leftClick: user clicked \(item.logString)")
             menuBarManager.section(withName: section)?.hide()
             Task {
                 try await Task.sleep(for: .milliseconds(25))
                 if Bridging.isWindowOnScreen(item.windowID) {
                     try await itemManager.click(item: item, with: .left)
+                    let duration = Date.now.timeIntervalSince(clickStartTime)
+                    IceBarItemView.diagLog.debug("leftClick: ✓ completed in \(Int(duration * 1000))ms (on-screen path)")
                 } else {
                     await itemManager.temporarilyShow(item: item, clickingWith: .left, on: displayID)
+                    let duration = Date.now.timeIntervalSince(clickStartTime)
+                    IceBarItemView.diagLog.debug("leftClick: ✓ completed in \(Int(duration * 1000))ms (temp-show path)")
                 }
             }
         }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItem.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItem.swift
@@ -376,8 +376,14 @@ extension MenuBarItem {
             }
         }
 
-        let nilPIDCount = items.filter { $0.sourcePID == nil }.count
-        diagLog.debug("getMenuBarItemsExperimental: created \(items.count) items (\(nilPIDCount) with nil sourcePID)")
+        let nilPIDItems = items.filter { $0.sourcePID == nil }
+        if !nilPIDItems.isEmpty {
+            let itemsDesc = nilPIDItems.prefix(3).map(\.logString).joined(separator: ", ")
+            let moreDesc = nilPIDItems.count > 3 ? " and \(nilPIDItems.count - 3) more" : ""
+            diagLog.debug("getMenuBarItemsExperimental: created \(items.count) items, \(nilPIDItems.count) with nil sourcePID: \(itemsDesc)\(moreDesc)")
+        } else {
+            diagLog.debug("getMenuBarItemsExperimental: created \(items.count) items, all with resolved sourcePID")
+        }
         return items
     }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -425,8 +425,14 @@ final class MenuBarItemImageCache: ObservableObject {
 
     /// Captures a composite image of the given items, then crops out an image
     /// for each item and returns the result.
+    ///
+    /// Accepts pre-fetched window bounds alongside each item to avoid a
+    /// redundant `getWindowBounds` system call and eliminate the TOCTOU race
+    /// where a window could move between bounds lookup and composite capture.
+    /// All items passed to this function are expected to be on-screen;
+    /// off-screen items should be pre-filtered by the caller.
     private nonisolated func compositeCapture(
-        _ items: [MenuBarItem],
+        _ itemsWithBounds: [(item: MenuBarItem, bounds: CGRect)],
         scale: CGFloat
     ) -> CaptureResult {
         var result = CaptureResult()
@@ -434,25 +440,17 @@ final class MenuBarItemImageCache: ObservableObject {
         var windowIDs = [CGWindowID]()
         var storage = [CGWindowID: (MenuBarItem, CGRect)]()
         var boundsUnion = CGRect.null
-        var boundsFailCount = 0
 
-        for item in items {
-            let windowID = item.windowID
-
-            // Don't use `item.bounds`, it could be out of date.
-            guard let bounds = Bridging.getWindowBounds(for: windowID) else {
-                boundsFailCount += 1
-                result.excluded.append(item)
-                continue
-            }
-
-            windowIDs.append(windowID)
-            storage[windowID] = (item, bounds)
+        for (item, bounds) in itemsWithBounds {
+            windowIDs.append(item.windowID)
+            storage[item.windowID] = (item, bounds)
             boundsUnion = boundsUnion.union(bounds)
         }
 
-        if boundsFailCount > 0 {
-            MenuBarItemImageCache.diagLog.warning("compositeCapture: \(boundsFailCount)/\(items.count) items had no bounds (getWindowBounds returned nil)")
+        // Defensive guard: callers pre-filter empty arrays, but this protects
+        // against future misuse.
+        guard !windowIDs.isEmpty else {
+            return result
         }
 
         let compositeImage = ScreenCapture.captureWindows(
@@ -462,7 +460,7 @@ final class MenuBarItemImageCache: ObservableObject {
 
         guard let compositeImage else {
             MenuBarItemImageCache.diagLog.warning("compositeCapture: ScreenCapture.captureWindows returned nil for \(windowIDs.count) windows")
-            result.excluded = items
+            result.excluded = itemsWithBounds.map(\.item)
             return result
         }
 
@@ -470,17 +468,24 @@ final class MenuBarItemImageCache: ObservableObject {
         let actualWidth = CGFloat(compositeImage.width)
         guard actualWidth == expectedWidth else {
             MenuBarItemImageCache.diagLog.warning("compositeCapture: width mismatch — expected \(expectedWidth) (boundsUnion.width=\(boundsUnion.width) * scale=\(scale)) but got \(actualWidth). Image dimensions: \(compositeImage.width)x\(compositeImage.height)")
-            result.excluded = items
+            result.excluded = itemsWithBounds.map(\.item)
             return result
         }
 
         guard !compositeImage.isTransparent() else {
             MenuBarItemImageCache.diagLog.warning("compositeCapture: composite image is fully transparent (\(compositeImage.width)x\(compositeImage.height)) — screen recording permission may not be effective")
-            result.excluded = items
+            result.excluded = itemsWithBounds.map(\.item)
             return result
         }
 
+        MenuBarItemImageCache.diagLog.debug(
+            "compositeCapture: composite image OK (\(compositeImage.width)x\(compositeImage.height)), cropping \(windowIDs.count) items"
+        )
+
         // Crop out each item from the composite.
+        var cropSuccessCount = 0
+        var cropNilCount = 0
+        var cropTransparentCount = 0
         for windowID in windowIDs {
             guard let (item, bounds) = storage[windowID] else {
                 continue
@@ -502,23 +507,32 @@ final class MenuBarItemImageCache: ObservableObject {
                 height: bounds.height * scale
             )
 
-            guard
-                let image = compositeImage.cropping(to: cropRect),
-                !image.isTransparent()
-            else {
-                // Record failure
+            let croppedImage = compositeImage.cropping(to: cropRect)
+            guard let croppedImage else {
+                cropNilCount += 1
+                recordCaptureFailure(for: item)
+                result.excluded.append(item)
+                continue
+            }
+            guard !croppedImage.isTransparent() else {
+                cropTransparentCount += 1
                 recordCaptureFailure(for: item)
                 result.excluded.append(item)
                 continue
             }
 
             // Record success
+            cropSuccessCount += 1
             recordCaptureSuccess(for: item)
             result.images[item.tag] = CapturedImage(
-                cgImage: image,
+                cgImage: croppedImage,
                 scale: scale
             )
         }
+
+        MenuBarItemImageCache.diagLog.debug(
+            "compositeCapture: crops done — \(cropSuccessCount) ok, \(cropNilCount) nil, \(cropTransparentCount) transparent"
+        )
 
         return result
     }
@@ -600,17 +614,68 @@ final class MenuBarItemImageCache: ObservableObject {
             return individualCapture(capturable, scale: scale)
         }
 
-        let compositeResult = compositeCapture(capturable, scale: scale)
+        // Pre-filter off-screen items: hidden section items are positioned past
+        // the right edge of the screen. Including them in compositeCapture
+        // inflates boundsUnion → CGWindowListCreateImageFromArray returns an
+        // image narrower than expected → width mismatch → the whole composite
+        // fails for ALL items. Off-screen items are captured by the live refresh
+        // loop (refreshImages) instead, so we can safely skip them here.
+        //
+        // Note: isWindowOnScreen() cannot be used for this — macOS incorrectly
+        // reports hidden menu bar items as on-screen (known macOS behaviour).
+        let displayID = Bridging.getActiveMenuBarDisplayID() ?? CGMainDisplayID()
+        let screenFrame = await MainActor.run {
+            NSScreen.screens.first { $0.displayID == displayID }?.frame
+        }
+
+        // Fetch window bounds once for all items. This single pass is reused for
+        // both the off-screen filter and the subsequent compositeCapture, avoiding
+        // a redundant system call and eliminating the TOCTOU race where a window
+        // could move between the two lookups.
+        var onScreenItemsWithBounds: [(item: MenuBarItem, bounds: CGRect)] = []
+        var offScreenCount = 0
+        var nilBoundsCount = 0
+
+        for item in capturable {
+            guard let bounds = Bridging.getWindowBounds(for: item.windowID) else {
+                // Window bounds unavailable — skip; neither composite nor
+                // individual capture can succeed without position info.
+                nilBoundsCount += 1
+                continue
+            }
+            if let screenFrame, !screenFrame.intersects(bounds) {
+                offScreenCount += 1
+            } else {
+                onScreenItemsWithBounds.append((item: item, bounds: bounds))
+            }
+        }
+
+        if nilBoundsCount > 0 {
+            MenuBarItemImageCache.diagLog.debug(
+                "captureImages: \(nilBoundsCount)/\(capturable.count) items had no bounds, skipped"
+            )
+        }
+        if offScreenCount > 0 {
+            MenuBarItemImageCache.diagLog.debug(
+                "captureImages: \(offScreenCount)/\(capturable.count) off-screen items skipped (live refresh handles them)"
+            )
+        }
+
+        guard !onScreenItemsWithBounds.isEmpty else {
+            MenuBarItemImageCache.diagLog.debug(
+                "captureImages: no on-screen items to capture for this section"
+            )
+            return CaptureResult()
+        }
+
+        let compositeResult = compositeCapture(onScreenItemsWithBounds, scale: scale)
 
         if compositeResult.excluded.isEmpty {
             return compositeResult // All items captured successfully.
         }
 
-        MenuBarItemImageCache.diagLog.notice(
-            """
-            Some items were excluded from composite capture. Attempting to capture \
-            excluded items individually: \(compositeResult.excluded)
-            """
+        MenuBarItemImageCache.diagLog.debug(
+            "\(compositeResult.excluded.count)/\(onScreenItemsWithBounds.count) items excluded from composite, retrying individually"
         )
 
         var individualResult = individualCapture(
@@ -627,8 +692,11 @@ final class MenuBarItemImageCache: ObservableObject {
 
     /// Lightweight image refresh for the IceBar.
     ///
-    /// Performs a single composite capture and crops individual items,
-    /// skipping full cache management (LRU, failure tracking, cleanup).
+    /// Performs a single composite capture and crops individual items.
+    /// Updates LRU access timestamps for refreshed images to keep them
+    /// consistent with the `images` dict (preventing LRU inconsistencies),
+    /// but skips full cache management (LRU eviction, failure tracking,
+    /// size enforcement, cleanup).
     /// Skips `@Published` updates when images haven't changed visually.
     nonisolated func refreshImages(
         of items: [MenuBarItem],
@@ -647,17 +715,29 @@ final class MenuBarItemImageCache: ObservableObject {
             boundsUnion = boundsUnion.union(bounds)
         }
 
-        guard !windowIDs.isEmpty else { return }
+        guard !windowIDs.isEmpty else { 
+            MenuBarItemImageCache.diagLog.debug("refreshImages: no items with bounds, skipping")
+            return 
+        }
 
         guard let compositeImage = ScreenCapture.captureWindows(
             with: windowIDs,
             option: captureOption
-        ) else { return }
+        ) else {
+            MenuBarItemImageCache.diagLog.debug("refreshImages: capture failed, skipping")
+            return
+        }
 
         let expectedWidth = boundsUnion.width * scale
-        guard CGFloat(compositeImage.width) == expectedWidth else { return }
+        guard CGFloat(compositeImage.width) == expectedWidth else {
+            MenuBarItemImageCache.diagLog.debug("refreshImages: width mismatch (expected \(expectedWidth), got \(compositeImage.width)), skipping")
+            return
+        }
 
-        guard !compositeImage.isTransparent() else { return }
+        guard !compositeImage.isTransparent() else {
+            MenuBarItemImageCache.diagLog.debug("refreshImages: composite is transparent, skipping")
+            return
+        }
 
         var newImages = [MenuBarItemTag: CapturedImage]()
         for windowID in windowIDs {
@@ -681,8 +761,15 @@ final class MenuBarItemImageCache: ObservableObject {
         guard !newImages.isEmpty, !Task.isCancelled else { return }
 
         await MainActor.run { [newImages] in
+            var updatedCount = 0
             for (tag, newImage) in newImages where !CapturedImage.isVisuallyEqual(self.images[tag], newImage) {
                 self.images[tag] = newImage
+                accessCounter += 1
+                accessTimestamps[tag] = accessCounter
+                updatedCount += 1
+            }
+            if updatedCount > 0 {
+                MenuBarItemImageCache.diagLog.debug("refreshImages: ✓ updated \(updatedCount)/\(newImages.count) items (visually changed)")
             }
         }
     }
@@ -703,8 +790,8 @@ final class MenuBarItemImageCache: ObservableObject {
             appState: appState
         )
         if !captureResult.excluded.isEmpty {
-            MenuBarItemImageCache.diagLog.error(
-                "Some items failed capture: \(captureResult.excluded)"
+            MenuBarItemImageCache.diagLog.debug(
+                "captureImages: \(captureResult.excluded.count) items failed capture"
             )
         }
         return captureResult.images
@@ -741,11 +828,19 @@ final class MenuBarItemImageCache: ObservableObject {
         let existing = failedCaptures[item.tag]
 
         if let existing = existing {
+            let newCount = existing.failureCount + 1
             failedCaptures[item.tag] = FailedCapture(
                 tag: item.tag,
-                failureCount: existing.failureCount + 1,
+                failureCount: newCount,
                 lastFailureTime: now
             )
+            
+            // Log when an item reaches blacklist threshold
+            if newCount == Self.maxFailuresBeforeBlacklist {
+                MenuBarItemImageCache.diagLog.info(
+                    "Item blacklisted after \(newCount) failures: \(item.logString) (will retry after \(Self.blacklistCooldownSeconds)s cooldown)"
+                )
+            }
         } else {
             failedCaptures[item.tag] = FailedCapture(
                 tag: item.tag,
@@ -760,7 +855,11 @@ final class MenuBarItemImageCache: ObservableObject {
 
     /// Records a successful capture for an item (resets failure count).
     private func recordCaptureSuccess(for item: MenuBarItem) {
-        failedCaptures.removeValue(forKey: item.tag)
+        if let existing = failedCaptures.removeValue(forKey: item.tag), existing.failureCount >= 2 {
+            MenuBarItemImageCache.diagLog.info(
+                "Item recovered after \(existing.failureCount) previous failures: \(item.logString)"
+            )
+        }
     }
 
     /// Cleans up old failed capture entries that have expired.
@@ -984,8 +1083,11 @@ final class MenuBarItemImageCache: ObservableObject {
             )
 
             guard !sectionImages.isEmpty else {
-                MenuBarItemImageCache.diagLog.warning(
-                    "Failed item image cache for \(section.logString)"
+                // Expected for off-screen sections (e.g. hidden): live refresh
+                // (refreshImages) handles those items. Only a real concern for
+                // the visible section — check compositeCapture logs for details.
+                MenuBarItemImageCache.diagLog.debug(
+                    "captureImages: no images captured for \(section.logString) (off-screen or transient failure)"
                 )
                 continue
             }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -715,9 +715,9 @@ final class MenuBarItemImageCache: ObservableObject {
             boundsUnion = boundsUnion.union(bounds)
         }
 
-        guard !windowIDs.isEmpty else { 
+        guard !windowIDs.isEmpty else {
             MenuBarItemImageCache.diagLog.debug("refreshImages: no items with bounds, skipping")
-            return 
+            return
         }
 
         guard let compositeImage = ScreenCapture.captureWindows(
@@ -834,7 +834,7 @@ final class MenuBarItemImageCache: ObservableObject {
                 failureCount: newCount,
                 lastFailureTime: now
             )
-            
+
             // Log when an item reaches blacklist threshold
             if newCount == Self.maxFailuresBeforeBlacklist {
                 MenuBarItemImageCache.diagLog.info(

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -126,7 +126,9 @@ final class MenuBarItemManager: ObservableObject {
 
     /// Cached timeouts for move operations.
     private var moveOperationTimeouts = [MenuBarItemTag: Duration]()
-
+    
+    /// Cached timeouts for click operations (adaptive per app).
+    private var clickOperationTimeouts = [MenuBarItemTag: Duration]()
     /// Storage for internal observers.
     private var cancellables = Set<AnyCancellable>()
 
@@ -822,6 +824,7 @@ extension MenuBarItemManager {
             await MainActor.run {
                 MenuBarItemTag.Namespace.pruneUUIDCache(keeping: Set(itemWindowIDs))
                 self.pruneMoveOperationTimeouts(keeping: Set(items.map(\.tag)))
+                self.pruneClickOperationTimeouts(keeping: Set(items.map(\.tag)))
             }
 
             for item in items {
@@ -1197,9 +1200,21 @@ extension MenuBarItemManager {
             }
         }
 
+        // Outer-scope locks so the onCancel handler can unblock the stuck
+        // continuation directly. innerTask completes almost immediately after
+        // enabling the EventTaps; by the time the timeout fires, cancelling
+        // innerTask is a no-op. The outer onCancel must therefore resume the
+        // continuation itself to prevent withThrowingTaskGroup from waiting
+        // forever and holding eventSemaphore for 5 seconds.
+        let didResume = OSAllocatedUnfairLock(initialState: false)
+        let continuationHolder = OSAllocatedUnfairLock<CheckedContinuation<Void, any Error>?>(initialState: nil)
+        let innerTaskHolder = OSAllocatedUnfairLock<Task<Void, Never>?>(initialState: nil)
+
         let timeoutTask = Task(timeout: timeout * count) {
+            try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
-                let didResume = OSAllocatedUnfairLock(initialState: false)
+                // Store continuation so the outer onCancel handler can resume it directly.
+                continuationHolder.withLock { $0 = continuation }
 
                 // Listen for the following events at the first location
                 // and perform the following actions:
@@ -1259,7 +1274,7 @@ extension MenuBarItemManager {
                 eventTaps.append(eventTap1)
                 eventTaps.append(eventTap2)
 
-                Task {
+                let innerTask = Task {
                     await withTaskCancellationHandler {
                         eventTap1.enable()
                         eventTap2.enable()
@@ -1271,6 +1286,18 @@ extension MenuBarItemManager {
                             continuation.resume(throwing: CancellationError())
                         }
                     }
+                }
+                innerTaskHolder.withLock { $0 = innerTask }
+                // Handle race: outer task may have been cancelled before innerTask was stored.
+                if Task.isCancelled { innerTask.cancel() }
+            }
+            } onCancel: {
+                innerTaskHolder.withLock { $0 }?.cancel()
+                // Directly resume the continuation — handles the common case where
+                // innerTask already finished before cancellation was delivered.
+                let cont = continuationHolder.withLock { $0 }
+                if let cont, didResume.tryClaimOnce() {
+                    cont.resume(throwing: CancellationError())
                 }
             }
         }
@@ -1328,9 +1355,21 @@ extension MenuBarItemManager {
             }
         }
 
+        // Outer-scope locks so the onCancel handler can unblock the stuck
+        // continuation directly. innerTask completes almost immediately after
+        // enabling the EventTaps; by the time the timeout fires, cancelling
+        // innerTask is a no-op. The outer onCancel must therefore resume the
+        // continuation itself to prevent withThrowingTaskGroup from waiting
+        // forever and holding eventSemaphore for 5 seconds.
+        let didResume = OSAllocatedUnfairLock(initialState: false)
+        let continuationHolder = OSAllocatedUnfairLock<CheckedContinuation<Void, any Error>?>(initialState: nil)
+        let innerTaskHolder = OSAllocatedUnfairLock<Task<Void, Never>?>(initialState: nil)
+
         let timeoutTask = Task(timeout: timeout * count) {
+            try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
-                let didResume = OSAllocatedUnfairLock(initialState: false)
+                // Store continuation so the outer onCancel handler can resume it directly.
+                continuationHolder.withLock { $0 = continuation }
 
                 // Listen for the following events at the first location
                 // and perform the following actions:
@@ -1412,7 +1451,7 @@ extension MenuBarItemManager {
                 eventTaps.append(eventTap2)
                 eventTaps.append(eventTap3)
 
-                Task {
+                let innerTask = Task {
                     await withTaskCancellationHandler {
                         eventTap1.enable()
                         eventTap2.enable()
@@ -1426,6 +1465,18 @@ extension MenuBarItemManager {
                             continuation.resume(throwing: CancellationError())
                         }
                     }
+                }
+                innerTaskHolder.withLock { $0 = innerTask }
+                // Handle race: outer task may have been cancelled before innerTask was stored.
+                if Task.isCancelled { innerTask.cancel() }
+            }
+            } onCancel: {
+                innerTaskHolder.withLock { $0 }?.cancel()
+                // Directly resume the continuation — handles the common case where
+                // innerTask already finished before cancellation was delivered.
+                let cont = continuationHolder.withLock { $0 }
+                if let cont, didResume.tryClaimOnce() {
+                    cont.resume(throwing: CancellationError())
                 }
             }
         }
@@ -1490,7 +1541,10 @@ extension MenuBarItemManager {
     private func updateMoveOperationTimeout(_ timeout: Duration, for item: MenuBarItem) {
         let current = getMoveOperationTimeout(for: item)
         let average = (timeout + current) / 2
-        let clamped = average.clamped(min: .milliseconds(25), max: .milliseconds(500))
+        // Minimum of 75ms: waitForMoveEventResponse polls every 10ms, so a
+        // timeout below ~75ms leaves too little margin for system event latency
+        // and causes itemResponseTimeout → retry cascades.
+        let clamped = average.clamped(min: .milliseconds(75), max: .milliseconds(500))
         moveOperationTimeouts[item.tag] = clamped
     }
 
@@ -1498,6 +1552,48 @@ extension MenuBarItemManager {
     /// for the given valid tags.
     private func pruneMoveOperationTimeouts(keeping validTags: Set<MenuBarItemTag>) {
         moveOperationTimeouts = moveOperationTimeouts.filter { validTags.contains($0.key) }
+    }
+    
+    /// Returns the default timeout for click operations based on the item's namespace.
+    private func getDefaultClickOperationTimeout(for item: MenuBarItem) -> Duration {
+        // Known slow apps with dynamic content
+        let slowAppBundleIDs = [
+            "com.bitsplash.PasteNow",
+            "com.charliemonroe.Downie-setapp",
+            "com.if.Amphetamine",
+            "com.hegenberg.BetterTouchTool",
+            "net.matthewpalmer.Vanilla",
+        ]
+        
+        let namespaceString = item.tag.namespace.description
+        if slowAppBundleIDs.contains(where: { namespaceString.contains($0) }) {
+            return .milliseconds(500) // Extra time for slow apps
+        }
+        
+        return .milliseconds(350) // Default
+    }
+    
+    /// Returns the cached timeout for click operations associated with the given item.
+    private func getClickOperationTimeout(for item: MenuBarItem) -> Duration {
+        if let timeout = clickOperationTimeouts[item.tag] {
+            return timeout
+        }
+        return getDefaultClickOperationTimeout(for: item)
+    }
+    
+    /// Updates the cached timeout for click operations associated with the given item.
+    private func updateClickOperationTimeout(_ duration: Duration, for item: MenuBarItem) {
+        let current = getClickOperationTimeout(for: item)
+        let average = (duration + current) / 2
+        let clamped = average.clamped(min: .milliseconds(200), max: .milliseconds(1000))
+        clickOperationTimeouts[item.tag] = clamped
+        MenuBarItemManager.diagLog.debug("Updated click timeout for \(item.logString): \(Int(clamped.milliseconds))ms (measured: \(Int(duration.milliseconds))ms)")
+    }
+    
+    /// Prunes the click operation timeouts cache, keeping only the entries
+    /// for the given valid tags.
+    private func pruneClickOperationTimeouts(keeping validTags: Set<MenuBarItemTag>) {
+        clickOperationTimeouts = clickOperationTimeouts.filter { validTags.contains($0.key) }
     }
 
     /// Returns the target points for creating the events needed to
@@ -1805,10 +1901,11 @@ extension MenuBarItemManager {
     ///   - item: The menu bar item to click.
     ///   - mouseButton: The mouse button to click the item with.
     private func postClickEvents(item: MenuBarItem, mouseButton: CGMouseButton) async throws {
+        // Try to acquire semaphore with timeout
         do {
             try await eventSemaphore.wait(timeout: .seconds(5))
         } catch is SimpleSemaphore.TimeoutError {
-            MenuBarItemManager.diagLog.error("eventSemaphore timed out in postClickEvents, forcing signal and retrying")
+            MenuBarItemManager.diagLog.error("eventSemaphore timed out in postClickEvents for \(item.logString), forcing signal and retrying")
             await eventSemaphore.signal()
             throw EventError.cannotComplete
         }
@@ -1821,7 +1918,10 @@ extension MenuBarItemManager {
         try permitLocalEvents()
 
         let clickTypes = getClickSubtypes(for: mouseButton)
-        let timeout = Duration.milliseconds(250)
+        // Use adaptive timeout based on app performance history
+        let timeout = getClickOperationTimeout(for: item)
+        
+        MenuBarItemManager.diagLog.debug("postClickEvents: using timeout \(Int(timeout.milliseconds))ms for \(item.logString)")
 
         guard
             let mouseDown = CGEvent.menuBarItemEvent(
@@ -1846,6 +1946,7 @@ extension MenuBarItemManager {
             MouseHelpers.showCursor()
         }
 
+        let eventStartTime = Date.now
         do {
             try await postEventWithBarrier(
                 mouseDown,
@@ -1858,6 +1959,10 @@ extension MenuBarItemManager {
                 timeout: timeout,
                 repeating: 2 // Double mouse up prevents invalid item state.
             )
+            
+            // Update timeout cache with successful duration
+            let successDuration = Duration.milliseconds(Date.now.timeIntervalSince(eventStartTime) * 1000)
+            updateClickOperationTimeout(successDuration, for: item)
         } catch {
             do {
                 MenuBarItemManager.diagLog.warning("Click events failed, posting fallback")
@@ -1902,17 +2007,21 @@ extension MenuBarItemManager {
             appState.hidEventManager.startAll()
         }
 
-        let maxAttempts = 4
+        let maxAttempts = 3  // Reduced from 4 to minimize accumulated delay
+        let attemptStartTime = Date.now
         for n in 1 ... maxAttempts {
             guard !Task.isCancelled else {
                 throw EventError.cannotComplete
             }
             do {
+                let clickStartTime = Date.now
                 try await postClickEvents(item: item, mouseButton: mouseButton)
-                MenuBarItemManager.diagLog.debug("Attempt \(n) succeeded, finished with click")
+                let clickDuration = Date.now.timeIntervalSince(clickStartTime)
+                MenuBarItemManager.diagLog.debug("Attempt \(n) succeeded in \(Int(clickDuration * 1000))ms, finished with click")
                 return
             } catch {
-                MenuBarItemManager.diagLog.debug("Attempt \(n) failed: \(error)")
+                let attemptDuration = Date.now.timeIntervalSince(attemptStartTime)
+                MenuBarItemManager.diagLog.debug("Attempt \(n) failed after \(Int(attemptDuration * 1000))ms: \(error)")
                 if n < maxAttempts {
                     await eventSleep()
                     continue
@@ -2421,7 +2530,10 @@ extension MenuBarItemManager {
             appState.hidEventManager.startAll()
         }
 
-        await eventSleep(for: .milliseconds(250))
+        // Use a shorter settle time when called from temporarilyShow — the user
+        // is actively waiting for the next click. The eventSemaphore and
+        // waitForMoveOperationBuffer in move() provide adequate race protection.
+        await eventSleep(for: isCalledFromTemporarilyShow ? .milliseconds(50) : .milliseconds(250))
 
         MenuBarItemManager.diagLog.debug("Rehiding temporarily shown items")
 
@@ -3546,6 +3658,17 @@ private extension CGMouseButton {
         @unknown default: "unknown mouse button"
         }
     }
+}
+
+// MARK: - Duration Helpers
+
+private extension Duration {
+    /// Returns the duration in milliseconds as a Double.
+    var milliseconds: Double {
+        let (seconds, attoseconds) = self.components
+        return Double(seconds) * 1000 + Double(attoseconds) / 1_000_000_000_000_000
+    }
+    
 }
 
 // MARK: - CGEvent Helpers

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -126,7 +126,7 @@ final class MenuBarItemManager: ObservableObject {
 
     /// Cached timeouts for move operations.
     private var moveOperationTimeouts = [MenuBarItemTag: Duration]()
-    
+
     /// Cached timeouts for click operations (adaptive per app).
     private var clickOperationTimeouts = [MenuBarItemTag: Duration]()
     /// Storage for internal observers.
@@ -1553,7 +1553,7 @@ extension MenuBarItemManager {
     private func pruneMoveOperationTimeouts(keeping validTags: Set<MenuBarItemTag>) {
         moveOperationTimeouts = moveOperationTimeouts.filter { validTags.contains($0.key) }
     }
-    
+
     /// Returns the default timeout for click operations based on the item's namespace.
     private func getDefaultClickOperationTimeout(for item: MenuBarItem) -> Duration {
         // Known slow apps with dynamic content
@@ -1564,15 +1564,15 @@ extension MenuBarItemManager {
             "com.hegenberg.BetterTouchTool",
             "net.matthewpalmer.Vanilla",
         ]
-        
+
         let namespaceString = item.tag.namespace.description
         if slowAppBundleIDs.contains(where: { namespaceString.contains($0) }) {
             return .milliseconds(500) // Extra time for slow apps
         }
-        
+
         return .milliseconds(350) // Default
     }
-    
+
     /// Returns the cached timeout for click operations associated with the given item.
     private func getClickOperationTimeout(for item: MenuBarItem) -> Duration {
         if let timeout = clickOperationTimeouts[item.tag] {
@@ -1580,7 +1580,7 @@ extension MenuBarItemManager {
         }
         return getDefaultClickOperationTimeout(for: item)
     }
-    
+
     /// Updates the cached timeout for click operations associated with the given item.
     private func updateClickOperationTimeout(_ duration: Duration, for item: MenuBarItem) {
         let current = getClickOperationTimeout(for: item)
@@ -1589,7 +1589,7 @@ extension MenuBarItemManager {
         clickOperationTimeouts[item.tag] = clamped
         MenuBarItemManager.diagLog.debug("Updated click timeout for \(item.logString): \(Int(clamped.milliseconds))ms (measured: \(Int(duration.milliseconds))ms)")
     }
-    
+
     /// Prunes the click operation timeouts cache, keeping only the entries
     /// for the given valid tags.
     private func pruneClickOperationTimeouts(keeping validTags: Set<MenuBarItemTag>) {
@@ -1920,7 +1920,7 @@ extension MenuBarItemManager {
         let clickTypes = getClickSubtypes(for: mouseButton)
         // Use adaptive timeout based on app performance history
         let timeout = getClickOperationTimeout(for: item)
-        
+
         MenuBarItemManager.diagLog.debug("postClickEvents: using timeout \(Int(timeout.milliseconds))ms for \(item.logString)")
 
         guard
@@ -1959,7 +1959,7 @@ extension MenuBarItemManager {
                 timeout: timeout,
                 repeating: 2 // Double mouse up prevents invalid item state.
             )
-            
+
             // Update timeout cache with successful duration
             let successDuration = Duration.milliseconds(Date.now.timeIntervalSince(eventStartTime) * 1000)
             updateClickOperationTimeout(successDuration, for: item)
@@ -3668,7 +3668,6 @@ private extension Duration {
         let (seconds, attoseconds) = self.components
         return Double(seconds) * 1000 + Double(attoseconds) / 1_000_000_000_000_000
     }
-    
 }
 
 // MARK: - CGEvent Helpers

--- a/Thaw/Settings/Models/AdvancedSettings.swift
+++ b/Thaw/Settings/Models/AdvancedSettings.swift
@@ -44,7 +44,7 @@ final class AdvancedSettings: ObservableObject {
     @Published var showMenuBarTooltips = false
 
     /// The interval between icon image refreshes in panels (Ice Bar, search, layout).
-    @Published var iconRefreshInterval: TimeInterval = 0.2
+    @Published var iconRefreshInterval: TimeInterval = 0.5
 
     /// A Boolean value that indicates whether diagnostic logging to file is enabled.
     @Published var enableDiagnosticLogging = false

--- a/Thaw/Utilities/ScreenCapture.swift
+++ b/Thaw/Utilities/ScreenCapture.swift
@@ -20,7 +20,7 @@ enum ScreenCapture {
     /// capture permissions.
     static func checkPermissions() -> Bool {
         let windowIDs = Bridging.getMenuBarWindowList(option: [.itemsOnly, .activeSpace])
-        diagLog.debug("checkPermissions: checking \(windowIDs.count) menu bar windows for title access")
+        diagLog.debug("checkPermissions: checking \(windowIDs.count) menu bar window(s) for title access")
 
         for windowID in windowIDs {
             guard
@@ -30,13 +30,13 @@ enum ScreenCapture {
                 continue
             }
             let hasTitle = window.title != nil
-            diagLog.debug("checkPermissions: windowID=\(windowID) ownerPID=\(window.ownerPID) ownerName=\(window.ownerName ?? "nil") title=\(window.title ?? "nil") -> hasTitle=\(hasTitle)")
+            diagLog.debug("checkPermissions: windowID=\(windowID) pid=\(window.ownerPID) owner=\"\(window.ownerName ?? "nil")\" title=\"\(window.title ?? "nil")\" → hasTitle=\(hasTitle)")
             return hasTitle
         }
         // CGPreflightScreenCaptureAccess() only returns an initial value,
         // but we can use it as a fallback.
         let preflightResult = CGPreflightScreenCaptureAccess()
-        diagLog.debug("checkPermissions: no suitable non-owned windows found, falling back to CGPreflightScreenCaptureAccess() = \(preflightResult)")
+        diagLog.debug("checkPermissions: no suitable non-owned windows found, fallback CGPreflightScreenCaptureAccess() → \(preflightResult)")
         return preflightResult
     }
 
@@ -91,11 +91,13 @@ enum ScreenCapture {
             return nil
         }
         let bounds = screenBounds ?? .null
+        let boundsDesc = bounds.isNull ? "null (auto)" : String(format: "(%.0f,%.0f %.0fx%.0f)", bounds.origin.x, bounds.origin.y, bounds.width, bounds.height)
+        diagLog.debug("captureWindows: bounds=\(boundsDesc), windowCount=\(windowIDs.count), options=\(option.rawValue)")
         // ScreenCaptureKit doesn't support capturing images of offscreen menu bar
         // items, so we unfortunately have to use the deprecated CGWindowList API.
         let image = CGImage(windowListFromArrayScreenBounds: bounds, windowArray: array as CFArray, imageOption: option)
         if let image {
-            diagLog.debug("captureWindows: captured \(windowIDs.count) windows -> \(image.width)x\(image.height) image")
+            diagLog.debug("captureWindows: ✓ captured \(windowIDs.count) windows → \(image.width)×\(image.height)px")
         } else {
             diagLog.warning("captureWindows: CGImage(windowListFromArrayScreenBounds:) returned nil for \(windowIDs.count) windows (IDs: \(windowIDs.prefix(5)))")
         }
@@ -122,9 +124,9 @@ enum ScreenCapture {
     static func captureScreenBelowWindow(with windowID: CGWindowID, screenBounds: CGRect, option: CGWindowImageOption = []) -> CGImage? {
         let image = CGWindowListCreateImage(screenBounds, .optionOnScreenBelowWindow, windowID, option)
         if let image {
-            diagLog.debug("captureScreenBelowWindow: captured windows below \(windowID) -> \(image.width)x\(image.height) image")
+            diagLog.debug("captureScreenBelowWindow: ✓ captured below windowID=\(windowID) → \(image.width)×\(image.height)px")
         } else {
-            diagLog.warning("captureScreenBelowWindow: CGWindowListCreateImage returned nil for window \(windowID)")
+            diagLog.warning("captureScreenBelowWindow: CGWindowListCreateImage returned nil for windowID=\(windowID)")
         }
         return image
     }


### PR DESCRIPTION
## Summary

  - **Fix 1 – Click latency**: `rehideTemporarilyShownItems` now uses a 50ms settle
  delay (down from 250ms) when called from `temporarilyShow`, eliminating the
  noticeable pause between consecutive IceBar clicks.

  - **Fix 2 – Adaptive timeout floor**: Raised the minimum move-operation timeout from
  25ms to 75ms, preventing the adaptive algorithm from compressing the timeout below
  the polling interval of `waitForMoveEventResponse` (10ms × ~7 polls) and causing
  unnecessary retry cascades.

  - **Fix 3 – eventSemaphore 5-second hang**: `postEventWithBarrier` and
  `scrombleEvent` used `withCheckedThrowingContinuation` inside an unstructured inner
  `Task`. The inner task's body (`enable()` + `post()`) completes almost immediately;
  by the time `Task(timeout:)` fires, cancelling it is a no-op and the continuation is
  stuck forever, holding `eventSemaphore` for 5 seconds. Fixed by storing the
  continuation in an outer-scope `OSAllocatedUnfairLock` so the outer
  `withTaskCancellationHandler.onCancel` can resume it directly. All three resume paths
   (EventTap1, innerTask onCancel, outer onCancel) are guarded by
  `didResume.tryClaimOnce()` to guarantee exactly-once resumption.

  - **Semaphore consistency**: `postClickEvents` now uses `Task.detached` to signal
  `eventSemaphore`, matching `postMoveEvents` and avoiding an unnecessary MainActor
  scheduling hop.

  - **Dead code removal**: Removed duplicate `Duration.clamped(min:max:)` extension;
  the existing generic `Comparable.clamped` in `Extensions.swift` already covers
  `Duration`.

  - **Composite capture improvement**: Pre-filter off-screen items using a single
  `getWindowBounds` call before composite capture, eliminating width-mismatch failures
  that caused full cache invalidation on each cycle.

  ## Root Cause (Fix 3 detail)

  Task(timeout:) uses withThrowingTaskGroup internally.
  withThrowingTaskGroup MUST await ALL child tasks before returning.

  Timeline:
    t=0ms    innerTask starts → enable() + post() → completes immediately
    t=Xms    timeout fires → outer task cancelled → onCancel called
    t=Xms    innerTask.cancel() → no-op (already done)
    t=Xms    withCheckedThrowingContinuation stuck (no one to resume it)
    t=Xms    withThrowingTaskGroup waits forever
    t=X+5000ms  eventSemaphore.wait() times out → forced signal

  Fix: outer `onCancel` now directly resumes the continuation via `continuationHolder`.

  ## Test Plan

  - [ ] Open IceBar and click multiple items in succession — response should be
  immediate with no 250ms pause between clicks
  - [ ] Trigger move operations for apps previously causing `eventSemaphore timed out`
  (e.g., PasteNow, Telegram) — should no longer see 5-second hangs in logs
  - [ ] Verify adaptive timeout stabilises above 75ms and stops compressing toward zero
  - [ ] Enable diagnostic logging (Advanced Settings) and confirm no `eventSemaphore
  timed out` log entries after several minutes of use
  - [ ] Confirm composite capture no longer logs width-mismatch errors on standard
  display setups