### PR TITLE
fix: add SSMenuAgent (Screen Sharing) to immovable items

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemTag.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemTag.swift
@@ -29,7 +29,7 @@ struct MenuBarItemTag: Hashable, CustomStringConvertible {
     /// by this tag is a system item.
     var isSystemItem: Bool {
         switch namespace {
-        case .controlCenter, .systemUIServer, .textInputMenuAgent, .weather, .passwords, .screenCaptureUI, .thaw:
+        case .controlCenter, .systemUIServer, .textInputMenuAgent, .weather, .passwords, .screenCaptureUI, .ssMenuAgent, .thaw:
             return true
         case .string, .uuid, .null:
             return false
@@ -137,7 +137,7 @@ extension MenuBarItemTag {
     /// In macOS 26, this list contains the "Clock" and "Control Center" items.
     /// In earlier releases, it also contained the "Siri" item.
     static let immovableItems: [MenuBarItemTag] = {
-        var items = [clock, controlCenter]
+        var items = [clock, controlCenter, ssMenuAgent]
         if #unavailable(macOS 26.0) {
             items.append(siri)
         }
@@ -203,6 +203,13 @@ extension MenuBarItemTag {
 
     /// The tag for the system "Siri" item.
     static let siri = MenuBarItemTag(namespace: .systemUIServer, title: "Siri")
+
+    /// The tag for the system "SSMenuAgent" item (Screen Sharing menu extra).
+    ///
+    /// macOS prevents this item from being repositioned via Command+drag.
+    /// The item visually follows the cursor during the drag, but springs
+    /// back to its original position on mouse-up.
+    static let ssMenuAgent = MenuBarItemTag(namespace: .ssMenuAgent, title: "Item-0")
 
     /// The tag for the system "Time Machine" item.
     static let timeMachine = if #available(macOS 26.0, *) {
@@ -294,6 +301,9 @@ extension MenuBarItemTag.Namespace {
 
     /// The namespace for the "TextInputMenuAgent" process.
     static let textInputMenuAgent = string("com.apple.TextInputMenuAgent")
+
+    /// The namespace for the "SSMenuAgent" process (Screen Sharing menu extra).
+    static let ssMenuAgent = string("com.apple.SSMenuAgent")
 
     /// The namespace for the "WeatherMenu" process.
     static let weather = string("com.apple.weather.menu")


### PR DESCRIPTION
## Summary

macOS prevents the SSMenuAgent menu extra (binoculars / Screen Sharing icon) from being repositioned via Command+drag. The item visually follows the cursor during the drag but **springs back to its original position on mouse-up**. This causes Thaw to retry the move 8 times and then show an error dialog.

- Add `SSMenuAgent` (`com.apple.SSMenuAgent:Item-0`) to `immovableItems` so the layout editor disables dragging for this item entirely
- Add `.ssMenuAgent` namespace constant and tag constant following the existing pattern
- Add `.ssMenuAgent` to `isSystemItem` for consistent system item identity

## Investigation Details

### Environment
- macOS 26.3 (Tahoe), MacBook Pro, Thaw signed release
- SSMenuAgent tag: `com.apple.SSMenuAgent:Item-0` (sourcePID correctly resolved via XPC)

### Manual Command+drag test
Holding Command and dragging the binoculars icon in the menu bar: the icon follows the cursor during the drag, but when released, it **springs back** to its original position. This matches the behavior of Clock and Control Center (both already in `immovableItems`).

### Layout editor drag
Dragging SSMenuAgent from the Visible bar to the Hidden bar in Thaw Settings → Menu Bar Layout produces this error dialog:

> **"SSMenuAgent" took too long to respond**
> Please try again. If the error persists, please file a bug report.

This is `EventError.itemResponseTimeout` — the `move()` function posts Command+drag events, `waitForMoveEventResponse()` polls for position change, the item never moves, and after 8 retry attempts the error propagates.

### Diagnostic logs (from `log stream --predicate 'subsystem == "com.stonerl.Thaw"'`)

```
cacheItemsRegardless: item tag=com.apple.SSMenuAgent:Item-0 (windowID: 15030) title=Item-0 windowID=15030 sourcePID=44321 ownerPID=450
```

The XPC service correctly resolves the true owner PID (44321 = SSMenuAgent), while `ownerPID` reports 450 (Control Center) due to the macOS 26 CGWindowList regression (FB18327911).

### Code path

1. `LayoutBarPaddingView.move()` → `appState.itemManager.move(item:to:)`
2. `move()` passes `item.isMovable` check (SSMenuAgent not in `immovableItems`)
3. `postMoveEvents()` creates Command+mouseDown/mouseUp CGEvents targeted at SSMenuAgent's sourcePID
4. `waitForMoveEventResponse()` polls item origin for ~100ms — **item never moves**
5. Throws `EventError.itemResponseTimeout` → caught by retry loop
6. After 8 attempts, error propagates → `NSAlert` shown

## Context

This issue also exists in Ice (the upstream project Thaw was forked from). I originally discovered and reported it there as jordanbaird/Ice#885, where it manifests as a "Missing bounds rectangle" error instead. Now that I'm using Thaw, I'm submitting the fix here since Thaw is the actively maintained fork. The root cause is the same: macOS prevents SSMenuAgent from being repositioned, but neither Ice nor Thaw had it in their immovable items list.

## Test plan

- [ ] Verify SSMenuAgent (binoculars) icon is **grayed out / not draggable** in the Menu Bar Layout editor
- [ ] Verify no error dialog appears when the layout is loaded with SSMenuAgent present
- [ ] Verify other items (Stats, 1Password, etc.) remain fully draggable
- [ ] Verify Clock and Control Center remain immovable (no regression)

Related: jordanbaird/Ice#885

🤖 Generated with [Claude Code](https://claude.com/claude-code)