### PR TITLE
fix(menubar): distinguish items with same icon from different apps

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItem.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItem.swift
@@ -322,12 +322,24 @@ extension MenuBarItem {
         // may fail for one of the windows due to timing skew between
         // CG and AX coordinate updates.
         //
-        // If an unresolved item shares the same window title with a
-        // resolved item, it almost certainly belongs to the same app.
-        // Re-create the item with the sibling's sourcePID so it gets
-        // the correct namespace, display name, and app icon.
+        // Only propagate a resolved PID to unresolved items sharing
+        // the same title when it is safe to do so. We require that
+        // the resolved PID already accounts for at least 2 items
+        // (across any title), proving the app is a multi-item app.
+        // Without this guard, a single-item app's PID could be
+        // incorrectly assigned to an unresolved item from a
+        // *different* app that happens to share the same title
+        // (e.g. two apps both using "Item-0").
         let unresolvedIndices = items.indices.filter { items[$0].sourcePID == nil && !items[$0].isControlItem }
         if !unresolvedIndices.isEmpty {
+            // Count how many items each PID has been resolved to.
+            var resolvedCountByPID = [pid_t: Int]()
+            for item in items where item.sourcePID != nil {
+                if let pid = item.sourcePID {
+                    resolvedCountByPID[pid, default: 0] += 1
+                }
+            }
+
             // Build a lookup from window title to resolved sourcePID.
             // Use nil as a sentinel for conflicting PIDs (different
             // apps sharing the same title, e.g. multiple apps using
@@ -349,6 +361,14 @@ extension MenuBarItem {
             for idx in unresolvedIndices {
                 let item = items[idx]
                 if let title = item.title, let siblingPID = titleToPID[title] ?? nil {
+                    // Only propagate if the resolved PID is already known
+                    // to own multiple items, confirming it is a multi-item
+                    // app where one window simply failed spatial matching.
+                    let resolvedCount = resolvedCountByPID[siblingPID, default: 0]
+                    guard resolvedCount >= 2 else {
+                        diagLog.debug("getMenuBarItemsExperimental: skipping propagation of sourcePID \(siblingPID) to windowID \(item.windowID) (title=\(title)) — PID has only \(resolvedCount) resolved item(s)")
+                        continue
+                    }
                     diagLog.debug("getMenuBarItemsExperimental: propagating sourcePID \(siblingPID) to unresolved windowID \(item.windowID) (title=\(title))")
                     items[idx] = MenuBarItem(uncheckedItemWindow: windows[idx], sourcePID: siblingPID)
                 }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -2289,7 +2289,7 @@ extension MenuBarItemManager {
         // and use it as a fallback if the neighbor-based return destination
         // becomes stale by the time we rehide.
         let originalSection = itemCache.address(for: item.tag)?.section ?? .hidden
-        let tagIdentifier = "\(item.tag.namespace):\(item.tag.title)"
+        let tagIdentifier = item.tag.tagIdentifier
 
         // Rehide any previously temporarily shown items before showing a new one.
         // This prevents stale contexts from accumulating when the user opens multiple
@@ -2348,7 +2348,7 @@ extension MenuBarItemManager {
         case .rightOfItem: position = "right"
         }
         pendingReturnDestinations[tagIdentifier] = [
-            "neighbor": "\(neighborTag.namespace):\(neighborTag.title)",
+            "neighbor": neighborTag.tagIdentifier,
             "position": position,
         ]
         persistPendingRelocations()
@@ -2602,7 +2602,7 @@ extension MenuBarItemManager {
             do {
                 try await move(item: item, to: destination, on: context.displayID, skipInputPause: true)
                 // Successfully rehidden — remove the pending relocation entry.
-                let tagIdentifier = "\(context.tag.namespace):\(context.tag.title)"
+                let tagIdentifier = context.tag.tagIdentifier
                 pendingRelocations.removeValue(forKey: tagIdentifier)
                 pendingReturnDestinations.removeValue(forKey: tagIdentifier)
             } catch {
@@ -2659,7 +2659,7 @@ extension MenuBarItemManager {
         }
         // Also clear any pending relocation since the user explicitly
         // placed the item in a new position.
-        let tagIdentifier = "\(tag.namespace):\(tag.title)"
+        let tagIdentifier = tag.tagIdentifier
         if pendingRelocations.removeValue(forKey: tagIdentifier) != nil {
             pendingReturnDestinations.removeValue(forKey: tagIdentifier)
             persistPendingRelocations()
@@ -2844,7 +2844,7 @@ extension MenuBarItemManager {
         // Don't interfere with items that are currently temporarily shown —
         // those are handled by the normal rehide flow.
         let activelyShownTags = Set(temporarilyShownItemContexts.map {
-            "\($0.tag.namespace):\($0.tag.title)"
+            $0.tag.tagIdentifier
         })
 
         let hiddenBounds = bestBounds(for: controlItems.hidden)
@@ -2865,7 +2865,7 @@ extension MenuBarItemManager {
 
             // Find the item in the current menu bar items.
             guard let item = items.first(where: {
-                tagIdentifier == "\($0.tag.namespace):\($0.tag.title)"
+                tagIdentifier == $0.tag.tagIdentifier
             }) else {
                 // Item not present yet (app hasn't relaunched). Keep the entry.
                 continue
@@ -2886,14 +2886,14 @@ extension MenuBarItemManager {
             let destination: MoveDestination
             if let destInfo = pendingReturnDestinations[tagIdentifier],
                let neighborTagString = destInfo["neighbor"],
-               let neighborItem = items.first(where: { neighborTagString == "\($0.tag.namespace):\($0.tag.title)" })
+               let neighborItem = items.first(where: { neighborTagString == $0.tag.tagIdentifier })
             {
                 if destInfo["position"] == "left" {
                     destination = .leftOfItem(neighborItem)
                 } else {
                     destination = .rightOfItem(neighborItem)
                 }
-            } else if let fallbackTagString = temporarilyShownItemContexts.first(where: { tagIdentifier == "\($0.tag.namespace):\($0.tag.title)" })?.fallbackNeighborTag,
+            } else if let fallbackTagString = temporarilyShownItemContexts.first(where: { tagIdentifier == $0.tag.tagIdentifier })?.fallbackNeighborTag,
                       let fallbackItem = items.first(matching: fallbackTagString)
             {
                 destination = .rightOfItem(fallbackItem)
@@ -3022,7 +3022,7 @@ extension MenuBarItemManager {
 
         // Don't interfere with temporarily shown items.
         let activelyShownTags = Set(temporarilyShownItemContexts.map {
-            "\($0.tag.namespace):\($0.tag.title)"
+            $0.tag.tagIdentifier
         })
 
         // Count items per namespace to detect multi-icon apps
@@ -3033,7 +3033,7 @@ extension MenuBarItemManager {
         }
 
         for item in items where !item.isControlItem && item.isMovable && item.canBeHidden {
-            let tagString = "\(item.tag.namespace):\(item.tag.title)"
+            let tagString = item.tag.tagIdentifier
             guard !activelyShownTags.contains(tagString) else { continue }
 
             // Skip indexed items (instanceIndex > 0). These naturally position
@@ -3177,7 +3177,7 @@ extension MenuBarItemManager {
 
         // Don't interfere with items that are currently temporarily shown.
         let activelyShownTags = Set(temporarilyShownItemContexts.map {
-            "\($0.tag.namespace):\($0.tag.title)"
+            $0.tag.tagIdentifier
         })
 
         // Count items per namespace to detect indexed and multi-icon apps
@@ -3261,7 +3261,7 @@ extension MenuBarItemManager {
                     anchorIndex += 1
                     continue
                 }
-                let tagString = "\(candidate.tag.namespace):\(candidate.tag.title)"
+                let tagString = candidate.tag.tagIdentifier
                 if activelyShownTags.contains(tagString) {
                     anchorIndex += 1
                     continue
@@ -3278,7 +3278,7 @@ extension MenuBarItemManager {
                 guard let item = itemsByID[filteredSaved[i]] else { continue }
 
                 // Skip items that are currently temporarily shown.
-                let tagString = "\(item.tag.namespace):\(item.tag.title)"
+                let tagString = item.tag.tagIdentifier
                 guard !activelyShownTags.contains(tagString) else { continue }
 
                 do {

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemTag.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemTag.swift
@@ -104,9 +104,20 @@ struct MenuBarItemTag: Hashable, CustomStringConvertible {
     }
 
     /// Returns a Boolean value that indicates whether the given tag
-    /// matches this tag, ignoring their window identifiers and instance indices.
+    /// matches this tag, ignoring their window identifiers.
     func matchesIgnoringWindowID(_ other: MenuBarItemTag) -> Bool {
-        namespace == other.namespace && title == other.title
+        namespace == other.namespace && title == other.title && instanceIndex == other.instanceIndex
+    }
+
+    /// A stable string identifier that uniquely identifies this tag
+    /// across window ID changes (e.g. app restarts). Includes the
+    /// instance index when it is nonzero so that multiple items from
+    /// the same app with the same title are distinguishable.
+    var tagIdentifier: String {
+        if instanceIndex > 0 {
+            return "\(namespace):\(title):\(instanceIndex)"
+        }
+        return "\(namespace):\(title)"
     }
 
     /// Creates a tag with the given namespace, title, window identifier,


### PR DESCRIPTION
When two apps register menu bar items with the same icon (and thus the same namespace + title on macOS 26), Thaw could conflate them into a single logical item. This caused:
- Clicking one item could activate the wrong one
- Auto-hide (rehide) would twitch and leave one item stuck visible
- Pending relocation entries collided, preventing correct rehide

<img width="1118" height="144" alt="image" src="https://github.com/user-attachments/assets/0397e0be-9511-4088-b6d0-972b0dc01b9f" />


Root causes and fixes:

1. `matchesIgnoringWindowID` ignored both windowID and instanceIndex. Two items distinguished only by instanceIndex were treated as one in click handling, bounds lookup, temporarily-shown matching, and image cache cleanup. Now compares instanceIndex as well.

2. PID propagation on macOS 26 could assign App A's PID to App B's unresolved item when both shared a generic title like "Item-0". Now only propagates when the resolved PID already owns 2+ items, confirming it is a multi-item app.

3. Runtime identifiers for pendingRelocations, pendingReturnDestinations, and activelyShownTags used "namespace:title" without instanceIndex, causing key collisions. Introduced `MenuBarItemTag.tagIdentifier` which appends instanceIndex when nonzero, and adopted it across all temporarily-shown and section-restore code paths.

