### PR TITLE
fix(menubar): suppress restore during startup settling period to prevent icon parade

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -147,6 +147,12 @@ final class MenuBarItemManager: ObservableObject {
     private var isRestoringItemOrder = false
     /// Timestamp when isRestoringItemOrder was set (for timeout detection).
     private var isRestoringItemOrderTimestamp: Date?
+    /// True during the startup settling period, during which restore operations
+    /// and section-order saves are suppressed. This prevents cascading icon moves
+    /// when many apps launch at login (login item boot) or restart in quick succession
+    /// (e.g. app update checks). Cleared after a fixed delay, then one final
+    /// restore runs to enforce the user's saved layout.
+    private var isInStartupSettling = false
     /// Persisted bundle identifiers explicitly placed in hidden section.
     private var pinnedHiddenBundleIDs = Set<String>()
     /// Persisted bundle identifiers explicitly placed in always-hidden section.
@@ -330,6 +336,27 @@ final class MenuBarItemManager: ObservableObject {
         await cacheItemsRegardless()
         MenuBarItemManager.diagLog.debug("performSetup: initial cache complete, items in cache: visible=\(itemCache[.visible].count), hidden=\(itemCache[.hidden].count), alwaysHidden=\(itemCache[.alwaysHidden].count), managedItems=\(itemCache.managedItems.count)")
         configureCancellables(with: appState)
+        // Suppress restore and section-order saves for a settling period after launch.
+        // During login (system uptime < 60 s) many apps load over ~30 s, each triggering
+        // a cache cycle; without this guard every launch notification causes a restore
+        // that conflicts with the next, producing the "icon parade" effect.
+        // After the settling period ends, one final cacheItemsRegardless() enforces the
+        // user's saved layout against whatever macOS placed items.
+        let settleDelay: Duration = ProcessInfo.processInfo.systemUptime < 60 ? .seconds(30) : .seconds(5)
+        isInStartupSettling = true
+        MenuBarItemManager.diagLog.debug("performSetup: startup settling period started (\(settleDelay))")
+        // @MainActor ensures the flag flip and final cache call are never
+        // interleaved with notification-triggered cache cycles between them.
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(for: settleDelay)
+            isInStartupSettling = false
+            MenuBarItemManager.diagLog.debug("performSetup: startup settling period ended, running restore")
+            // skipRecentMoveCheck: true — relocateNewLeftmostItems/relocatePendingItems
+            // may have stamped lastMoveOperationTimestamp during settling; without this
+            // flag the final restore would be silently skipped by the 5 s cooldown.
+            await cacheItemsRegardless(skipRecentMoveCheck: true)
+        }
         MenuBarItemManager.diagLog.debug("performSetup: MenuBarItemManager setup complete")
     }
 
@@ -774,7 +801,7 @@ extension MenuBarItemManager {
             isRestoringItemOrderTimestamp = nil
         }
 
-        if !isRestoringItemOrder, !isResettingLayout {
+        if !isRestoringItemOrder, !isResettingLayout, !isInStartupSettling {
             saveSectionOrder(from: context.cache)
         }
         MenuBarItemManager.diagLog.debug("Updated menu bar item cache: visible=\(context.cache[.visible].count), hidden=\(context.cache[.hidden].count), alwaysHidden=\(context.cache[.alwaysHidden].count)")
@@ -902,6 +929,16 @@ extension MenuBarItemManager {
                     await self?.cacheItemsRegardless(skipRecentMoveCheck: true)
                     continuation?.resume()
                 }
+                return
+            }
+
+            // Skip all restore logic during the startup settling period.
+            // The settling period prevents cascading icon moves when many apps
+            // load at login or restart in quick succession (app update checks).
+            // A final cacheItemsRegardless() after the period ends handles restore.
+            guard !isInStartupSettling else {
+                await uncheckedCacheItems(items: items, controlItems: controlItems, displayID: displayID)
+                MenuBarItemManager.diagLog.debug("cacheItemsRegardless: startup settling active, skipping restore")
                 return
             }
 
@@ -2955,7 +2992,10 @@ extension MenuBarItemManager {
     ) async -> Bool {
         guard !savedSectionOrder.isEmpty else { return false }
         guard !suppressNextNewLeftmostItemRelocation else { return false }
-        guard !lastMoveOperationOccurred(within: .seconds(2)) else { return false }
+        // 5 s cooldown (up from 2 s) gives more time for the system to settle after a
+        // restore before another one can start, preventing cascading icon moves when
+        // multiple apps restart in quick succession (e.g. app update checks).
+        guard !lastMoveOperationOccurred(within: .seconds(5)) else { return false }
 
         // Only restore when previous window IDs have disappeared (app restarted).
         // This prevents undoing the user's manual section moves on regular cache refreshes.
@@ -3159,7 +3199,9 @@ extension MenuBarItemManager {
         // (user drag in the Layout Bar, internal relocations, etc.). External
         // app restarts never go through our move() path, so their cache cycles
         // will have no recent move timestamp.
-        guard !lastMoveOperationOccurred(within: .seconds(2)) else { return false }
+        // 5 s cooldown (up from 2 s) matches restoreItemsToSavedSections and
+        // prevents back-to-back restores when apps restart in quick succession.
+        guard !lastMoveOperationOccurred(within: .seconds(5)) else { return false }
 
         // Only restore when previous window IDs have disappeared, indicating
         // an app restarted (old windows destroyed, new ones created). During

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -153,6 +153,10 @@ final class MenuBarItemManager: ObservableObject {
     /// (e.g. app update checks). Cleared after a fixed delay, then one final
     /// restore runs to enforce the user's saved layout.
     private var isInStartupSettling = false
+    /// Handle to the in-flight startup settling Task. Retained so that a
+    /// subsequent performSetup() call can cancel the previous settling period
+    /// before starting a new one, preventing multiple concurrent settling tasks.
+    private var startupSettlingTask: Task<Void, Never>?
     /// Persisted bundle identifiers explicitly placed in hidden section.
     private var pinnedHiddenBundleIDs = Set<String>()
     /// Persisted bundle identifiers explicitly placed in always-hidden section.
@@ -343,13 +347,26 @@ final class MenuBarItemManager: ObservableObject {
         // After the settling period ends, one final cacheItemsRegardless() enforces the
         // user's saved layout against whatever macOS placed items.
         let settleDelay: Duration = ProcessInfo.processInfo.systemUptime < 60 ? .seconds(30) : .seconds(5)
+        // Cancel any in-flight settling task before starting a new one.
+        // Prevents multiple concurrent settling tasks if performSetup() is called
+        // again (e.g. after a display reconnect or permission re-grant triggers
+        // a second setup pass). The cancelled task exits without touching shared
+        // state; this call manages isInStartupSettling for the new period.
+        startupSettlingTask?.cancel()
         isInStartupSettling = true
         MenuBarItemManager.diagLog.debug("performSetup: startup settling period started (\(settleDelay))")
         // @MainActor ensures the flag flip and final cache call are never
         // interleaved with notification-triggered cache cycles between them.
-        Task { @MainActor [weak self] in
+        startupSettlingTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            try? await Task.sleep(for: settleDelay)
+            do {
+                try await Task.sleep(for: settleDelay)
+            } catch {
+                // Cancelled by a subsequent performSetup() call; exit without
+                // touching shared state — the new call manages isInStartupSettling.
+                MenuBarItemManager.diagLog.debug("performSetup: startup settling task cancelled")
+                return
+            }
             isInStartupSettling = false
             MenuBarItemManager.diagLog.debug("performSetup: startup settling period ended, running restore")
             // skipRecentMoveCheck: true — relocateNewLeftmostItems/relocatePendingItems

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -157,6 +157,11 @@ final class MenuBarItemManager: ObservableObject {
     /// subsequent performSetup() call can cancel the previous settling period
     /// before starting a new one, preventing multiple concurrent settling tasks.
     private var startupSettlingTask: Task<Void, Never>?
+    /// Absolute deadline for the current startup settling period. Stored so
+    /// that a re-entry of performSetup() (e.g. permission re-grant) can
+    /// preserve any remaining time from the original period rather than
+    /// resetting to a shorter delay based on current systemUptime.
+    private var settlingDeadline: ContinuousClock.Instant?
     /// Persisted bundle identifiers explicitly placed in hidden section.
     private var pinnedHiddenBundleIDs = Set<String>()
     /// Persisted bundle identifiers explicitly placed in always-hidden section.
@@ -346,21 +351,28 @@ final class MenuBarItemManager: ObservableObject {
         // that conflicts with the next, producing the "icon parade" effect.
         // After the settling period ends, one final cacheItemsRegardless() enforces the
         // user's saved layout against whatever macOS placed items.
-        let settleDelay: Duration = ProcessInfo.processInfo.systemUptime < 60 ? .seconds(30) : .seconds(5)
+        //
+        // On re-entry (e.g. a permission re-grant during the login window): take the
+        // MAX of the previous deadline and the newly computed one. This prevents a
+        // second performSetup() call from resetting systemUptime to a higher value
+        // (> 60 s) and silently truncating the 30-second login settling window.
+        let preferredDelay: Duration = ProcessInfo.processInfo.systemUptime < 60 ? .seconds(30) : .seconds(5)
+        let newDeadline = ContinuousClock.now.advanced(by: preferredDelay)
+        let deadline = max(settlingDeadline ?? newDeadline, newDeadline)
+        settlingDeadline = deadline
         // Cancel any in-flight settling task before starting a new one.
         // Prevents multiple concurrent settling tasks if performSetup() is called
-        // again (e.g. after a display reconnect or permission re-grant triggers
-        // a second setup pass). The cancelled task exits without touching shared
-        // state; this call manages isInStartupSettling for the new period.
+        // again. The cancelled task exits without touching shared state; this call
+        // manages isInStartupSettling for the new period.
         startupSettlingTask?.cancel()
         isInStartupSettling = true
-        MenuBarItemManager.diagLog.debug("performSetup: startup settling period started (\(settleDelay))")
+        MenuBarItemManager.diagLog.debug("performSetup: startup settling period started (delay: \(preferredDelay))")
         // @MainActor ensures the flag flip and final cache call are never
         // interleaved with notification-triggered cache cycles between them.
         startupSettlingTask = Task { @MainActor [weak self] in
             guard let self else { return }
             do {
-                try await Task.sleep(for: settleDelay)
+                try await Task.sleep(until: deadline, clock: .continuous)
             } catch {
                 // Cancelled by a subsequent performSetup() call; exit without
                 // touching shared state — the new call manages isInStartupSettling.
@@ -368,6 +380,7 @@ final class MenuBarItemManager: ObservableObject {
                 return
             }
             isInStartupSettling = false
+            settlingDeadline = nil
             MenuBarItemManager.diagLog.debug("performSetup: startup settling period ended, running restore")
             // skipRecentMoveCheck: true — relocateNewLeftmostItems/relocatePendingItems
             // may have stamped lastMoveOperationTimestamp during settling; without this
@@ -3523,6 +3536,12 @@ extension MenuBarItemManager {
     /// - Returns: The number of items that failed to move.
     func resetLayoutToFreshState() async throws -> Int {
         MenuBarItemManager.diagLog.info("Resetting menu bar layout to fresh state")
+        // A user-initiated reset is authoritative: end the startup settling period
+        // immediately so that the post-reset cache is not blocked from running restore
+        // and saveSectionOrder by an in-flight settling task.
+        startupSettlingTask?.cancel()
+        isInStartupSettling = false
+        settlingDeadline = nil
         isResettingLayout = true
         defer { isResettingLayout = false }
 


### PR DESCRIPTION
## Problem

Addresses the \"icon parade\" reported in #224 — icons continuously shuffling for 10–15 seconds. The root cause is that `restoreItemsToSavedSections` and `restoreSavedItemOrder` fire on **every** `didLaunchApplicationNotification` (1 s debounce). During login, 20+ apps load over ~30 seconds, each triggering its own restore cycle that conflicts with the next, producing cascading icon moves.

A secondary trigger is app update checks (e.g. BetterTouchTool), which briefly remove and re-add a menu bar icon, causing the same back-to-back restore cascade outside of login.

## Solution

### Startup settling period

Introduce `isInStartupSettling`, a flag that blocks restore operations and `saveSectionOrder()` calls for a fixed window after `performSetup()` completes:

- **30 s** when `ProcessInfo.processInfo.systemUptime < 60` (login item / auto-launch boot)
- **5 s** otherwise (manual restart, app-update scenario)

During the period, every `didLaunchApplicationNotification` still triggers a cache cycle so the UI stays accurate, but neither `restoreItemsToSavedSections` nor `restoreSavedItemOrder` runs.

`saveSectionOrder()` is also suppressed during settling to protect the UserDefaults-loaded reference order from being overwritten by transient physical positions before restore has run.

When the period expires, one final `cacheItemsRegardless(skipRecentMoveCheck: true)` enforces the user's saved layout against whatever macOS placed items. `skipRecentMoveCheck: true` prevents the restore from being silently skipped by the 5 s move cooldown in case `relocateNewLeftmostItems` stamped a timestamp near the end of the window.

### Re-entrancy safety

`startupSettlingTask: Task<Void, Never>?` tracks the in-flight task. A subsequent `performSetup()` call cancels the previous task before starting a new one. The cancelled task uses `do/catch` on `Task.sleep` to exit cleanly without touching shared state.

A `settlingDeadline: ContinuousClock.Instant?` is stored so that re-entry computes `max(existingDeadline, newDeadline)`, preventing a second call from truncating the original 30 s login window if `systemUptime` has crossed 60 s by then.

### Layout reset interaction

`resetLayoutToFreshState()` cancels the settling task and clears the flag immediately — a user-initiated reset is authoritative and must not be blocked by an in-flight settling period.

### Move cooldown bump

Both `restoreItemsToSavedSections` and `restoreSavedItemOrder` raise their move-operation cooldown from 2 s to 5 s, providing more separation between consecutive automatic restores when apps restart in quick succession.

## Changes

Single file: `Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift` (+89 / -5)

## Test plan

- [ ] **Login item boot** — enable Launch at Login, reboot, verify no icon shuffle during the first ~30 s after login
- [ ] **App update trigger** — use BetterTouchTool's "Check for updates" and verify icons do not shuffle
- [ ] **Normal app restart** — quit and relaunch an app that has a hidden menu bar item; verify it is restored to the correct section within ~5–8 s
- [ ] **Reset Layout during boot** — open Settings and press Reset Layout within 30 s of login; verify the reset takes effect immediately without waiting for settling to expire
- [ ] **Permission re-grant** — revoke and re-grant Screen Recording permission during the settling window; verify settling deadline is preserved (not truncated)
- [ ] **Show/hide** — verify IceBar show/hide behaviour is unaffected during and after the settling period

> ⚠️ **More testing needed.** The 30 s / 5 s thresholds and the `systemUptime < 60` boundary are heuristics. Feedback on edge cases — especially on slower machines or unusual login configurations — would be very helpful before merging.

Fixes #224