### PR TITLE
[codex] Align control item hover background with native menu bar items

### DIFF
--- a/Thaw/MenuBar/ControlItem/ControlItem.swift
+++ b/Thaw/MenuBar/ControlItem/ControlItem.swift
@@ -83,8 +83,7 @@ final class ControlItem {
                     }
 
                     NSLayoutConstraint.activate([
-                        button.topAnchor.constraint(equalTo: contentView.topAnchor),
-                        button.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+                        button.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
                     ])
                 } else {
                     self.constraint = nil


### PR DESCRIPTION
Closes #252.

The control item used for Thaw's separator and overflow affordance was constrained to the top and bottom edges of the status item content view. On current macOS builds that causes its highlighted background to occupy a different vertical footprint than adjacent native menu bar items, so the separator looks taller and visually out of place when hovered or pressed.

The underlying issue is that the button was being stretched to fill the container rather than aligned the way native status bar controls are. That makes the active and hover background shape follow the full content view height instead of the standard centered capsule geometry users expect in the menu bar.

This change replaces the top and bottom pinning with a vertical centering constraint on the status item button. Keeping the button centered lets AppKit render the control at the same apparent vertical alignment as neighboring system items, which makes the hover and active background match native menu bar behavior more closely.

I validated the change with the same checks used by the repository CI:

- `swiftlint --strict`
- `xcodebuild -project Thaw.xcodeproj -scheme Thaw -destination platform=macOS -configuration Release MACOSX_DEPLOYMENT_TARGET=14.0 CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO build`
