### PR TITLE
feat: highlight Thaw Bar icons on hover

### DIFF
--- a/Thaw/MenuBar/IceBar/IceBar.swift
+++ b/Thaw/MenuBar/IceBar/IceBar.swift
@@ -602,6 +602,7 @@ private struct IceBarItemView: View {
                 .background {
                     RoundedRectangle(cornerRadius: 4, style: .continuous)
                         .fill((isLightBackground ? Color.black : Color.white).opacity(isHovered ? 0.1 : 0))
+                        .padding(.vertical, 3)
                 }
                 .contentShape(Rectangle())
                 .overlay {

--- a/Thaw/MenuBar/IceBar/IceBar.swift
+++ b/Thaw/MenuBar/IceBar/IceBar.swift
@@ -480,6 +480,7 @@ private struct IceBarContentView: View {
         } else {
             ScrollView(.horizontal) {
                 HStack(spacing: 0) {
+                    let isLightBackground = (colorManager.colorInfo?.color.brightness ?? 0) > 0.67
                     ForEach(items, id: \.windowID) { item in
                         IceBarItemView(
                             imageCache: imageCache,
@@ -489,7 +490,8 @@ private struct IceBarContentView: View {
                             section: section,
                             displayID: screen.displayID,
                             maxHeight: itemMaxHeight,
-                            tooltipDelay: appState.settings.advanced.tooltipDelay
+                            tooltipDelay: appState.settings.advanced.tooltipDelay,
+                            isLightBackground: isLightBackground
                         )
                     }
                 }
@@ -513,11 +515,14 @@ private struct IceBarItemView: View {
     @ObservedObject var itemManager: MenuBarItemManager
     @ObservedObject var menuBarManager: MenuBarManager
 
+    @State private var isHovered = false
+
     let item: MenuBarItem
     let section: MenuBarSection.Name
     let displayID: CGDirectDisplayID
     let maxHeight: CGFloat?
     let tooltipDelay: TimeInterval
+    let isLightBackground: Bool
 
     private var leftClickAction: () -> Void {
         return { [weak itemManager, weak menuBarManager] in
@@ -593,15 +598,24 @@ private struct IceBarItemView: View {
                 .antialiased(true)
                 .resizable()
                 .frame(width: size.width, height: size.height)
+                .padding(.horizontal, 3)
+                .background {
+                    RoundedRectangle(cornerRadius: 4, style: .continuous)
+                        .fill((isLightBackground ? Color.black : Color.white).opacity(isHovered ? 0.1 : 0))
+                }
                 .contentShape(Rectangle())
                 .overlay {
                     IceBarItemClickView(
                         item: item,
                         tooltipDelay: tooltipDelay,
                         leftClickAction: leftClickAction,
-                        rightClickAction: rightClickAction
+                        rightClickAction: rightClickAction,
+                        onHover: { hovering in
+                            isHovered = hovering
+                        }
                     )
                 }
+                .animation(.easeInOut(duration: 0.15), value: isHovered)
                 .accessibilityLabel(item.displayName)
                 .accessibilityAction(named: "left click", leftClickAction)
                 .accessibilityAction(named: "right click", rightClickAction)
@@ -618,6 +632,7 @@ private struct IceBarItemClickView: NSViewRepresentable {
 
         let leftClickAction: () -> Void
         let rightClickAction: () -> Void
+        let onHover: (Bool) -> Void
 
         private var lastLeftMouseDownDate = Date.now
         private var lastRightMouseDownDate = Date.now
@@ -632,12 +647,14 @@ private struct IceBarItemClickView: NSViewRepresentable {
             item: MenuBarItem,
             tooltipDelay: TimeInterval,
             leftClickAction: @escaping () -> Void,
-            rightClickAction: @escaping () -> Void
+            rightClickAction: @escaping () -> Void,
+            onHover: @escaping (Bool) -> Void
         ) {
             self.item = item
             self.tooltipDelay = tooltipDelay
             self.leftClickAction = leftClickAction
             self.rightClickAction = rightClickAction
+            self.onHover = onHover
             super.init(frame: .zero)
         }
 
@@ -664,11 +681,13 @@ private struct IceBarItemClickView: NSViewRepresentable {
         override func mouseEntered(with event: NSEvent) {
             super.mouseEntered(with: event)
             tooltipController.scheduleShow(delay: tooltipDelay)
+            onHover(true)
         }
 
         override func mouseExited(with event: NSEvent) {
             super.mouseExited(with: event)
             tooltipController.cancel()
+            onHover(false)
         }
 
         override func mouseDown(with event: NSEvent) {
@@ -713,13 +732,15 @@ private struct IceBarItemClickView: NSViewRepresentable {
 
     let leftClickAction: () -> Void
     let rightClickAction: () -> Void
+    let onHover: (Bool) -> Void
 
     func makeNSView(context _: Context) -> NSView {
         Represented(
             item: item,
             tooltipDelay: tooltipDelay,
             leftClickAction: leftClickAction,
-            rightClickAction: rightClickAction
+            rightClickAction: rightClickAction,
+            onHover: onHover
         )
     }
 


### PR DESCRIPTION
## What does this PR do?

Adds a subtle hover highlight effect to icons in the Thaw Bar (IceBar). When hovering over a menu bar item, a semi-transparent rounded-rectangle background fades in behind the icon, providing visual feedback about which item will be activated on click.

## PR Type

- [ ] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [x] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What is the current behavior?

Hovering over icons in the Thaw Bar provides no visual feedback. Users cannot tell which item they are about to click.

Issue Number: #257

## What is the new behavior?

- A rounded-rectangle background highlight (10% opacity) appears behind the icon on hover.
- The highlight color is derived from the actual menu bar brightness via `IceBarColorManager` (black on light bars, white on dark bars), matching the same appearance logic used for icon foreground colors.
- Hover state is communicated from the existing `NSTrackingArea` in `IceBarItemClickView` back to SwiftUI via an `onHover` callback, consistent with the existing tooltip tracking pattern.
- A smooth 0.15s ease-in-out animation transitions the highlight in and out.

## PR Checklist

- [x] I've built and run the app locally
- [x] I've checked for console errors or crashes
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

### Implementation details

Only `IceBar.swift` is modified (25 lines added, 4 changed):

- `IceBarItemView`: Added `@State private var isHovered` and `isLightBackground` parameter. Applied `.padding(.horizontal, 3)`, a `RoundedRectangle` background, and `.animation()` modifier.
- `IceBarItemClickView` / `Represented`: Added `onHover: (Bool) -> Void` callback, called from `mouseEntered` and `mouseExited`.
- `IceBarContentView`: Passes `isLightBackground` (computed from `colorManager.colorInfo`) to each item view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Menu bar items now display interactive hover effects with visually distinct rounded backgrounds that adapt to light and dark themes
  * Enhanced user interaction feedback through refined animations and spacing adjustments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->