### PR TITLE
Remove redundant rebuildWindowBoundsLookup in handleShowOnClick

### DIFF
--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -403,8 +403,6 @@ extension HIDEventManager {
     // MARK: Handle Show On Click
 
     private func handleShowOnClick(appState: AppState, screen: NSScreen, isDoubleClick: Bool = false) {
-        rebuildWindowBoundsLookup(from: appState.itemManager.itemCache)
-
         guard isMouseInsideEmptyMenuBarSpace(appState: appState, screen: screen) else {
             return
         }


### PR DESCRIPTION
## Summary

- Remove redundant `rebuildWindowBoundsLookup` call in `handleShowOnClick`
- The Combine sink on `itemCache` (line 286) already keeps the window bounds lookup up to date whenever the cache changes
- The extra call triggered a full Window Server IPC round-trip on every menu bar click, adding unnecessary latency

## Test plan
- [ ] Click empty area of menu bar to show/hide items — verify behavior is unchanged
- [ ] Double-click for always-hidden section — verify behavior is unchanged
- [ ] Right-click context menu in menu bar — verify behavior is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized click event handling by removing a redundant window bounds lookup rebuild, reducing unnecessary computations and improving performance during click interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->