### PR TITLE
i18n: update Simplified Chinese (zh-Hans) translation

### DIFF
--- a/Thaw/Resources/Localizable.xcstrings
+++ b/Thaw/Resources/Localizable.xcstrings
@@ -17278,7 +17278,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "搜索菜单栏项目中"
+            "value" : "搜索菜单栏项目"
           }
         },
         "zh-Hant" : {
@@ -17374,7 +17374,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "搜索菜单栏项目中…"
+            "value" : "搜索菜单栏项目…"
           }
         },
         "zh-Hant" : {
@@ -18239,6 +18239,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bu ekranda gizli menü çubuğu öğelerini menü çubuğunun altındaki ayrı bir çubukta göster."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在该显示器的菜单栏下方，以独立菜单栏显示隐藏的项目。"
           }
         },
         "zh-Hant" : {


### PR DESCRIPTION
- Added missing entries in the Simplified Chinese translation

- [Show hidden menu bar items in a separate bar below the menu bar on this display.] →translate→ [在该显示器的菜单栏下方，以独立的菜单栏显示隐藏的菜单栏项目。]
- Correct the incorrect translation：[搜索菜单栏项目中]→[搜索菜单栏项目]
- Correct the incorrect translation：[搜索菜单栏项目中...]→[搜索菜单栏项目...]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Localization**
  * Enhanced Chinese (Simplified) translations for improved clarity in menu search functionality and visibility settings for hidden items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->