### PR TITLE
fix: restore item order for single-icon items when multi-icon apps present

### DIFF
--- a/FREQUENT_ISSUES.md
+++ b/FREQUENT_ISSUES.md
@@ -24,7 +24,7 @@ the always-hidden section, then Command + drag the item into a different section
 
 ## Thaw does not remember the order of items
 
-This is not a bug, but a missing feature. It is being tracked in [#26](https://github.com/jordanbaird/Thaw/issues/26).
+Order restoration works for single-icon apps. Apps that register multiple menu bar icons from the same process (e.g. iStat Menus, Stats, MenuMeters) are treated as opaque blocks — their internal ordering is left to macOS, but they no longer prevent other items from being restored to their saved positions.
 
 ## How do I solve the `Thaw cannot arrange menu bar items in automatically hidden menu bars` error?
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -147,6 +147,11 @@ final class MenuBarItemManager: ObservableObject {
     private var isRestoringItemOrder = false
     /// Timestamp when isRestoringItemOrder was set (for timeout detection).
     private var isRestoringItemOrderTimestamp: Date?
+    /// Indicates the most recent order restore was partial (multi-icon/indexed
+    /// items were present). While true, `saveSectionOrder` is suppressed to
+    /// prevent overwriting good saved state with potentially randomised
+    /// positions. Cleared on explicit user drag or a full (non-partial) restore.
+    private var restoreWasPartiallySkipped = false
     /// True during the startup settling period, during which restore operations
     /// and section-order saves are suppressed. This prevents cascading icon moves
     /// when many apps launch at login (login item boot) or restart in quick succession
@@ -484,6 +489,7 @@ final class MenuBarItemManager: ObservableObject {
     /// (e.g. the user cmd+dragged an item directly on the menu bar).
     func recordExternalMoveOperation() {
         lastMoveOperationTimestamp = .now
+        restoreWasPartiallySkipped = false
     }
 }
 
@@ -829,9 +835,12 @@ extension MenuBarItemManager {
             MenuBarItemManager.diagLog.debug("Resetting stale isRestoringItemOrder flag (timeout)")
             isRestoringItemOrder = false
             isRestoringItemOrderTimestamp = nil
+            restoreWasPartiallySkipped = false
         }
 
-        if !isRestoringItemOrder, !isResettingLayout, !isInStartupSettling {
+        if !isRestoringItemOrder, !isResettingLayout, !isInStartupSettling,
+           !restoreWasPartiallySkipped
+        {
             saveSectionOrder(from: context.cache)
         }
         MenuBarItemManager.diagLog.debug("Updated menu bar item cache: visible=\(context.cache[.visible].count), hidden=\(context.cache[.hidden].count), alwaysHidden=\(context.cache[.alwaysHidden].count)")
@@ -3342,23 +3351,33 @@ extension MenuBarItemManager {
             $0.tag.tagIdentifier
         })
 
-        // Count items per namespace to detect indexed and multi-icon apps
+        // Count items per namespace and collect namespaces with indexed items
+        // so we can exclude them from ordering without bailing out entirely.
         var itemsPerNamespace = [String: Int]()
-        var hasIndexedItems = false
+        var namespacesWithIndexedItems = Set<String>()
         for item in items where !item.isControlItem && item.isMovable && item.canBeHidden {
             let ns = item.tag.namespace.description
             itemsPerNamespace[ns, default: 0] += 1
             if item.tag.instanceIndex > 0 {
-                hasIndexedItems = true
+                namespacesWithIndexedItems.insert(ns)
             }
         }
 
-        // Skip if indexed or multi-icon apps are present. These naturally position
-        // themselves, and restoring order causes shuffling.
-        let hasMultiIconApps = itemsPerNamespace.values.contains { $0 > 1 }
-        guard !hasIndexedItems && !hasMultiIconApps else {
-            MenuBarItemManager.diagLog.debug("restoreSavedItemOrder: skipping due to indexed/multi-icon items present")
-            return false
+        // Build exclusion set: multi-icon namespaces and namespaces with indexed
+        // items. These naturally self-position and restoring them causes shuffling.
+        // Control Center items only appear one at a time and can be safely restored.
+        let excludedNamespaces = Set(
+            itemsPerNamespace.filter { $0.key != "com.apple.controlcenter" && $0.value > 1 }.keys
+        ).union(namespacesWithIndexedItems)
+        let hasExcludedNamespaces = !excludedNamespaces.isEmpty
+
+        if hasExcludedNamespaces {
+            MenuBarItemManager.diagLog.debug(
+                "restoreSavedItemOrder: multi-icon/indexed items present — restoring single-icon items only (excluded: \(excludedNamespaces))"
+            )
+            restoreWasPartiallySkipped = true
+        } else {
+            restoreWasPartiallySkipped = false
         }
 
         // Build a lookup from uniqueIdentifier → MenuBarItem for all current non-control items.
@@ -3391,9 +3410,17 @@ extension MenuBarItemManager {
                 continue
             }
 
-            // Filter saved identifiers to only those present in this section right now.
+            // Filter saved identifiers to only those present in this section right now,
+            // excluding items from multi-icon/indexed namespaces.
             let currentIDSet = Set(currentItems.map(\.uniqueIdentifier))
-            let filteredSaved = savedIdentifiers.filter { currentIDSet.contains($0) }
+            let filteredSaved = savedIdentifiers.filter { id in
+                guard currentIDSet.contains(id) else { return false }
+                if hasExcludedNamespaces {
+                    let ns = String(id.split(separator: ":").first ?? "")
+                    return !excludedNamespaces.contains(ns)
+                }
+                return true
+            }
 
             guard !filteredSaved.isEmpty else { continue }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -3412,10 +3412,13 @@ extension MenuBarItemManager {
             // Filter saved identifiers to only those present in this section right now,
             // excluding items from multi-icon/indexed namespaces.
             let currentIDSet = Set(currentItems.map(\.uniqueIdentifier))
+            let namespaceByID = Dictionary(
+                uniqueKeysWithValues: currentItems.map { ($0.uniqueIdentifier, $0.tag.namespace.description) }
+            )
             let filteredSaved = savedIdentifiers.filter { id in
                 guard currentIDSet.contains(id) else { return false }
                 if hasExcludedNamespaces {
-                    let ns = String(id.split(separator: ":").first ?? "")
+                    guard let ns = namespaceByID[id] else { return false }
                     return !excludedNamespaces.contains(ns)
                 }
                 return true

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -152,6 +152,10 @@ final class MenuBarItemManager: ObservableObject {
     /// prevent overwriting good saved state with potentially randomised
     /// positions. Cleared on explicit user drag or a full (non-partial) restore.
     private var restoreWasPartiallySkipped = false
+    /// Re-entrancy guard for `restoreSavedItemOrder`. Separate from
+    /// `isRestoringItemOrder` which the caller uses to suppress saves during
+    /// the entire restore phase (cross-section + within-section).
+    private var isInWithinSectionRestore = false
     /// True during the startup settling period, during which restore operations
     /// and section-order saves are suppressed. This prevents cascading icon moves
     /// when many apps launch at login (login item boot) or restart in quick succession
@@ -3320,8 +3324,10 @@ extension MenuBarItemManager {
     ) async -> Bool {
         guard !savedSectionOrder.isEmpty else { return false }
 
-        // Don't attempt another restore while a previous restore's recache is in flight.
-        guard !isRestoringItemOrder else { return false }
+        // Don't attempt another restore while a previous within-section restore is in flight.
+        guard !isInWithinSectionRestore else { return false }
+        isInWithinSectionRestore = true
+        defer { isInWithinSectionRestore = false }
 
         // Don't restore while suppressing relocations (first launch / reset).
         guard !suppressNextNewLeftmostItemRelocation else { return false }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -3413,7 +3413,8 @@ extension MenuBarItemManager {
             // excluding items from multi-icon/indexed namespaces.
             let currentIDSet = Set(currentItems.map(\.uniqueIdentifier))
             let namespaceByID = Dictionary(
-                uniqueKeysWithValues: currentItems.map { ($0.uniqueIdentifier, $0.tag.namespace.description) }
+                currentItems.map { ($0.uniqueIdentifier, $0.tag.namespace.description) },
+                uniquingKeysWith: { first, _ in first }
             )
             let filteredSaved = savedIdentifiers.filter { id in
                 guard currentIDSet.contains(id) else { return false }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -835,7 +835,6 @@ extension MenuBarItemManager {
             MenuBarItemManager.diagLog.debug("Resetting stale isRestoringItemOrder flag (timeout)")
             isRestoringItemOrder = false
             isRestoringItemOrderTimestamp = nil
-            restoreWasPartiallySkipped = false
         }
 
         if !isRestoringItemOrder, !isResettingLayout, !isInStartupSettling,


### PR DESCRIPTION
## Summary

Fixes #300

- `restoreSavedItemOrder()` now excludes multi-icon/indexed app items from ordering instead of bailing out entirely, so single-icon items are still restored to their saved positions
- Adds `restoreWasPartiallySkipped` flag to suppress `saveSectionOrder()` after a partial restore, preventing good saved state from being overwritten with randomised positions
- Clears the partial-skip flag on explicit user drag (cmd+drag) so normal save behavior resumes

## Context

Apps like [Stats](https://github.com/exelban/stats), iStat Menus, and MenuMeters register multiple menu bar icons from a single process. The previous logic detected this and skipped order restoration for *all* items, causing icons to jump around on every restart. Over time, `saveSectionOrder()` would overwrite the good saved state with randomised positions, making the problem progressively worse.

## Test plan

- [ ] Install Stats (or another multi-icon menu bar app) alongside several single-icon menu bar apps
- [ ] Arrange icons in desired order, restart Mac
- [ ] Verify single-icon items restore to saved positions
- [ ] Verify multi-icon app items are left alone (no shuffling)
- [ ] Cmd+drag an icon to a new position, restart — verify the new position is saved
- [ ] Test without any multi-icon apps installed — verify full restore still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented partial restores involving multi-icon or indexed items from overwriting previously saved section layouts.
  * After a partial restore, normal saving of section order is suppressed until the user performs a manual rearrangement or an explicit full restore.

* **Documentation**
  * Clarified that single-icon apps restore saved order; multi-icon apps from the same process are treated as grouped blocks and won’t block other items from being restored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->