### PR TITLE
docs: add contributing guidelines to the repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# Contributing to Thaw
+The following is a set of guidelines to contribute to Thaw on GitHub.
+Feel free to propose any changes to this document. All contributions welcome.
+
+## <a name="coc"></a>Code of Conduct
+Please read and follow our [Code of Conduct][coc].
+
+## Ways to contribute
+- Bug reports
+- Documentation improvements
+- Code
+- Translations
+
+## Before You Start
+
+Regardless of the type of contribution, you'll need a GitHub account and a fork of the repository:
+
+1. Fork the repository on GitHub
+2. Clone your fork locally
+```bash
+git clone https://github.com/YOUR_USERNAME/Thaw.git
+```
+3. Navigate to the cloned directory
+4. Create a branch for your changes
+```bash
+git checkout -b your-branch-name
+```
+5. When ready, open a pull request against `stonerl/Thaw:main`
+## Non-technical contributions
+
+### Reporting bugs
+Before submitting a bug report, please search the [issue tracker][it] and check [Frequent Issues][fq] — your problem may already be known with a workaround available.
+
+We want to fix all issues as soon as possible, but before fixing a bug we need to be able to reproduce them first. Our bug report template will guide you through the information we need. Issues without enough information to reproduce the problem may be closed until more details are provided.
+
+If the app crashed — attaching a log file will help us significantly, you can find these in Thaw's settings under the General tab.
+
+### Translations
+If you want to help translate Thaw into your language or improve existing ones, you'll need Xcode 16.4+.
+
+1. Open `Thaw.xcodeproj` from your cloned fork.
+2. Navigate to `Thaw -> Resources -> Localizable.xcstrings`.
+3. Add a new language using the **+** button at the bottom or update existing strings.
+4. Submit a Pull Request with your changes using the [Localization / Translation PR template][lt].
+
+_Note: You can see the exact completion percentage for each language directly in the Xcode String Catalog editor._
+
+### Documentation improvements
+
+If you find something unclear, incomplete, or out of date in any of the project's docs, a pull request to fix it is welcome.
+ 
+This includes but is not limited to:
+- Fixing typos or unclear wording
+- Keeping the README up to date
+- Adding new entries to [Frequent Issues][fq]
+- Improving this and other guides.
+
+## Technical contributions
+
+### Prerequisites
+- Xcode 16.4+
+- macOS 14+
+
+### Getting Started
+
+1. Open `Thaw.xcodeproj` in Xcode 16.4 or later
+```bash
+open Thaw.xcodeproj
+```
+2. Build and run the app (`Cmd+R`) to confirm everything works before making changes
+
+### Code Style
+Thaw uses [SwiftLint](https://github.com/realm/SwiftLint) and [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) to enforce consistent code style.
+
+Before submitting a request, run:
+```bash
+swiftformat .
+swiftlint lint
+```
+
+Pull requests are automatically reviewed by SonarCloud for code quality and CodeRabbit for AI-assisted review. You may receive automated comments from these tools, so please address any findings before requesting a human review.
+
+### Pull Requests
+Open a pull request [here][pr] and select the [appropriate template][prt] — it will guide you through the required information and checklist. Make sure the CI passes and wait for code review. You may be asked to make changes; when finished, request a re-review using the GitHub feature or mention the reviewers.
+
+## Resources
+- [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
+- [Using Issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues)
+- [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)
+
+[coc]: CODE_OF_CONDUCT.md
+[fq]: FREQUENT_ISSUES.md
+[it]: https://github.com/stonerl/Thaw/issues
+[pr]: https://github.com/stonerl/Thaw/pulls
+[lt]: https://github.com/stonerl/Thaw/blob/main/.github/PULL_REQUEST_TEMPLATE/localization.md
+[prt]: https://github.com/stonerl/Thaw/blob/main/.github/pull_request_template.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ swiftlint lint
 Pull requests are automatically reviewed by SonarCloud for code quality and CodeRabbit for AI-assisted review. You may receive automated comments from these tools, so please address any findings before requesting a human review.
 
 ### Pull Requests
-Open a pull request [here][pr] and select the [appropriate template][prt] — it will guide you through the required information and checklist. Make sure the CI passes and wait for code review. You may be asked to make changes; when finished, request a re-review using the GitHub feature or mention the reviewers.
+Open a pull request via the [Thaw pull requests page][pr] and select the [appropriate template][prt] — it will guide you through the required information and checklist.
 
 ## Resources
 - [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)

--- a/README.md
+++ b/README.md
@@ -158,17 +158,6 @@ Thaw is currently available in the following languages:
 
 _Note: languages marked with (\*) are currently only available in the development branch._
 
-### Help Translate Thaw
-
-If you want to help translate Thaw into your language or improve existing ones, you'll need the latest version of Xcode.
-
-1. Open `Thaw.xcodeproj` in Xcode 16.4 or later.
-2. Navigate to `Thaw -> Resources -> Localizable.xcstrings`.
-3. Add a new language using the **+** button at the bottom or update existing strings.
-4. Submit a Pull Request with your changes!
-
-_Note: You can see the exact completion percentage for each language directly in the Xcode String Catalog editor._
-
 ## Features/Roadmap
 
 <details>


### PR DESCRIPTION
## What does this PR do?

A brief description of the changes proposed in this pull request.

## PR Type

- [X] Documentation

## Does this PR introduce a breaking change?

- [X] No

## What is the current behavior?

There is no contributing guide in the repository. Contributors have no structured reference for how to report bugs, submit translations, or open pull requests.

## What is the new behavior?

Adds `CONTRIBUTING.md` with sections for:

- Bug reporting
- Translations (moved from `README`)
- Documentation improvements
- Technical contributions (getting started, code style, PR process)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive contribution guide covering how to report issues, propose code/docs/translations, system requirements, build/setup steps, and code style expectations
  * Removed the previous “Help Translate” instructions from the README and consolidated translation workflow into the new contribution guide
<!-- end of auto-generated comment: release notes by coderabbit.ai -->