### PR TITLE
fix: reduce IceBar click jitter with fast-path temporarilyShow

### DIFF
--- a/Thaw/MenuBar/IceBar/IceBar.swift
+++ b/Thaw/MenuBar/IceBar/IceBar.swift
@@ -539,7 +539,7 @@ private struct IceBarItemView: View {
                     let duration = Date.now.timeIntervalSince(clickStartTime)
                     IceBarItemView.diagLog.debug("leftClick: ✓ completed in \(Int(duration * 1000))ms (on-screen path)")
                 } else {
-                    await itemManager.temporarilyShow(item: item, clickingWith: .left, on: displayID)
+                    await itemManager.temporarilyShow(item: item, clickingWith: .left, on: displayID, fastPath: true)
                     let duration = Date.now.timeIntervalSince(clickStartTime)
                     IceBarItemView.diagLog.debug("leftClick: ✓ completed in \(Int(duration * 1000))ms (temp-show path)")
                 }
@@ -558,7 +558,7 @@ private struct IceBarItemView: View {
                 if Bridging.isWindowOnScreen(item.windowID) {
                     try await itemManager.click(item: item, with: .right)
                 } else {
-                    await itemManager.temporarilyShow(item: item, clickingWith: .right, on: displayID)
+                    await itemManager.temporarilyShow(item: item, clickingWith: .right, on: displayID, fastPath: true)
                 }
             }
         }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -1950,7 +1950,8 @@ extension MenuBarItemManager {
         to destination: MoveDestination,
         on displayID: CGDirectDisplayID? = nil,
         skipInputPause: Bool = false,
-        watchdogTimeout: DispatchTimeInterval? = nil
+        watchdogTimeout: DispatchTimeInterval? = nil,
+        maxMoveAttempts: Int = 8
     ) async throws {
         guard item.isMovable else {
             throw EventError.itemNotMovable(item)
@@ -2009,7 +2010,7 @@ extension MenuBarItemManager {
             MouseHelpers.showCursor()
         }
 
-        let maxAttempts = 8
+        let maxAttempts = maxMoveAttempts
         for n in 1 ... maxAttempts {
             guard !Task.isCancelled else {
                 throw EventError.cannotComplete
@@ -2428,7 +2429,7 @@ extension MenuBarItemManager {
     ///   - item: The item to temporarily show.
     ///   - mouseButton: The mouse button to click the item with.
     ///   - displayID: The display identifier to show the item on.
-    func temporarilyShow(item: MenuBarItem, clickingWith mouseButton: CGMouseButton, on displayID: CGDirectDisplayID? = nil) async {
+    func temporarilyShow(item: MenuBarItem, clickingWith mouseButton: CGMouseButton, on displayID: CGDirectDisplayID? = nil, fastPath: Bool = false) async {
         guard let appState else {
             MenuBarItemManager.diagLog.error("Missing AppState, so not showing \(item.logString)")
             return
@@ -2522,7 +2523,14 @@ extension MenuBarItemManager {
         MenuBarItemManager.diagLog.debug("Temporarily showing \(item.logString) on display \(resolvedDisplayID)")
 
         do {
-            try await move(item: item, to: moveDestination, on: resolvedDisplayID, skipInputPause: true)
+            if fastPath {
+                // Single attempt move — the first attempt always repositions the item
+                // close enough. Skipping retries eliminates the visible jitter from
+                // the 8-attempt retry loop with exponentially increasing timeouts.
+                try await move(item: item, to: moveDestination, on: resolvedDisplayID, skipInputPause: true, maxMoveAttempts: 1)
+            } else {
+                try await move(item: item, to: moveDestination, on: resolvedDisplayID, skipInputPause: true)
+            }
         } catch {
             MenuBarItemManager.diagLog.error("Error showing item: \(error)")
             pendingRelocations.removeValue(forKey: tagIdentifier)
@@ -2547,24 +2555,31 @@ extension MenuBarItemManager {
             runRehideTimer()
         }
 
-        // Wait for the item's position to stabilize after the move. Some
-        // apps need time to process the window relocation before they can
-        // correctly position their popup in response to a click.
-        await waitForItemPositionToSettle(item: item)
+        let clickItem: MenuBarItem
+        if fastPath {
+            // Fast path: skip settle wait, re-fetch, and extra sleep to minimize
+            // the time the jittering icon is visible before the menu opens.
+            clickItem = item
+        } else {
+            // Wait for the item's position to stabilize after the move. Some
+            // apps need time to process the window relocation before they can
+            // correctly position their popup in response to a click.
+            await waitForItemPositionToSettle(item: item)
 
-        // Re-fetch the item from the live window list specifically for this display.
-        // Prefer an exact windowID match, then fall back to namespace+title with PID matching.
-        let refreshedItems = await MenuBarItem.getMenuBarItems(on: resolvedDisplayID, option: .onScreen)
-        let clickItem = refreshedItems.first(where: { $0.windowID == item.windowID }) ??
-            refreshedItems.first(where: {
-                $0.tag.matchesIgnoringWindowID(item.tag) &&
-                    ($0.sourcePID ?? $0.ownerPID) == (item.sourcePID ?? item.ownerPID)
-            }) ?? item
+            // Re-fetch the item from the live window list specifically for this display.
+            // Prefer an exact windowID match, then fall back to namespace+title with PID matching.
+            let refreshedItems = await MenuBarItem.getMenuBarItems(on: resolvedDisplayID, option: .onScreen)
+            clickItem = refreshedItems.first(where: { $0.windowID == item.windowID }) ??
+                refreshedItems.first(where: {
+                    $0.tag.matchesIgnoringWindowID(item.tag) &&
+                        ($0.sourcePID ?? $0.ownerPID) == (item.sourcePID ?? item.ownerPID)
+                }) ?? item
 
-        // Give the owning app a little extra time to finish processing the
-        // move internally. Some apps (e.g. OneDrive) need more than just a
-        // stable window position before they can respond to clicks.
-        await eventSleep(for: .milliseconds(25))
+            // Give the owning app a little extra time to finish processing the
+            // move internally. Some apps (e.g. OneDrive) need more than just a
+            // stable window position before they can respond to clicks.
+            await eventSleep(for: .milliseconds(25))
+        }
 
         let idsBeforeClick = Set(Bridging.getWindowList(option: .onScreen))
 


### PR DESCRIPTION
## Problem

When clicking hidden items from the IceBar, the icon visibly jitters/shifts in the menu bar for ~1.8 seconds before the menu opens. This is caused by:

1. `move()` retrying 8 times with exponentially increasing timeouts, even though the first attempt always repositions the item close enough (position verification fails due to slight drift after mouseUp)
2. ~300ms of post-move delays (250ms settle wait, item re-fetch, 25ms extra sleep) before the click fires

## Fix

Add a `fastPath` mode for IceBar clicks that:
- Limits `move()` to 1 attempt (via new `maxMoveAttempts` parameter, default 8 for existing callers)
- Skips the settle wait, item re-fetch, and extra sleep between move and click

This reduces the visible jitter from ~1.8s to a brief flash (~100ms).

## Changes

- `MenuBarItemManager.swift`: Add `maxMoveAttempts` parameter to `move()` and `fastPath` parameter to `temporarilyShow()`
- `IceBar.swift`: Pass `fastPath: true` for both left and right click handlers

## Testing

Tested on macOS Tahoe with 30+ menu bar items across two displays. Hidden items clicked from the IceBar now open their menus with minimal visible jitter. No regression for non-IceBar move operations (layout, rehide, etc.) which continue using the default 8-attempt path.
