### PR TITLE
Refine listener naming and singleton init comment

### DIFF
--- a/MenuBarItemService/Listener.swift
+++ b/MenuBarItemService/Listener.swift
@@ -18,10 +18,12 @@ final class Listener {
     private let name = MenuBarItemService.name
 
     /// The underlying XPC listener object.
-    private var listener: XPCListener?
+    private var xpcListener: XPCListener?
 
     /// Creates the shared listener.
-    private init() {}
+    private init() {
+        // Intentionally empty: this type is a singleton and is configured via `activate()`.
+    }
 
     deinit {
         cancel()
@@ -52,7 +54,7 @@ final class Listener {
     /// same team identifier as the service process.
     @available(macOS 26.0, *)
     private func uncheckedActivateWithSameTeamRequirement() throws {
-        listener = try XPCListener(service: name, requirement: .isFromSameTeam()) { [weak self] request in
+        xpcListener = try XPCListener(service: name, requirement: .isFromSameTeam()) { [weak self] request in
             request.accept { message in
                 self?.handleMessage(message)
             }
@@ -61,7 +63,7 @@ final class Listener {
 
     /// Activates the listener without checking if it is already active.
     private func uncheckedActivate() throws {
-        listener = try XPCListener(service: name) { [weak self] request in
+        xpcListener = try XPCListener(service: name) { [weak self] request in
             request.accept { message in
                 self?.handleMessage(message)
             }
@@ -70,7 +72,7 @@ final class Listener {
 
     /// Activates the listener.
     func activate() {
-        guard listener == nil else {
+        guard xpcListener == nil else {
             diagLog.notice("Listener is already active")
             return
         }
@@ -91,6 +93,6 @@ final class Listener {
     /// Cancels the listener.
     func cancel() {
         diagLog.debug("Canceling listener")
-        listener.take()?.cancel()
+        xpcListener.take()?.cancel()
     }
 }


### PR DESCRIPTION
## What does this PR do?

#316 Updates `MenuBarItemService/Listener.swift` to improve naming clarity and initializer intent without changing runtime behavior.

Changes included:
- Renamed the private field `listener` to `xpcListener`.
- Updated all corresponding references (`activate`, unchecked activate helpers, and `cancel`).
- Added an explicit comment inside `private init()` to clarify that the initializer is intentionally empty for singleton lifecycle management.

## PR Type

- [ ] Bugfix
- [ ] CI/CD related changes
- [x] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

## What is the current behavior?

The listener implementation works as expected, but uses a generic field name (`listener`) and an empty private initializer with no inline explanation.

Issue Number: N/A

## What is the new behavior?

Behavior is unchanged.  
The code is clearer and more maintainable through:
- More explicit field naming (`xpcListener`).
- Explicit documentation of intentionally empty singleton initializer.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

Scope intentionally limited to one file:
- `MenuBarItemService/Listener.swift`

No functional logic changes were introduced.

### Notes for reviewers

Please focus on naming consistency and whether the singleton initializer comment matches project conventions for intentionally empty initializers.