### PR TITLE
Rename symbols to match naming convention

### DIFF
--- a/Shared/Bridging/Bridging.swift
+++ b/Shared/Bridging/Bridging.swift
@@ -358,9 +358,9 @@ extension Bridging {
             return []
         }
         var list = [CGWindowID](repeating: 0, count: Int(count))
-        let result = CGSGetWindowList(getMainConnection(), nullConnection, count, &list, &count)
+        let result = cgsGetWindowList(getMainConnection(), nullConnection, count, &list, &count)
         guard result == .success else {
-            diagLog.error("CGSGetWindowList failed with error \(result.logString)")
+            diagLog.error("cgsGetWindowList failed with error \(result.logString)")
             return []
         }
         return [CGWindowID](list[..<Int(count)])

--- a/Shared/Bridging/Shims.swift
+++ b/Shared/Bridging/Shims.swift
@@ -119,7 +119,7 @@ func cgsGetOnScreenWindowCount(
 ) -> CGError
 
 @_silgen_name("CGSGetWindowList")
-func CGSGetWindowList(
+func cgsGetWindowList(
     _ cid: CGSConnectionID,
     _ targetCID: CGSConnectionID,
     _ count: Int32,

--- a/Shared/Utilities/DiagnosticLogger.swift
+++ b/Shared/Utilities/DiagnosticLogger.swift
@@ -20,12 +20,12 @@ final class DiagnosticLogger: @unchecked Sendable {
 
     /// Whether diagnostic logging to file is currently enabled.
     /// Thread-safe via OSAllocatedUnfairLock.
-    private let _isEnabled = OSAllocatedUnfairLock(initialState: false)
+    private let isEnabledLock = OSAllocatedUnfairLock(initialState: false)
 
     var isEnabled: Bool {
-        get { _isEnabled.withLock { $0 } }
+        get { isEnabledLock.withLock { $0 } }
         set {
-            let oldValue = _isEnabled.withLock { current -> Bool in
+            let oldValue = isEnabledLock.withLock { current -> Bool in
                 let old = current
                 current = newValue
                 return old
@@ -72,14 +72,14 @@ final class DiagnosticLogger: @unchecked Sendable {
     }
 
     /// The current log file URL, if logging is active.
-    private let _currentLogFile = OSAllocatedUnfairLock<URL?>(initialState: nil)
+    private let currentLogFileLock = OSAllocatedUnfairLock<URL?>(initialState: nil)
 
     var currentLogFile: URL? {
-        _currentLogFile.withLock { $0 }
+        currentLogFileLock.withLock { $0 }
     }
 
     /// The file handle for writing.
-    private let _fileHandle = OSAllocatedUnfairLock<FileHandle?>(initialState: nil)
+    private let fileHandleLock = OSAllocatedUnfairLock<FileHandle?>(initialState: nil)
 
     /// Internal logger for DiagnosticLogger's own messages.
     private let osLog = Logger(
@@ -131,8 +131,8 @@ final class DiagnosticLogger: @unchecked Sendable {
         do {
             let handle = try FileHandle(forWritingTo: fileURL)
             handle.seekToEndOfFile()
-            _fileHandle.withLock { $0 = handle }
-            _currentLogFile.withLock { $0 = fileURL }
+            fileHandleLock.withLock { $0 = handle }
+            currentLogFileLock.withLock { $0 = fileURL }
 
             // Write header
             let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
@@ -160,7 +160,7 @@ final class DiagnosticLogger: @unchecked Sendable {
 
     /// Closes the current log file.
     private func closeLogFile() {
-        _fileHandle.withLock { handle in
+        fileHandleLock.withLock { handle in
             if let handle {
                 let ts = timestampFormatter.string(from: Date())
                 let footer = "\n\(ts) [DiagnosticLogger] Diagnostic logging stopped\n"
@@ -171,7 +171,7 @@ final class DiagnosticLogger: @unchecked Sendable {
             }
             handle = nil
         }
-        _currentLogFile.withLock { $0 = nil }
+        currentLogFileLock.withLock { $0 = nil }
         osLog.info("Diagnostic logging stopped")
     }
 
@@ -233,7 +233,7 @@ final class DiagnosticLogger: @unchecked Sendable {
         guard let data = line.data(using: .utf8) else { return }
 
         writeQueue.async { [weak self] in
-            self?._fileHandle.withLock { handle in
+            self?.fileHandleLock.withLock { handle in
                 handle?.write(data)
             }
         }

--- a/Thaw/Utilities/Migration.swift
+++ b/Thaw/Utilities/Migration.swift
@@ -28,8 +28,8 @@ extension MigrationManager {
 
         do {
             try performAll(blocks: [
-                migrate0_8_0,
-                migrate0_10_0,
+                migrateForRelease080,
+                migrateForRelease0100,
             ])
         } catch let error as MigrationError {
             results.append(.failureAndLogError(error))
@@ -38,10 +38,10 @@ extension MigrationManager {
         }
 
         results += [
-            migrate0_10_1(),
-            migrate0_11_10(),
-            migrate0_11_13(),
-            migrate0_11_13_1(),
+            migrateForRelease0101(),
+            migrateForRelease01110(),
+            migrateForRelease01113(),
+            migrateForRelease011131(),
             migratePerDisplayIceBar(),
         ]
 
@@ -63,14 +63,14 @@ extension MigrationManager {
 extension MigrationManager {
     /// Performs all migrations for the `0.8.0` release, catching any thrown
     /// errors and rethrowing them as a combined error.
-    private func migrate0_8_0() throws {
+    private func migrateForRelease080() throws {
         guard !Defaults.bool(forKey: .hasMigrated0_8_0) else {
             return
         }
         try performAll(blocks: [
-            migrateHotkeys0_8_0,
-            migrateControlItems0_8_0,
-            migrateSections0_8_0,
+            migrateHotkeysForRelease080,
+            migrateControlItemsForRelease080,
+            migrateSectionsForRelease080,
         ])
         Defaults.set(true, forKey: .hasMigrated0_8_0)
         diagLog.info("Successfully migrated to 0.8.0 settings")
@@ -81,7 +81,7 @@ extension MigrationManager {
     /// Migrates the user's saved hotkeys from the old method of storing
     /// them in their corresponding menu bar sections to the new method
     /// of storing them as stand-alone data in the `0.8.0` release.
-    private func migrateHotkeys0_8_0() throws {
+    private func migrateHotkeysForRelease080() throws {
         let sectionsArray: [[String: Any]]
         do {
             guard let array = try getMenuBarSectionArray() else {
@@ -125,7 +125,7 @@ extension MigrationManager {
 
     /// Migrates the control items from their old serialized representations
     /// to their new representations in the `0.8.0` release.
-    private func migrateControlItems0_8_0() throws {
+    private func migrateControlItemsForRelease080() throws {
         let sectionsArray: [[String: Any]]
         do {
             guard let array = try getMenuBarSectionArray() else {
@@ -180,7 +180,7 @@ extension MigrationManager {
 
     /// Migrates away from storing the menu bar sections in UserDefaults
     /// for the `0.8.0` release.
-    private func migrateSections0_8_0() {
+    private func migrateSectionsForRelease080() {
         Defaults.set(nil, forKey: .sections)
     }
 }
@@ -189,18 +189,18 @@ extension MigrationManager {
 
 extension MigrationManager {
     /// Performs all migrations for the `0.10.0` release.
-    private func migrate0_10_0() {
+    private func migrateForRelease0100() {
         guard !Defaults.bool(forKey: .hasMigrated0_10_0) else {
             return
         }
 
-        migrateControlItems0_10_0()
+        migrateControlItemsForRelease0100()
 
         Defaults.set(true, forKey: .hasMigrated0_10_0)
         diagLog.info("Successfully migrated to 0.10.0 settings")
     }
 
-    private func migrateControlItems0_10_0() {
+    private func migrateControlItemsForRelease0100() {
         for identifier in ControlItem.Identifier.allCases {
             ControlItemDefaults.migrate(
                 key: .preferredPosition,
@@ -215,11 +215,11 @@ extension MigrationManager {
 
 extension MigrationManager {
     /// Performs all migrations for the `0.10.1` release.
-    private func migrate0_10_1() -> MigrationResult {
+    private func migrateForRelease0101() -> MigrationResult {
         guard !Defaults.bool(forKey: .hasMigrated0_10_1) else {
             return .success
         }
-        let result = migrateControlItems0_10_1()
+        let result = migrateControlItemsForRelease0101()
         switch result {
         case .success, .successButShowAlert:
             Defaults.set(true, forKey: .hasMigrated0_10_1)
@@ -230,7 +230,7 @@ extension MigrationManager {
         return result
     }
 
-    private func migrateControlItems0_10_1() -> MigrationResult {
+    private func migrateControlItemsForRelease0101() -> MigrationResult {
         var needsResetPreferredPositions = false
 
         for identifier in ControlItem.Identifier.allCases {
@@ -262,11 +262,11 @@ extension MigrationManager {
 
 extension MigrationManager {
     /// Performs all migrations for the `0.11.10` release.
-    private func migrate0_11_10() -> MigrationResult {
+    private func migrateForRelease01110() -> MigrationResult {
         guard !Defaults.bool(forKey: .hasMigrated0_11_10) else {
             return .success
         }
-        let result = migrateAppearanceConfiguration0_11_10()
+        let result = migrateAppearanceConfigurationForRelease01110()
         switch result {
         case .success, .successButShowAlert:
             Defaults.set(true, forKey: .hasMigrated0_11_10)
@@ -277,7 +277,7 @@ extension MigrationManager {
         return result
     }
 
-    private func migrateAppearanceConfiguration0_11_10() -> MigrationResult {
+    private func migrateAppearanceConfigurationForRelease01110() -> MigrationResult {
         guard let oldData = Defaults.data(forKey: .menuBarAppearanceConfiguration) else {
             if Defaults.object(forKey: .menuBarAppearanceConfiguration) != nil {
                 diagLog.warning("Previous menu bar appearance data is corrupted")
@@ -319,13 +319,13 @@ extension MigrationManager {
 
 extension MigrationManager {
     /// Performs all migrations for the `0.11.13` release.
-    private func migrate0_11_13() -> MigrationResult {
+    private func migrateForRelease01113() -> MigrationResult {
         guard !Defaults.bool(forKey: .hasMigrated0_11_13) else {
             return .success
         }
 
-        migrateAppearanceConfiguration0_11_13()
-        migrateSectionDividers0_11_13()
+        migrateAppearanceConfigurationForRelease01113()
+        migrateSectionDividersForRelease01113()
 
         Defaults.set(true, forKey: .hasMigrated0_11_13)
         diagLog.info("Successfully migrated to 0.11.13 settings")
@@ -333,11 +333,11 @@ extension MigrationManager {
         return .success
     }
 
-    private func migrateAppearanceConfiguration0_11_13() {
+    private func migrateAppearanceConfigurationForRelease01113() {
         Defaults.removeObject(forKey: .menuBarAppearanceConfiguration)
     }
 
-    private func migrateSectionDividers0_11_13() {
+    private func migrateSectionDividersForRelease01113() {
         let style = if Defaults.bool(forKey: .showSectionDividers) {
             SectionDividerStyle.chevron
         } else {
@@ -352,12 +352,12 @@ extension MigrationManager {
 
 extension MigrationManager {
     /// Performs all migrations for the `0.11.13.1` release.
-    private func migrate0_11_13_1() -> MigrationResult {
+    private func migrateForRelease011131() -> MigrationResult {
         guard !Defaults.bool(forKey: .hasMigrated0_11_13_1) else {
             return .success
         }
 
-        migrateControlItems0_11_13_1()
+        migrateControlItemsForRelease011131()
 
         Defaults.set(true, forKey: .hasMigrated0_11_13_1)
         diagLog.info("Successfully migrated to 0.11.13.1 settings")
@@ -365,7 +365,7 @@ extension MigrationManager {
         return .success
     }
 
-    private func migrateControlItems0_11_13_1() {
+    private func migrateControlItemsForRelease011131() {
         for identifier in ControlItem.Identifier.allCases {
             ControlItemDefaults.migrate(
                 key: .preferredPosition,


### PR DESCRIPTION
## What does this PR do?

Renames functions and constants that did not match the `^[a-z][a-zA-Z0-9]*$` naming rule in the targeted files, and updates all corresponding call sites.

This PR also keeps the bridged `_silgen_name("CGSGetWindowList")` symbol unchanged while renaming the Swift-facing function to `cgsGetWindowList`, so style compliance is improved without breaking the underlying symbol binding.

## PR Type

- [ ] Bugfix
- [ ] CI/CD related changes
- [x] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

## What is the current behavior?

Several functions and constants in the affected files use names with underscores or uppercase prefixes that do not match the project's naming rule.

Issue Number: Closes #316

## What is the new behavior?

The affected symbols now use lowerCamelCase names that match `^[a-z][a-zA-Z0-9]*$`.

Changes include:
- Migration helper methods renamed to the `ForRelease...` style for readability
- `CGSGetWindowList` renamed to `cgsGetWindowList` at the Swift API level
- Private lock-backed constants in `DiagnosticLogger` renamed to compliant lowerCamelCase names
- Related references and log text updated accordingly

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [ ] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

Build verification completed with:

`xcodebuild -project Thaw.xcodeproj -scheme Thaw -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/ThawDerivedData -clonedSourcePackagesDirPath /tmp/ThawSourcePackages CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`

Result: `BUILD SUCCEEDED`

No behavior changes were intended in this PR; this is a naming compliance cleanup only.

### Notes for reviewers

Please focus on:
- Whether the `ForRelease...` naming style is acceptable for migration methods with release-version suffixes
- Whether the Swift-facing rename of `cgsGetWindowList` is clear enough while preserving `_silgen_name("CGSGetWindowList")`
- Whether any additional naming-cleanup scope should be included outside the targeted files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements for consistency and maintainability, including standardized naming conventions across utility and bridging components and improved synchronization mechanism organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->