### PR TITLE
refactor: move spacing executable URI to Info.plist config

### DIFF
--- a/Thaw/MenuBar/Spacing/MenuBarItemSpacingManager.swift
+++ b/Thaw/MenuBar/Spacing/MenuBarItemSpacingManager.swift
@@ -55,7 +55,7 @@ final class MenuBarItemSpacingManager {
     {
         let process = Process()
 
-        process.executableURL = URL(filePath: "/usr/bin/env")
+        process.executableURL = Constants.menuBarItemSpacingExecutableURL
         process.arguments = CollectionOfOne(command) + arguments
 
         let task = Task.detached {

--- a/Thaw/Resources/Info.plist
+++ b/Thaw/Resources/Info.plist
@@ -17,5 +17,11 @@
 			</array>
 		</dict>
 	</array>
+	<key>ThawRepositoryURL</key>
+	<string>https://github.com/stonerl/Thaw</string>
+	<key>ThawDonateURL</key>
+	<string>https://github.com/sponsors/stonerl</string>
+	<key>ThawMenuBarItemSpacingExecutableURI</key>
+	<string>file:///usr/bin/env</string>
 </dict>
 </plist>

--- a/Thaw/Utilities/Constants.swift
+++ b/Thaw/Utilities/Constants.swift
@@ -26,14 +26,45 @@ enum Constants {
     /// The app's display name.
     static let displayName = Bundle.main.displayName
 
+    /// Info.plist key used to configure the repository URL.
+    static let repositoryURLInfoPlistKey = "ThawRepositoryURL"
+
+    /// Info.plist key used to configure the donation URL.
+    static let donateURLInfoPlistKey = "ThawDonateURL"
+
     /// The project's GitHub repository URL.
-    static let repositoryURL = URL(string: "https://github.com/stonerl/Thaw")!
+    static let repositoryURL = requiredInfoPlistURL(repositoryURLInfoPlistKey)
 
     /// The URL for filing issues.
     static let issuesURL = repositoryURL.appendingPathComponent("issues")
 
     /// The URL for sponsoring/donating.
-    static let donateURL = URL(string: "https://github.com/sponsors/stonerl")!
+    static let donateURL = requiredInfoPlistURL(donateURLInfoPlistKey)
+
+    /// Info.plist key used to configure the executable URI for
+    /// `MenuBarItemSpacingManager` shell commands.
+    static let menuBarItemSpacingExecutableURIInfoPlistKey =
+        "ThawMenuBarItemSpacingExecutableURI"
+
+    /// The executable URL used by `MenuBarItemSpacingManager`.
+    static let menuBarItemSpacingExecutableURL = requiredInfoPlistURL(
+        menuBarItemSpacingExecutableURIInfoPlistKey
+    )
+
+    /// Returns a required URL from Info.plist.
+    private static func requiredInfoPlistURL(
+        _ key: String,
+    ) -> URL {
+        guard
+            let value = Bundle.main.object(forInfoDictionaryKey: key) as? String,
+            let url = URL(string: value),
+            url.scheme != nil
+        else {
+            fatalError("Missing or invalid Info.plist URL for key: \(key)")
+        }
+
+        return url
+    }
 
     // swiftlint:enable force_unwrapping
 }


### PR DESCRIPTION
## What does this PR do?

Refactors hardcoded URIs into Info.plist-driven configuration.
Specifically, moves MenuBarItemSpacingManager executable URI lookup to `Info.plist` and keeps existing behavior via configured default value (`file:///usr/bin/env`).

## PR Type

- [ ] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [x] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

## What is the current behavior?

`MenuBarItemSpacingManager` used a hardcoded executable URI (`/usr/bin/env`) in code.
Issue Number: #316

## What is the new behavior?

- Adds `ThawMenuBarItemSpacingExecutableURI` in `Info.plist`
- Reads URI from `Constants.menuBarItemSpacingExecutableURL`
- `MenuBarItemSpacingManager` uses the configured URI instead of hardcoded value
- Also keeps repository/donate URLs sourced from `Info.plist`

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [ ] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

Build succeeded after changes.

### Notes for reviewers

Please focus on:
- `requiredInfoPlistURL` usage in `Constants`
- `ThawMenuBarItemSpacingExecutableURI` key/value in `Info.plist`
- Runtime behavior of `MenuBarItemSpacingManager.runCommand`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored application configuration settings to externalize repository, donation, and menu bar spacing settings for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->