### PR TITLE
[Fix] #305 More robust Option + Click detection

### DIFF
--- a/Thaw/MenuBar/ControlItem/ControlItem.swift
+++ b/Thaw/MenuBar/ControlItem/ControlItem.swift
@@ -577,15 +577,13 @@ final class ControlItem {
                     return
                 }
 
-                if modifierFlags == .control {
+                if modifierFlags.intersection(.deviceIndependentFlagsMask) == .control {
                     showMenu()
                     return
                 }
 
-                if modifierFlags == .option {
-                    // Option-click: only toggle always-hidden if enabled.
+                if modifierFlags.intersection(.deviceIndependentFlagsMask) == .option {
                     if
-                        appState.settings.advanced.useOptionClickToShowAlwaysHiddenSection,
                         let section = menuBarManager.section(withName: .alwaysHidden),
                         section.isEnabled
                     {

--- a/Thaw/MenuBar/MenuBarSection.swift
+++ b/Thaw/MenuBar/MenuBarSection.swift
@@ -349,7 +349,7 @@ final class MenuBarSection {
         menuBarManager.iceBarPanel.close() // Make sure Ice Bar is always closed.
         menuBarManager.showOnHoverAllowed = true
 
-        if appState.settings.advanced.useOptionClickToShowAlwaysHiddenSection {
+        if let appState, appState.settings.advanced.useOptionClickToShowAlwaysHiddenSection {
             for section in menuBarManager.sections {
                 section.desiredState = .hideSection
                 section.updateControlItemState(for: nil)

--- a/Thaw/MenuBar/MenuBarSection.swift
+++ b/Thaw/MenuBar/MenuBarSection.swift
@@ -349,9 +349,22 @@ final class MenuBarSection {
         menuBarManager.iceBarPanel.close() // Make sure Ice Bar is always closed.
         menuBarManager.showOnHoverAllowed = true
 
-        for section in menuBarManager.sections {
-            section.desiredState = .hideSection
-            section.updateControlItemState(for: nil)
+        if appState.settings.advanced.useOptionClickToShowAlwaysHiddenSection {
+            for section in menuBarManager.sections {
+                section.desiredState = .hideSection
+                section.updateControlItemState(for: nil)
+            }
+        } else {
+            switch name {
+            case .alwaysHidden:
+                desiredState = .hideSection
+                updateControlItemState(for: nil)
+            default:
+                for section in menuBarManager.sections {
+                    section.desiredState = .hideSection
+                    section.updateControlItemState(for: nil)
+                }
+            }
         }
 
         stopRehideChecks()


### PR DESCRIPTION
## What does this PR do?

I found that Option + Click was not working after #305 was merged into `development` branch (it worked when I opened the PR though. I recently rebuilt the app from the source code finding it not working). The issue was caused by that I used `modifierFlags == .option` condition to detect Option + Click, which could be too strict, as macOS mouse events often include additional system-level bits.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What is the current behavior?

Option + Click will only open the hidden bar (after #305 was merged).

Issue Number: #305

## What is the new behavior?

Simply fixed the error by using `intersection(.deviceIndependentFlagsMask) == .option`, which is a more robust method.

No changes are brought to the case when the setting for Option + Click is off.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [x] I've added or updated tests (if applicable)
- [x] I've updated documentation as needed
- [x] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced modifier key detection for Control and Option clicks for improved reliability.

* **Refactor**
  * Updated menu bar section visibility behavior based on advanced settings configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->