### PR TITLE
Clean up HIDEventManager lint warnings

### DIFF
--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -393,13 +393,11 @@ final class HIDEventManager: ObservableObject {
         // Check the mouseMovedTap if it should be active.
         if let appState,
            needsMouseMovedTap(appState: appState),
-           mouseMovedTap.ensureValid()
+           mouseMovedTap.ensureValid(),
+           !mouseMovedTap.isEnabled
         {
-            // Tap is valid. Make sure it's enabled.
-            if !mouseMovedTap.isEnabled {
-                Self.diagLog.warning("mouseMovedTap was valid but not enabled, re-enabling")
-                mouseMovedTap.start()
-            }
+            Self.diagLog.warning("mouseMovedTap was valid but not enabled, re-enabling")
+            mouseMovedTap.start()
         }
     }
 
@@ -449,7 +447,6 @@ extension HIDEventManager {
                    alwaysHiddenSection.isEnabled
                 {
                     alwaysHiddenSection.show()
-                    return
                 }
             } else {
                 guard appState.settings.general.showOnClick else {


### PR DESCRIPTION
## What does this PR do?

Resolves two lint warnings in `HIDEventManager.swift` without changing intended behavior.

## PR Type

- [ ] Bugfix
- [ ] CI/CD related changes
- [x] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

## What is the current behavior?

`HIDEventManager.swift` triggers lint warnings for a nested `if` and a redundant `return`.

Issue Number: #316 

## What is the new behavior?

The nested `if` is merged into a single condition, and the redundant `return` is removed.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [ ] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

Xcode file-level diagnostics for `HIDEventManager.swift` reported no issues after the change.

### Notes for reviewers

This PR is limited to lint cleanup in `HIDEventManager.swift`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of mouse movement event detection during system health checks.
  * Fixed double-click behavior to properly display previously hidden sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->