### PR TITLE
Fix empty implementation lint findings

### DIFF
--- a/Shared/Utilities/DiagnosticLogger.swift
+++ b/Shared/Utilities/DiagnosticLogger.swift
@@ -109,7 +109,9 @@ final class DiagnosticLogger: @unchecked Sendable {
         qos: .utility
     )
 
-    private init() {}
+    private init() {
+        // Intentionally empty: `DiagnosticLogger` is a singleton, and log file setup is deferred until logging is enabled.
+    }
 
     // MARK: - File Management
 

--- a/Thaw/Events/EventMonitor.swift
+++ b/Thaw/Events/EventMonitor.swift
@@ -483,7 +483,9 @@ extension EventMonitor.EventPublisher {
             }
         }
 
-        func request(_: Subscribers.Demand) {}
+        func request(_: Subscribers.Demand) {
+            // Intentionally empty: AppKit pushes events as they occur, so this passive monitor cannot honor Combine backpressure.
+        }
 
         func cancel() {
             box = nil

--- a/Thaw/Events/RunLoopLocalEventMonitor.swift
+++ b/Thaw/Events/RunLoopLocalEventMonitor.swift
@@ -120,7 +120,9 @@ extension RunLoopLocalEventMonitor.RunLoopLocalEventPublisher {
             self.monitor.start()
         }
 
-        func request(_: Subscribers.Demand) {}
+        func request(_: Subscribers.Demand) {
+            // Intentionally empty: local AppKit events are pushed by the run loop, so this monitor cannot honor Combine backpressure.
+        }
 
         func cancel() {
             monitor.stop()

--- a/Thaw/MenuBar/Appearance/MenuBarAppearanceEditor/MenuBarAppearanceEditor.swift
+++ b/Thaw/MenuBar/Appearance/MenuBarAppearanceEditor/MenuBarAppearanceEditor.swift
@@ -326,11 +326,13 @@ private struct PreviewButton: View {
     }
 
     var body: some View {
-        Button("Hold to Preview") {}
-            .buttonStyle(PreviewButtonStyle(isPressed: $isPressed))
-            .onChange(of: isPressed) {
-                manager.previewConfiguration = isPressed ? previewConfiguration : nil
-            }
+        Button("Hold to Preview") {
+            // Intentionally empty: preview state is driven by `PreviewButtonStyle` updating `isPressed` while the button is held.
+        }
+        .buttonStyle(PreviewButtonStyle(isPressed: $isPressed))
+        .onChange(of: isPressed) {
+            manager.previewConfiguration = isPressed ? previewConfiguration : nil
+        }
     }
 }
 

--- a/Thaw/MenuBar/IceBar/IceBar.swift
+++ b/Thaw/MenuBar/IceBar/IceBar.swift
@@ -627,13 +627,13 @@ private struct IceBarItemView: View {
 // MARK: - IceBarItemClickView
 
 private struct IceBarItemClickView: NSViewRepresentable {
-    private final class Represented: NSView {
-        let item: MenuBarItem
-        let tooltipDelay: TimeInterval
+    final class Represented: NSView {
+        var item: MenuBarItem
+        var tooltipDelay: TimeInterval
 
-        let leftClickAction: () -> Void
-        let rightClickAction: () -> Void
-        let onHover: (Bool) -> Void
+        var leftClickAction: () -> Void
+        var rightClickAction: () -> Void
+        var onHover: (Bool) -> Void
 
         private var lastLeftMouseDownDate = Date.now
         private var lastRightMouseDownDate = Date.now
@@ -657,6 +657,21 @@ private struct IceBarItemClickView: NSViewRepresentable {
             self.rightClickAction = rightClickAction
             self.onHover = onHover
             super.init(frame: .zero)
+        }
+
+        func update(
+            item: MenuBarItem,
+            tooltipDelay: TimeInterval,
+            leftClickAction: @escaping () -> Void,
+            rightClickAction: @escaping () -> Void,
+            onHover: @escaping (Bool) -> Void
+        ) {
+            self.item = item
+            self.tooltipDelay = tooltipDelay
+            self.leftClickAction = leftClickAction
+            self.rightClickAction = rightClickAction
+            self.onHover = onHover
+            tooltipController.text = item.displayName
         }
 
         @available(*, unavailable)
@@ -735,7 +750,7 @@ private struct IceBarItemClickView: NSViewRepresentable {
     let rightClickAction: () -> Void
     let onHover: (Bool) -> Void
 
-    func makeNSView(context _: Context) -> NSView {
+    func makeNSView(context _: Context) -> Represented {
         Represented(
             item: item,
             tooltipDelay: tooltipDelay,
@@ -745,5 +760,15 @@ private struct IceBarItemClickView: NSViewRepresentable {
         )
     }
 
-    func updateNSView(_: NSView, context _: Context) {}
+    func updateNSView(_ nsView: Represented, context _: Context) {
+        // Keep the backing `NSView` in sync with SwiftUI updates; tooltip text,
+        // tooltip timing, and click handlers can all change after creation.
+        nsView.update(
+            item: item,
+            tooltipDelay: tooltipDelay,
+            leftClickAction: leftClickAction,
+            rightClickAction: rightClickAction,
+            onHover: onHover
+        )
+    }
 }

--- a/Thaw/MenuBar/LayoutBar/LayoutBar.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBar.swift
@@ -17,7 +17,11 @@ struct LayoutBar: View {
             LayoutBarScrollView(appState: appState, section: section)
         }
 
-        func updateNSView(_: LayoutBarScrollView, context _: Context) {}
+        func updateNSView(_: LayoutBarScrollView, context _: Context) {
+            // Intentionally empty: `LayoutBarScrollView` wires itself to shared
+            // state during initialization, so subsequent updates arrive through
+            // its internal observers rather than SwiftUI's representable hook.
+        }
     }
 
     @EnvironmentObject var appState: AppState

--- a/Thaw/UI/Modifiers/OnWindowChange.swift
+++ b/Thaw/UI/Modifiers/OnWindowChange.swift
@@ -31,7 +31,12 @@ private struct WindowReaderView: NSViewRepresentable {
         return view
     }
 
-    func updateNSView(_: NSView, context _: Context) {}
+    func updateNSView(_ nsView: NSView, context _: Context) {
+        guard let view = nsView as? Represented else {
+            return
+        }
+        view.action = action
+    }
 }
 
 extension View {

--- a/Thaw/UI/Modifiers/OnWindowChange.swift
+++ b/Thaw/UI/Modifiers/OnWindowChange.swift
@@ -25,16 +25,13 @@ private struct WindowReaderView: NSViewRepresentable {
 
     var action: (NSWindow?) -> Void
 
-    func makeNSView(context _: Context) -> NSView {
+    func makeNSView(context _: Context) -> Represented {
         let view = Represented()
         view.action = action
         return view
     }
 
-    func updateNSView(_ nsView: NSView, context _: Context) {
-        guard let view = nsView as? Represented else {
-            return
-        }
+    func updateNSView(_ view: Represented, context _: Context) {
         view.action = action
     }
 }

--- a/Thaw/UI/Modifiers/OnWindowChange.swift
+++ b/Thaw/UI/Modifiers/OnWindowChange.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 private struct WindowReaderView: NSViewRepresentable {
-    private final class Represented: NSView {
+    final class Represented: NSView {
         var action: ((NSWindow?) -> Void)?
 
         override func viewDidMoveToWindow() {

--- a/Thaw/Utilities/ScreenCapture.swift
+++ b/Thaw/Utilities/ScreenCapture.swift
@@ -67,7 +67,10 @@ enum ScreenCapture {
             // try accessing SCShareableContent to trigger a request if the
             // user doesn't have permissions.
             // Workaround: CGRequestScreenCaptureAccess() is broken on macOS 15+.
-            SCShareableContent.getWithCompletionHandler { _, _ in }
+            SCShareableContent.getWithCompletionHandler { _, _ in
+                // Intentionally empty: the call is only used to trigger the
+                // system screen capture permission prompt on macOS 15+.
+            }
         } else {
             CGRequestScreenCaptureAccess()
         }


### PR DESCRIPTION
## What does this PR do?

Resolves lint findings for empty functions and closures by documenting intentional no-op implementations and completing the `NSViewRepresentable` updates that need to keep AppKit state in sync with SwiftUI.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [x] Other (please describe): Lint cleanup for empty functions/closures

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

## What is the current behavior?

Several empty functions/closures are flagged by lint. In addition, some `NSViewRepresentable` wrappers leave `updateNSView` empty even when their SwiftUI inputs can change, which can leave backing AppKit views with stale state.

Issue Number: #316 

## What is the new behavior?

Intentional no-op implementations are now documented inline where appropriate, and representables that need live updates now synchronize their backing `NSView` instances with the latest SwiftUI state.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [ ] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

Built successfully with Xcode `BuildProject`.

The main behavioral changes are in:
- `Thaw/MenuBar/IceBar/IceBar.swift`
- `Thaw/UI/Modifiers/OnWindowChange.swift`

The remaining file changes are lint-oriented comments for intentional no-op implementations.

## Notes for reviewers

Please focus review on the `updateNSView` implementations in `IceBarItemClickView` and `WindowReaderView`; those are the only changes that alter runtime behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tooltips for menu bar items now update correctly during interface changes.
  * Window-change handlers reliably receive the current action across SwiftUI updates.

* **New Features**
  * Menu bar item view now supports live updates to tooltip text and click/hover behavior.

* **Chores**
  * Minor internal clarifications and stability improvements (no user-facing behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->