### PR TITLE
Remove redundant condition check

### DIFF
--- a/Thaw/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift
@@ -82,10 +82,6 @@ struct MenuBarLayoutSettingsPane: View {
                         }
                     } else {
                         Text("Loading menu bar items…")
-                    }
-                    if loadDeadlineReached {
-                        EmptyView()
-                    } else {
                         ProgressView()
                     }
                 }


### PR DESCRIPTION
## What does this PR do?

Removes a redundant condition check in `MenuBarLayoutSettingsPane.swift` where `loadDeadlineReached` was being checked twice unnecessarily.

## PR Type

- [ ] Bugfix
- [ ] CI/CD related changes
- [x] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [x] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What is the current behavior?

Line 72 checks `loadDeadlineReached`, then line 86 checks it again. The second check is redundant since we're already inside the conditional block.

Issue Number: #316

## What is the new behavior?

Moved `ProgressView()` into the else branch with the loading text. Removed the unnecessary second check and `EmptyView()`.

## PR Checklist

- [x] I've built and run the app locally
- [x] I've checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

SwiftFormat and SwiftLint both pass with no issues.

### Notes for reviewers

Simple refactor - no behavior changes. When loading, shows text + spinner. When timeout, shows error message only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading behavior in the menu bar layout settings pane to consistently display the loading indicator while content is being prepared, rather than transitioning to an empty state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->