### PR TITLE
Fix settings pane desync and reduce layout/settings overhead

### DIFF
--- a/Thaw/MenuBar/LayoutBar/LayoutBarContainer.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarContainer.swift
@@ -109,19 +109,20 @@ final class LayoutBarContainer: NSView {
                 setArrangedViews(items: cache.managedItems(for: section))
             }
             .store(in: &c)
-
-            appState.imageCache.$images
-                .debounce(for: .milliseconds(50), scheduler: DispatchQueue.main)
-                .sink { [weak self] _ in
-                    guard let self else {
-                        return
-                    }
-                    layoutArrangedViews()
-                }
-                .store(in: &c)
         }
 
         cancellables = c
+    }
+
+    /// Relayouts the container after one arranged view changed size.
+    ///
+    /// This avoids subscribing the whole container to every image cache update.
+    func itemPreferredSizeDidChange(_ itemView: LayoutBarArrangedView) {
+        guard arrangedViews.contains(itemView) else {
+            return
+        }
+        shouldAnimateNextLayoutPass = false
+        layoutArrangedViews()
     }
 
     /// Performs layout of the container's arranged views.

--- a/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
@@ -13,6 +13,18 @@ import Combine
 
 /// A view that displays an image in a menu bar layout view.
 final class LayoutBarItemView: LayoutBarArrangedView {
+    private enum Metrics {
+        static let minWidth: CGFloat = 14
+        static let maxWidth: CGFloat = 240
+        static let minHeight: CGFloat = 18
+        static let placeholderCornerRadius: CGFloat = 6
+        static let placeholderHorizontalInset: CGFloat = 2
+        static let placeholderVerticalInset: CGFloat = 2
+        static let iconInset: CGFloat = 2
+        static let fallbackSymbolPointSize: CGFloat = 11
+        static let unresponsiveBadgeWidth: CGFloat = 15
+    }
+
     private weak var appState: AppState?
 
     private var cancellables = Set<AnyCancellable>()
@@ -22,14 +34,16 @@ final class LayoutBarItemView: LayoutBarArrangedView {
 
     private lazy var tooltipController = CustomTooltipController(text: item.displayName, view: self)
     private var tooltipTrackingArea: NSTrackingArea?
+    private let placeholderImage: NSImage?
 
     /// The image displayed inside the view.
     private var cachedImage: MenuBarItemImageCache.CapturedImage? {
         didSet {
-            if let image = cachedImage {
-                setFrameSize(image.scaledSize)
-            } else {
-                setFrameSize(.zero)
+            let previousSize = preferredSize(for: oldValue)
+            let newSize = preferredSize(for: cachedImage)
+            setFrameSize(newSize)
+            if previousSize != newSize {
+                (superview as? LayoutBarContainer)?.itemPreferredSizeDidChange(self)
             }
             needsDisplay = true
         }
@@ -43,8 +57,12 @@ final class LayoutBarItemView: LayoutBarArrangedView {
     init(appState: AppState, item: MenuBarItem) {
         self.item = item
         self.appState = appState
+        self.placeholderImage = Self.makePlaceholderImage(for: item)
 
-        super.init(frame: CGRect(origin: .zero, size: item.bounds.size))
+        let initialImage = appState.imageCache.image(for: item.tag)
+        self.cachedImage = initialImage
+
+        super.init(frame: CGRect(origin: .zero, size: Self.preferredSize(for: item, image: initialImage)))
         unregisterDraggedTypes()
 
         isEnabled = item.isMovable
@@ -62,7 +80,7 @@ final class LayoutBarItemView: LayoutBarArrangedView {
     }
 
     override func draggingImage() -> NSImage? {
-        cachedImage?.nsImage
+        cachedImage?.nsImage ?? placeholderBitmapImage()
     }
 
     override func updateTrackingAreas() {
@@ -129,15 +147,19 @@ final class LayoutBarItemView: LayoutBarArrangedView {
 
     override func draw(_: NSRect) {
         if !isDraggingPlaceholder {
-            cachedImage?.nsImage.draw(
-                in: bounds,
-                from: .zero,
-                operation: .sourceOver,
-                fraction: isEnabled ? 1.0 : 0.67
-            )
+            if let capturedImage = cachedImage?.nsImage {
+                capturedImage.draw(
+                    in: bounds,
+                    from: .zero,
+                    operation: .sourceOver,
+                    fraction: isEnabled ? 1.0 : 0.67
+                )
+            } else {
+                drawPlaceholder()
+            }
             if Bridging.isProcessUnresponsive(item.ownerPID) {
                 let warningImage = NSImage.warning
-                let width: CGFloat = 15
+                let width = Metrics.unresponsiveBadgeWidth
                 let scale = width / warningImage.size.width
                 let size = CGSize(
                     width: width,
@@ -178,6 +200,100 @@ final class LayoutBarItemView: LayoutBarArrangedView {
         draggingItem.setDraggingFrame(bounds, contents: draggingImage())
 
         beginDraggingSession(with: [draggingItem], event: event, source: self)
+    }
+
+    private func preferredSize(for image: MenuBarItemImageCache.CapturedImage?) -> CGSize {
+        Self.preferredSize(for: item, image: image)
+    }
+
+    private static func preferredSize(
+        for item: MenuBarItem,
+        image: MenuBarItemImageCache.CapturedImage?
+    ) -> CGSize {
+        if let image {
+            return image.scaledSize
+        }
+
+        let width = item.bounds.width.clamped(to: Metrics.minWidth ... Metrics.maxWidth)
+        let height = max(item.bounds.height, Metrics.minHeight)
+        return CGSize(width: width, height: height)
+    }
+
+    private static func makePlaceholderImage(for item: MenuBarItem) -> NSImage? {
+        if let icon = item.sourceApplication?.icon ?? item.owningApplication?.icon {
+            return icon
+        }
+        return NSImage(
+            systemSymbolName: "menubar.rectangle",
+            accessibilityDescription: item.displayName
+        )
+    }
+
+    private func drawPlaceholder() {
+        let placeholderRect = bounds.insetBy(
+            dx: Metrics.placeholderHorizontalInset,
+            dy: Metrics.placeholderVerticalInset
+        )
+        let backgroundPath = NSBezierPath(
+            roundedRect: placeholderRect,
+            xRadius: Metrics.placeholderCornerRadius,
+            yRadius: Metrics.placeholderCornerRadius
+        )
+        NSColor.quaternaryLabelColor.withAlphaComponent(0.18).setFill()
+        backgroundPath.fill()
+
+        NSColor.separatorColor.withAlphaComponent(0.35).setStroke()
+        backgroundPath.lineWidth = 1
+        backgroundPath.stroke()
+
+        guard let placeholderImage else {
+            return
+        }
+
+        let iconBounds = placeholderRect.insetBy(
+            dx: Metrics.iconInset,
+            dy: Metrics.iconInset
+        )
+        let iconSide = min(iconBounds.width, iconBounds.height)
+        guard iconSide > 0 else {
+            return
+        }
+
+        let iconRect = CGRect(
+            x: placeholderRect.midX - (iconSide / 2),
+            y: placeholderRect.midY - (iconSide / 2),
+            width: iconSide,
+            height: iconSide
+        )
+
+        if placeholderImage.isTemplate {
+            let tinted = placeholderImage.copy() as? NSImage
+            tinted?.isTemplate = true
+            NSColor.secondaryLabelColor.set()
+            tinted?.draw(
+                in: iconRect,
+                from: .zero,
+                operation: .sourceOver,
+                fraction: isEnabled ? 0.8 : 0.5
+            )
+        } else {
+            placeholderImage.draw(
+                in: iconRect,
+                from: .zero,
+                operation: .sourceOver,
+                fraction: isEnabled ? 0.9 : 0.5
+            )
+        }
+    }
+
+    private func placeholderBitmapImage() -> NSImage? {
+        guard let rep = bitmapImageRepForCachingDisplay(in: bounds) else {
+            return nil
+        }
+        cacheDisplay(in: bounds, to: rep)
+        let image = NSImage(size: bounds.size)
+        image.addRepresentation(rep)
+        return image
     }
 }
 

--- a/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
@@ -114,7 +114,9 @@ final class LayoutBarItemView: LayoutBarArrangedView {
         if let appState {
             let tag = item.tag
             let imageForTag = appState.imageCache.$images
-                .map { images -> MenuBarItemImageCache.CapturedImage? in images[tag] }
+                .map { [weak appState] _ -> MenuBarItemImageCache.CapturedImage? in
+                    appState?.imageCache.image(for: tag)
+                }
 
             imageForTag
                 .removeDuplicates(by: MenuBarItemImageCache.CapturedImage.isVisuallyEqual)

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -131,6 +131,13 @@ final class MenuBarItemImageCache: ObservableObject {
 
         // Try to load cached images from disk
         loadFromDisk()
+
+        // Keep a fresh layout snapshot ready so opening the layout settings
+        // pane does not need to capture every item from scratch.
+        currentUpdateTask?.cancel()
+        currentUpdateTask = Task { [weak self] in
+            await self?.refreshVisibleConsumersOrPrewarmLayoutCache()
+        }
     }
 
     // MARK: Disk Persistence
@@ -296,7 +303,7 @@ final class MenuBarItemImageCache: ObservableObject {
                 }
                 self.currentUpdateTask?.cancel()
                 self.currentUpdateTask = Task {
-                    await self.updateCache()
+                    await self.refreshVisibleConsumersOrPrewarmLayoutCache()
                 }
             }
             .store(in: &c)
@@ -332,6 +339,49 @@ final class MenuBarItemImageCache: ObservableObject {
     }
 
     // MARK: Live Refresh
+
+    /// Refreshes the cache for currently visible consumers, or keeps a warm
+    /// background snapshot ready for the layout settings pane when no consumer
+    /// is visible.
+    private func refreshVisibleConsumersOrPrewarmLayoutCache() async {
+        guard let appState else {
+            return
+        }
+
+        let isIceBarPresented = await appState.navigationState.isIceBarPresented
+        let isSearchPresented = await appState.navigationState.isSearchPresented
+        let hasVisibleConsumer = await hasVisibleCaptureConsumer(
+            appState: appState,
+            isIceBarPresented: isIceBarPresented,
+            isSearchPresented: isSearchPresented
+        )
+
+        if hasVisibleConsumer {
+            await updateCache()
+        } else {
+            await updateCache(
+                sections: MenuBarSection.Name.allCases,
+                allowBackgroundCapture: true
+            )
+        }
+    }
+
+    /// Returns whether any visible surface currently needs live item captures.
+    private func hasVisibleCaptureConsumer(
+        appState: AppState,
+        isIceBarPresented: Bool,
+        isSearchPresented: Bool
+    ) async -> Bool {
+        if isIceBarPresented || isSearchPresented {
+            return true
+        }
+
+        let isAppFrontmost = await appState.navigationState.isAppFrontmost
+        let isSettingsPresented = await appState.navigationState.isSettingsPresented
+        let settingsNavID = await appState.navigationState.settingsNavigationIdentifier
+
+        return isAppFrontmost && isSettingsPresented && settingsNavID == .menuBarLayout
+    }
 
     /// Starts or stops the live image refresh loop based on navigation state.
     @MainActor
@@ -1198,7 +1248,11 @@ final class MenuBarItemImageCache: ObservableObject {
     }
 
     /// Updates the cache for the given sections, if necessary.
-    func updateCache(sections: [MenuBarSection.Name], skipRecentMoveCheck: Bool = false) async {
+    func updateCache(
+        sections: [MenuBarSection.Name],
+        skipRecentMoveCheck: Bool = false,
+        allowBackgroundCapture: Bool = false
+    ) async {
         guard let appState else {
             MenuBarItemImageCache.diagLog.debug("updateCache: appState is nil, skipping")
             return
@@ -1207,12 +1261,14 @@ final class MenuBarItemImageCache: ObservableObject {
         let isIceBarPresented = await appState.navigationState.isIceBarPresented
         let isSearchPresented = await appState.navigationState.isSearchPresented
 
-        if !isIceBarPresented, !isSearchPresented {
-            let isAppFrontmost = await appState.navigationState.isAppFrontmost
-            let isSettingsPresented = await appState.navigationState.isSettingsPresented
-            let settingsNavID = await appState.navigationState.settingsNavigationIdentifier
+        if !allowBackgroundCapture {
+            let hasVisibleConsumer = await hasVisibleCaptureConsumer(
+                appState: appState,
+                isIceBarPresented: isIceBarPresented,
+                isSearchPresented: isSearchPresented
+            )
 
-            guard isAppFrontmost, isSettingsPresented, settingsNavID == .menuBarLayout else {
+            guard hasVisibleConsumer else {
                 // This is the normal path when IceBar/search/settings are not visible — not an error
                 return
             }
@@ -1239,7 +1295,7 @@ final class MenuBarItemImageCache: ObservableObject {
             }
         }
 
-        MenuBarItemImageCache.diagLog.debug("updateCache: proceeding with cache update for \(sections.count) sections (iceBar=\(isIceBarPresented), search=\(isSearchPresented))")
+        MenuBarItemImageCache.diagLog.debug("updateCache: proceeding with cache update for \(sections.count) sections (iceBar=\(isIceBarPresented), search=\(isSearchPresented), background=\(allowBackgroundCapture))")
         await updateCacheWithoutChecks(sections: sections)
     }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -468,28 +468,32 @@ final class MenuBarItemImageCache: ObservableObject {
             return
         }
 
-        let nav = appState.navigationState
-        let needsRefresh = nav.isIceBarPresented
-            || nav.isSearchPresented
-            || (nav.isAppFrontmost && nav.isSettingsPresented
-                && nav.settingsNavigationIdentifier == .menuBarLayout)
+        // Compute visibility using centralized snapshot and helper to avoid duplication.
+        // Wrapping in Task since this is called from synchronous sink closures on main thread.
+        Task { [weak self, weak appState] in
+            guard let self, let appState else { return }
+            let nav = await MainActor.run {
+                self.makeNavigationStateSnapshot()
+            }
+            let needsRefresh = self.hasVisibleCaptureConsumer(nav: nav)
 
-        if needsRefresh {
-            // Already running — don't restart
-            guard liveRefreshTask == nil else { return }
-            MenuBarItemImageCache.diagLog.debug(
-                "Starting live refresh (iceBar=\(nav.isIceBarPresented), search=\(nav.isSearchPresented), settings=\(nav.isSettingsPresented))"
-            )
-            liveRefreshTask = Task { [weak self, weak appState] in
-                guard let self, let appState else { return }
-                await self.runLiveRefreshLoop(appState: appState)
+            if needsRefresh {
+                // Already running — don't restart
+                guard self.liveRefreshTask == nil else { return }
+                MenuBarItemImageCache.diagLog.debug(
+                    "Starting live refresh (iceBar=\(nav.isIceBarPresented), search=\(nav.isSearchPresented), settings=\(nav.isSettingsPresented))"
+                )
+                self.liveRefreshTask = Task { [weak self, weak appState] in
+                    guard let self, let appState else { return }
+                    await self.runLiveRefreshLoop(appState: appState)
+                }
+            } else {
+                if self.liveRefreshTask != nil {
+                    MenuBarItemImageCache.diagLog.debug("Stopping live refresh")
+                }
+                self.liveRefreshTask?.cancel()
+                self.liveRefreshTask = nil
             }
-        } else {
-            if liveRefreshTask != nil {
-                MenuBarItemImageCache.diagLog.debug("Stopping live refresh")
-            }
-            liveRefreshTask?.cancel()
-            liveRefreshTask = nil
         }
     }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -330,8 +330,10 @@ final class MenuBarItemImageCache: ObservableObject {
                     return
                 }
                 self.currentUpdateTask?.cancel()
-                self.currentUpdateTask = Task {
-                    await self.refreshVisibleConsumersOrPrewarmLayoutCache()
+                self.currentUpdateTask = Task { [weak self, settingsOpened] in
+                    await self?.refreshVisibleConsumersOrPrewarmLayoutCache(
+                        allowBackgroundCapture: settingsOpened
+                    )
                 }
             }
             .store(in: &c)

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -115,6 +115,11 @@ final class MenuBarItemImageCache: ObservableObject {
     /// The currently running live-refresh task, if any.
     private var liveRefreshTask: Task<Void, Never>?
 
+    /// Tracks whether the MenuBarLayoutSettingsPane has been opened at least once.
+    /// Used to gate background cache prewarming so captures only occur after the user
+    /// has accessed the layout settings.
+    @Published private(set) var settingsPaneHasBeenOpened = false
+
     deinit {
         memoryPressureSource?.cancel()
         currentUpdateTask?.cancel()
@@ -132,12 +137,26 @@ final class MenuBarItemImageCache: ObservableObject {
         // Try to load cached images from disk
         loadFromDisk()
 
+        // Only prewarm if a visible consumer exists at setup time.
+        // Background prewarming is gated by settingsPaneHasBeenOpened.
+        let hasVisible = hasVisibleCaptureConsumer()
+        guard hasVisible else {
+            return
+        }
+
         // Keep a fresh layout snapshot ready so opening the layout settings
         // pane does not need to capture every item from scratch.
         currentUpdateTask?.cancel()
         currentUpdateTask = Task { [weak self] in
             await self?.refreshVisibleConsumersOrPrewarmLayoutCache()
         }
+    }
+
+    /// Marks that the MenuBarLayoutSettingsPane has been opened.
+    /// Call this from the pane's onAppear or task modifier to enable background cache prewarming.
+    @MainActor
+    func markSettingsPaneOpened() {
+        settingsPaneHasBeenOpened = true
     }
 
     // MARK: Disk Persistence
@@ -301,6 +320,15 @@ final class MenuBarItemImageCache: ObservableObject {
                 guard let self else {
                     return
                 }
+                // Only trigger capture if a visible consumer exists or the settings pane
+                // has been opened at least once (itemCacheChangePublisher may indicate
+                // new items that the layout pane will need).
+                let nav = self.makeNavigationStateSnapshot()
+                let hasVisible = self.hasVisibleCaptureConsumer(nav: nav)
+                let settingsOpened = self.settingsPaneHasBeenOpened
+                guard hasVisible || settingsOpened else {
+                    return
+                }
                 self.currentUpdateTask?.cancel()
                 self.currentUpdateTask = Task {
                     await self.refreshVisibleConsumersOrPrewarmLayoutCache()
@@ -349,26 +377,49 @@ final class MenuBarItemImageCache: ObservableObject {
         let settingsNavigationIdentifier: SettingsNavigationIdentifier?
     }
 
+    /// Constructs a NavigationStateSnapshot from the current appState in a single MainActor hop.
+    /// Centralizes snapshot construction to avoid duplication across multiple call sites.
+    @MainActor
+    private func makeNavigationStateSnapshot() -> NavigationStateSnapshot {
+        guard let appState else {
+            return NavigationStateSnapshot(
+                isIceBarPresented: false,
+                isSearchPresented: false,
+                isAppFrontmost: false,
+                isSettingsPresented: false,
+                settingsNavigationIdentifier: nil
+            )
+        }
+        return NavigationStateSnapshot(
+            isIceBarPresented: appState.navigationState.isIceBarPresented,
+            isSearchPresented: appState.navigationState.isSearchPresented,
+            isAppFrontmost: appState.navigationState.isAppFrontmost,
+            isSettingsPresented: appState.navigationState.isSettingsPresented,
+            settingsNavigationIdentifier: appState.navigationState.settingsNavigationIdentifier
+        )
+    }
+
     /// Refreshes the cache for currently visible consumers, or keeps a warm
     /// background snapshot ready for the layout settings pane when no consumer
     /// is visible.
-    private func refreshVisibleConsumersOrPrewarmLayoutCache() async {
-        guard let appState else {
+    private func refreshVisibleConsumersOrPrewarmLayoutCache(allowBackgroundCapture: Bool = false) async {
+        guard appState != nil else {
             return
         }
 
         // Batch all navigation state reads into single MainActor hop
         let nav = await MainActor.run {
-            NavigationStateSnapshot(
-                isIceBarPresented: appState.navigationState.isIceBarPresented,
-                isSearchPresented: appState.navigationState.isSearchPresented,
-                isAppFrontmost: appState.navigationState.isAppFrontmost,
-                isSettingsPresented: appState.navigationState.isSettingsPresented,
-                settingsNavigationIdentifier: appState.navigationState.settingsNavigationIdentifier
-            )
+            makeNavigationStateSnapshot()
         }
 
         let hasVisibleConsumer = hasVisibleCaptureConsumer(nav: nav)
+
+        // Early-return unless a visible consumer exists or background capture is explicitly allowed.
+        // Background capture is gated by settingsPaneHasBeenOpened to avoid unnecessary full-screen
+        // captures when the user has never opened the layout settings pane.
+        guard hasVisibleConsumer || (allowBackgroundCapture && settingsPaneHasBeenOpened) else {
+            return
+        }
 
         if hasVisibleConsumer {
             await updateCache(nav: nav)
@@ -388,6 +439,22 @@ final class MenuBarItemImageCache: ObservableObject {
         }
 
         return nav.isAppFrontmost && nav.isSettingsPresented && nav.settingsNavigationIdentifier == .menuBarLayout
+    }
+
+    /// Convenience overload that reads current state on MainActor when no snapshot is provided.
+    @MainActor
+    private func hasVisibleCaptureConsumer() -> Bool {
+        guard let appState else {
+            return false
+        }
+        let nav = NavigationStateSnapshot(
+            isIceBarPresented: appState.navigationState.isIceBarPresented,
+            isSearchPresented: appState.navigationState.isSearchPresented,
+            isAppFrontmost: appState.navigationState.isAppFrontmost,
+            isSettingsPresented: appState.navigationState.isSettingsPresented,
+            settingsNavigationIdentifier: appState.navigationState.settingsNavigationIdentifier
+        )
+        return hasVisibleCaptureConsumer(nav: nav)
     }
 
     /// Starts or stops the live image refresh loop based on navigation state.
@@ -1266,19 +1333,13 @@ final class MenuBarItemImageCache: ObservableObject {
             return
         }
 
-        // Use provided snapshot or read fresh values
+        // Use provided snapshot or construct one in a single MainActor hop
         let navSnapshot: NavigationStateSnapshot
         if let nav {
             navSnapshot = nav
         } else {
             navSnapshot = await MainActor.run {
-                NavigationStateSnapshot(
-                    isIceBarPresented: appState.navigationState.isIceBarPresented,
-                    isSearchPresented: appState.navigationState.isSearchPresented,
-                    isAppFrontmost: appState.navigationState.isAppFrontmost,
-                    isSettingsPresented: appState.navigationState.isSettingsPresented,
-                    settingsNavigationIdentifier: appState.navigationState.settingsNavigationIdentifier
-                )
+                makeNavigationStateSnapshot()
             }
         }
 
@@ -1322,19 +1383,13 @@ final class MenuBarItemImageCache: ObservableObject {
             return
         }
 
-        // Use provided snapshot or read fresh values
+        // Use provided snapshot or construct one in a single MainActor hop
         let navSnapshot: NavigationStateSnapshot
         if let nav {
             navSnapshot = nav
         } else {
             navSnapshot = await MainActor.run {
-                NavigationStateSnapshot(
-                    isIceBarPresented: appState.navigationState.isIceBarPresented,
-                    isSearchPresented: appState.navigationState.isSearchPresented,
-                    isAppFrontmost: appState.navigationState.isAppFrontmost,
-                    isSettingsPresented: appState.navigationState.isSettingsPresented,
-                    settingsNavigationIdentifier: appState.navigationState.settingsNavigationIdentifier
-                )
+                makeNavigationStateSnapshot()
             }
         }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -340,6 +340,15 @@ final class MenuBarItemImageCache: ObservableObject {
 
     // MARK: Live Refresh
 
+    /// Snapshot of navigation state read in a single MainActor hop.
+    struct NavigationStateSnapshot {
+        let isIceBarPresented: Bool
+        let isSearchPresented: Bool
+        let isAppFrontmost: Bool
+        let isSettingsPresented: Bool
+        let settingsNavigationIdentifier: SettingsNavigationIdentifier?
+    }
+
     /// Refreshes the cache for currently visible consumers, or keeps a warm
     /// background snapshot ready for the layout settings pane when no consumer
     /// is visible.
@@ -348,39 +357,37 @@ final class MenuBarItemImageCache: ObservableObject {
             return
         }
 
-        let isIceBarPresented = await appState.navigationState.isIceBarPresented
-        let isSearchPresented = await appState.navigationState.isSearchPresented
-        let hasVisibleConsumer = await hasVisibleCaptureConsumer(
-            appState: appState,
-            isIceBarPresented: isIceBarPresented,
-            isSearchPresented: isSearchPresented
-        )
+        // Batch all navigation state reads into single MainActor hop
+        let nav = await MainActor.run {
+            NavigationStateSnapshot(
+                isIceBarPresented: appState.navigationState.isIceBarPresented,
+                isSearchPresented: appState.navigationState.isSearchPresented,
+                isAppFrontmost: appState.navigationState.isAppFrontmost,
+                isSettingsPresented: appState.navigationState.isSettingsPresented,
+                settingsNavigationIdentifier: appState.navigationState.settingsNavigationIdentifier
+            )
+        }
+
+        let hasVisibleConsumer = hasVisibleCaptureConsumer(nav: nav)
 
         if hasVisibleConsumer {
-            await updateCache()
+            await updateCache(nav: nav)
         } else {
             await updateCache(
                 sections: MenuBarSection.Name.allCases,
-                allowBackgroundCapture: true
+                allowBackgroundCapture: true,
+                nav: nav
             )
         }
     }
 
     /// Returns whether any visible surface currently needs live item captures.
-    private func hasVisibleCaptureConsumer(
-        appState: AppState,
-        isIceBarPresented: Bool,
-        isSearchPresented: Bool
-    ) async -> Bool {
-        if isIceBarPresented || isSearchPresented {
+    private func hasVisibleCaptureConsumer(nav: NavigationStateSnapshot) -> Bool {
+        if nav.isIceBarPresented || nav.isSearchPresented {
             return true
         }
 
-        let isAppFrontmost = await appState.navigationState.isAppFrontmost
-        let isSettingsPresented = await appState.navigationState.isSettingsPresented
-        let settingsNavID = await appState.navigationState.settingsNavigationIdentifier
-
-        return isAppFrontmost && isSettingsPresented && settingsNavID == .menuBarLayout
+        return nav.isAppFrontmost && nav.isSettingsPresented && nav.settingsNavigationIdentifier == .menuBarLayout
     }
 
     /// Starts or stops the live image refresh loop based on navigation state.
@@ -1251,22 +1258,32 @@ final class MenuBarItemImageCache: ObservableObject {
     func updateCache(
         sections: [MenuBarSection.Name],
         skipRecentMoveCheck: Bool = false,
-        allowBackgroundCapture: Bool = false
+        allowBackgroundCapture: Bool = false,
+        nav: NavigationStateSnapshot? = nil
     ) async {
         guard let appState else {
             MenuBarItemImageCache.diagLog.debug("updateCache: appState is nil, skipping")
             return
         }
 
-        let isIceBarPresented = await appState.navigationState.isIceBarPresented
-        let isSearchPresented = await appState.navigationState.isSearchPresented
+        // Use provided snapshot or read fresh values
+        let navSnapshot: NavigationStateSnapshot
+        if let nav {
+            navSnapshot = nav
+        } else {
+            navSnapshot = await MainActor.run {
+                NavigationStateSnapshot(
+                    isIceBarPresented: appState.navigationState.isIceBarPresented,
+                    isSearchPresented: appState.navigationState.isSearchPresented,
+                    isAppFrontmost: appState.navigationState.isAppFrontmost,
+                    isSettingsPresented: appState.navigationState.isSettingsPresented,
+                    settingsNavigationIdentifier: appState.navigationState.settingsNavigationIdentifier
+                )
+            }
+        }
 
         if !allowBackgroundCapture {
-            let hasVisibleConsumer = await hasVisibleCaptureConsumer(
-                appState: appState,
-                isIceBarPresented: isIceBarPresented,
-                isSearchPresented: isSearchPresented
-            )
+            let hasVisibleConsumer = hasVisibleCaptureConsumer(nav: navSnapshot)
 
             guard hasVisibleConsumer else {
                 // This is the normal path when IceBar/search/settings are not visible — not an error
@@ -1295,26 +1312,37 @@ final class MenuBarItemImageCache: ObservableObject {
             }
         }
 
-        MenuBarItemImageCache.diagLog.debug("updateCache: proceeding with cache update for \(sections.count) sections (iceBar=\(isIceBarPresented), search=\(isSearchPresented), background=\(allowBackgroundCapture))")
+        MenuBarItemImageCache.diagLog.debug("updateCache: proceeding with cache update for \(sections.count) sections (iceBar=\(navSnapshot.isIceBarPresented), search=\(navSnapshot.isSearchPresented), background=\(allowBackgroundCapture))")
         await updateCacheWithoutChecks(sections: sections)
     }
 
     /// Updates the cache for all sections, if necessary.
-    func updateCache() async {
+    func updateCache(nav: NavigationStateSnapshot? = nil) async {
         guard let appState else {
             return
         }
 
-        let isIceBarPresented = await appState.navigationState.isIceBarPresented
-        let isSearchPresented = await appState.navigationState.isSearchPresented
-        let isSettingsPresented = await appState.navigationState
-            .isSettingsPresented
+        // Use provided snapshot or read fresh values
+        let navSnapshot: NavigationStateSnapshot
+        if let nav {
+            navSnapshot = nav
+        } else {
+            navSnapshot = await MainActor.run {
+                NavigationStateSnapshot(
+                    isIceBarPresented: appState.navigationState.isIceBarPresented,
+                    isSearchPresented: appState.navigationState.isSearchPresented,
+                    isAppFrontmost: appState.navigationState.isAppFrontmost,
+                    isSettingsPresented: appState.navigationState.isSettingsPresented,
+                    settingsNavigationIdentifier: appState.navigationState.settingsNavigationIdentifier
+                )
+            }
+        }
 
         var sectionsNeedingDisplay = [MenuBarSection.Name]()
 
-        if isSettingsPresented || isSearchPresented {
+        if navSnapshot.isSettingsPresented || navSnapshot.isSearchPresented {
             sectionsNeedingDisplay = MenuBarSection.Name.allCases
-        } else if isIceBarPresented, let section = await appState.menuBarManager.iceBarPanel
+        } else if navSnapshot.isIceBarPresented, let section = await appState.menuBarManager.iceBarPanel
             .currentSection
         {
             sectionsNeedingDisplay.append(section)
@@ -1322,7 +1350,8 @@ final class MenuBarItemImageCache: ObservableObject {
 
         await updateCache(
             sections: sectionsNeedingDisplay,
-            skipRecentMoveCheck: isIceBarPresented
+            skipRecentMoveCheck: navSnapshot.isIceBarPresented,
+            nav: navSnapshot
         )
     }
 

--- a/Thaw/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift
@@ -96,20 +96,16 @@ struct MenuBarLayoutSettingsPane: View {
 
             diagLog.debug("Preloading menu bar layout caches (hasItems=\(self.hasItems), screenRecording=\(ScreenCapture.cachedCheckPermissions()))")
 
-            // Run cache updates in the background to avoid blocking the UI
-            Task {
-                await itemManager.cacheItemsRegardless(skipRecentMoveCheck: true)
-                diagLog.debug("Preload: itemCache after cacheItemsRegardless: managedItems=\(self.itemManager.itemCache.managedItems.count), visible=\(self.itemManager.itemCache[.visible].count), hidden=\(self.itemManager.itemCache[.hidden].count), alwaysHidden=\(self.itemManager.itemCache[.alwaysHidden].count)")
-                await appState.imageCache.updateCacheWithoutChecks(sections: MenuBarSection.Name.allCases)
-                diagLog.debug("Preload: imageCache after update: \(self.appState.imageCache.images.count) images")
-            }
+            async let preloadCaches: Void = preloadLayoutCaches()
 
             try? await Task.sleep(for: .seconds(3))
 
-            if !hasItems {
+            if !Task.isCancelled, !hasItems {
                 loadDeadlineReached = true
                 diagLog.error("Menu bar layout failed to load items after 3s timeout. cacheItems: \(itemManager.itemCache.managedItems.count), images: \(appState.imageCache.images.count), displayID: \(self.itemManager.itemCache.displayID.map { "\($0)" } ?? "nil")")
             }
+
+            await preloadCaches
         }
     }
 
@@ -227,6 +223,22 @@ struct MenuBarLayoutSettingsPane: View {
                 isResettingLayout = false
             }
         }
+    }
+
+    private func preloadLayoutCaches() async {
+        await itemManager.cacheItemsRegardless(skipRecentMoveCheck: true)
+        guard !Task.isCancelled else {
+            return
+        }
+
+        diagLog.debug("Preload: itemCache after cacheItemsRegardless: managedItems=\(self.itemManager.itemCache.managedItems.count), visible=\(self.itemManager.itemCache[.visible].count), hidden=\(self.itemManager.itemCache[.hidden].count), alwaysHidden=\(self.itemManager.itemCache[.alwaysHidden].count)")
+
+        await appState.imageCache.updateCacheWithoutChecks(sections: MenuBarSection.Name.allCases)
+        guard !Task.isCancelled else {
+            return
+        }
+
+        diagLog.debug("Preload: imageCache after update: \(self.appState.imageCache.images.count) images")
     }
 
     private enum ResetStatus {

--- a/Thaw/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift
@@ -38,6 +38,11 @@ struct MenuBarLayoutSettingsPane: View {
                 layoutBars
                 resetControls
             }
+            .onAppear {
+                // Enable background cache prewarming now that the user has opened
+                // the layout settings pane at least once.
+                appState.imageCache.markSettingsPaneOpened()
+            }
         }
     }
 

--- a/Thaw/Settings/SettingsView.swift
+++ b/Thaw/Settings/SettingsView.swift
@@ -70,7 +70,6 @@ struct SettingsView: View {
         .navigationTitle(navigationTitle)
     }
 
-    @ViewBuilder
     private var sidebar: some View {
         List {
             Section {

--- a/Thaw/Settings/SettingsView.swift
+++ b/Thaw/Settings/SettingsView.swift
@@ -9,12 +9,13 @@
 import SwiftUI
 
 struct SettingsView: View {
-    @EnvironmentObject var appState: AppState
+    let appState: AppState
     @ObservedObject var navigationState: AppNavigationState
     @Environment(\.appearsActive) private var appearsActive
     @Environment(\.sidebarRowSize) private var sidebarRowSize
 
     private let sidebarPadding: CGFloat = 3
+    private let sidebarItemCornerRadius: CGFloat = 12
 
     private var sidebarWidth: CGFloat {
         if #available(macOS 26.0, *) {
@@ -71,23 +72,10 @@ struct SettingsView: View {
 
     @ViewBuilder
     private var sidebar: some View {
-        // Use a Binding that wraps the navigation state to ensure updates happen
-        // on the main thread and avoid view update warnings.
-        let selection = Binding<SettingsNavigationIdentifier>(
-            get: { navigationState.settingsNavigationIdentifier },
-            set: { newValue in
-                if navigationState.settingsNavigationIdentifier != newValue {
-                    DispatchQueue.main.async {
-                        navigationState.settingsNavigationIdentifier = newValue
-                    }
-                }
-            }
-        )
-
-        List(selection: selection) {
+        List {
             Section {
                 ForEach(SettingsNavigationIdentifier.allCases) { identifier in
-                    sidebarItem(for: identifier)
+                    sidebarButton(for: identifier)
                 }
             } header: {
                 Text("\(Constants.displayName)")
@@ -106,18 +94,63 @@ struct SettingsView: View {
         .navigationSplitViewColumnWidth(sidebarWidth)
     }
 
-    private func sidebarItem(for identifier: SettingsNavigationIdentifier) -> some View {
+    private func sidebarButton(for identifier: SettingsNavigationIdentifier) -> some View {
+        let isSelected = navigationState.settingsNavigationIdentifier == identifier
+
+        return Button {
+            if !isSelected {
+                navigationState.settingsNavigationIdentifier = identifier
+            }
+        } label: {
+            sidebarItemLabel(for: identifier, isSelected: isSelected)
+        }
+        .buttonStyle(.plain)
+        .listRowInsets(EdgeInsets(top: 2, leading: 6, bottom: 2, trailing: 6))
+        .listRowBackground(Color.clear)
+    }
+
+    private func sidebarItemLabel(
+        for identifier: SettingsNavigationIdentifier,
+        isSelected: Bool
+    ) -> some View {
         Label {
             Text(identifier.localized)
                 .font(.system(size: sidebarFontSize))
-                .foregroundStyle(sidebarTextStyle)
         } icon: {
             identifier.iconResource.view
-                .foregroundStyle(sidebarTextStyle)
                 .padding(sidebarPadding)
         }
-        .frame(height: sidebarItemHeight)
-        .tag(identifier)
+        .foregroundStyle(sidebarItemForegroundStyle(isSelected: isSelected))
+        .frame(maxWidth: .infinity, minHeight: sidebarItemHeight, alignment: .leading)
+        .padding(.horizontal, 10)
+        .background(sidebarItemBackground(isSelected: isSelected))
+        .clipShape(RoundedRectangle(cornerRadius: sidebarItemCornerRadius, style: .continuous))
+        .contentShape(RoundedRectangle(cornerRadius: sidebarItemCornerRadius, style: .continuous))
+    }
+
+    private func sidebarItemForegroundStyle(isSelected: Bool) -> some ShapeStyle {
+        if isSelected {
+            return AnyShapeStyle(.white)
+        }
+        return AnyShapeStyle(sidebarTextStyle)
+    }
+
+    @ViewBuilder
+    private func sidebarItemBackground(isSelected: Bool) -> some View {
+        if isSelected {
+            RoundedRectangle(cornerRadius: sidebarItemCornerRadius, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: appearsActive
+                            ? [Color.accentColor.opacity(0.96), Color.accentColor]
+                            : [Color.secondary.opacity(0.35), Color.secondary.opacity(0.28)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+        } else {
+            Color.clear
+        }
     }
 
     @ToolbarContentBuilder
@@ -135,9 +168,11 @@ struct SettingsView: View {
     private var detailView: some View {
         if #available(macOS 26.0, *) {
             settingsPane
+                .id(navigationState.settingsNavigationIdentifier)
                 .scrollEdgeEffectStyle(.hard, for: .top)
         } else {
             settingsPane
+                .id(navigationState.settingsNavigationIdentifier)
         }
     }
 

--- a/Thaw/Settings/SettingsView.swift
+++ b/Thaw/Settings/SettingsView.swift
@@ -129,7 +129,7 @@ struct SettingsView: View {
     }
 
     private func sidebarItemForegroundStyle(isSelected: Bool) -> some ShapeStyle {
-        if isSelected {
+        if isSelected && appearsActive {
             return AnyShapeStyle(.white)
         }
         return AnyShapeStyle(sidebarTextStyle)

--- a/Thaw/Settings/SettingsWindow.swift
+++ b/Thaw/Settings/SettingsWindow.swift
@@ -17,7 +17,7 @@ struct SettingsWindow: Scene {
 
     var body: some Scene {
         IceWindow(id: .settings) {
-            SettingsView(navigationState: appState.navigationState)
+            SettingsView(appState: appState, navigationState: appState.navigationState)
                 .onWindowChange { window in
                     model.observeWindowToolbar(window)
                 }
@@ -32,12 +32,6 @@ struct SettingsWindow: Scene {
                         appState.isUpdateConsentPresented = false
                         Defaults.set(true, forKey: .hasSeenUpdateConsent)
                         appState.updatesManager.automaticallyChecksForUpdates = false
-                    }
-                }
-                .onAppear {
-                    Task { @MainActor in
-                        appState.imageCache.performCacheCleanup()
-                        appState.imageCache.logCacheStatus("Settings opened")
                     }
                 }
                 .frame(minWidth: 850, maxWidth: 1150, minHeight: 550, maxHeight: 750)


### PR DESCRIPTION
## Summary

This PR fixes an issue where the selected item in the Settings sidebar could get out of sync with the pane shown on the right, and also reduces some avoidable work in the Settings window and Menu Bar Layout UI.

In practice, this addresses cases where clicking `Menu Bar Layout` could still leave the `Displays` pane visible, along with some unnecessary work that made the Settings experience feel heavier than it should.

## What changed

### Settings navigation
- replaced the Settings sidebar's `List(selection:)`-driven selection with an explicit state-driven sidebar button list
- made sidebar highlighting and detail presentation use the same source of truth
- added a stable `.id(...)` to the detail pane so SwiftUI does not incorrectly reuse the previous pane view

### Settings window overhead
- removed image cache cleanup/logging work that was running when opening the Settings window
- changed `SettingsView` so it no longer depends on the full `AppState` as an environment object just to drive top-level pane switching

### Menu Bar Layout performance work
- made layout items render immediately from model data (`bounds`, app metadata, placeholders) instead of waiting for real captured images before they have usable size/content
- added placeholder/app-icon based rendering for layout items until captured menu bar images arrive
- stopped the entire layout container from relaying out on every `imageCache.$images` update
- only trigger relayout when an individual item's preferred size actually changes

### Cache behavior
- kept a warmed layout-image cache up to date in the background so opening the Menu Bar Layout pane does not always start from a cold image capture path

## Why

There were two overlapping issues:

1. the Settings sidebar and detail pane could become desynchronized because selection and pane presentation were not fully controlled by the same explicit state
2. the Menu Bar Layout/settings flow was doing too much eager work, especially around image capture and layout invalidation
<img width="850" height="602" alt="Thaw 2026-04-19 21 30 37" src="https://github.com/user-attachments/assets/0f2e4cf0-d4eb-478c-975d-451b000e6e44" />


This PR makes the navigation behavior deterministic and removes several sources of unnecessary UI work.


## Result

Expected improvements from this change:

- clicking a sidebar item reliably shows the matching pane
- reduced chance of the right-hand Settings pane getting "stuck" on the previous page
- faster initial rendering of the Menu Bar Layout pane
- less relayout churn while item images are being refreshed
- lower Settings-window overhead on open

## Testing

Tested locally with Debug builds by:
- opening Settings repeatedly
- switching quickly between `Displays`, `Menu Bar Layout`, and other panes
- verifying that the selected sidebar item and displayed pane stay in sync
- verifying that the Menu Bar Layout pane renders immediately with placeholders before captured images are filled in


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Menu bar items show rounded placeholder visuals and matching drag previews when cached images are unavailable.

* **Improvements**
  * Container relayouts now update efficiently for single-item size changes, reducing visual jank.
  * Items maintain sensible sizes when images are missing to avoid collapsed layouts.
  * Settings sidebar selection is snappier with refined row styling and reliable detail-pane re-instantiation.
  * Settings pane opening is tracked to improve cache behavior.

* **Stability**
  * Cache refresh/preload now favors visible consumers, with improved timeout and cancellation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->