### PR TITLE
Prevent double-click from being stolen by newly revealed hidden items

### DIFF
--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -695,55 +695,58 @@ extension HIDEventManager {
             return
         }
 
-        Task {
-            if isDoubleClick {
-                guard
-                    appState.settings.general.showOnClick,
-                    appState.settings.general.showOnDoubleClick
-                else {
-                    return
-                }
+        if isDoubleClick {
+            guard
+                appState.settings.general.showOnClick,
+                appState.settings.general.showOnDoubleClick
+            else {
+                return
+            }
+            Task {
                 if let alwaysHiddenSection = appState.menuBarManager.section(withName: .alwaysHidden),
                    alwaysHiddenSection.isEnabled
                 {
                     alwaysHiddenSection.show()
                 }
-            } else {
-                guard appState.settings.general.showOnClick else {
-                    return
-                }
+            }
+        } else {
+            guard appState.settings.general.showOnClick else {
+                return
+            }
 
-                if NSEvent.modifierFlags == .control {
-                    handleSecondaryContextMenu(appState: appState, screen: screen)
-                    return
-                }
+            if NSEvent.modifierFlags == .control {
+                handleSecondaryContextMenu(appState: appState, screen: screen)
+                return
+            }
 
-                if NSEvent.modifierFlags == .option {
-                    if appState.settings.advanced.useOptionClickToShowAlwaysHiddenSection,
-                       let alwaysHiddenSection = appState.menuBarManager.section(withName: .alwaysHidden),
-                       alwaysHiddenSection.isEnabled
-                    {
-                        alwaysHiddenSection.show()
-                    }
-                    return
-                }
-
-                if let hiddenSection = appState.menuBarManager.section(withName: .hidden),
-                   hiddenSection.isEnabled
+            if NSEvent.modifierFlags == .option {
+                if appState.settings.advanced.useOptionClickToShowAlwaysHiddenSection,
+                   let alwaysHiddenSection = appState.menuBarManager.section(withName: .alwaysHidden),
+                   alwaysHiddenSection.isEnabled
                 {
-                    let shouldArmGuard =
-                        appState.settings.general.showOnDoubleClick
-                            && hiddenSection.isHidden
-                            && (appState.menuBarManager.section(withName: .alwaysHidden)?.isEnabled ?? false)
-
-                    hiddenSection.toggle()
-
-                    if shouldArmGuard {
-                        armShowOnClickGuard(screen: screen, at: clickLocation)
-                    } else {
-                        disarmShowOnClickGuard()
-                    }
+                    Task { alwaysHiddenSection.show() }
                 }
+                return
+            }
+
+            if let hiddenSection = appState.menuBarManager.section(withName: .hidden),
+               hiddenSection.isEnabled
+            {
+                let shouldArmGuard =
+                    appState.settings.general.showOnDoubleClick
+                        && hiddenSection.isHidden
+                        && (appState.menuBarManager.section(withName: .alwaysHidden)?.isEnabled ?? false)
+
+                // Arm the guard synchronously before toggling so the CGEventTap
+                // is active before any second click can arrive; a Task hop would
+                // leave a window where the tap is not yet started.
+                if shouldArmGuard {
+                    armShowOnClickGuard(screen: screen, at: clickLocation)
+                } else {
+                    disarmShowOnClickGuard()
+                }
+
+                Task { hiddenSection.toggle() }
             }
         }
     }

--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -428,6 +428,11 @@ final class HIDEventManager: ObservableObject {
         var c = Set<AnyCancellable>()
 
         if let appState {
+            // Pre-seed so the initial CombineLatest3 emission is treated as a
+            // no-op when showOnHover is already true at subscription time,
+            // avoiding unnecessary startup rearm work.
+            lastShowOnHover = appState.settings.general.showOnHover
+
             // Start or stop the mouse-moved tap when show-on-hover,
             // menu-bar-tooltips, or per-display configurations change.
             Publishers.CombineLatest3(

--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -692,8 +692,8 @@ extension HIDEventManager {
                 {
                     let shouldArmGuard =
                         appState.settings.general.showOnDoubleClick
-                        && hiddenSection.isHidden
-                        && (appState.menuBarManager.section(withName: .alwaysHidden)?.isEnabled ?? false)
+                            && hiddenSection.isHidden
+                            && (appState.menuBarManager.section(withName: .alwaysHidden)?.isEnabled ?? false)
 
                     hiddenSection.toggle()
 

--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -403,6 +403,14 @@ final class HIDEventManager: ObservableObject {
     /// items on or off screen. Rebuilding from the last item cache in those
     /// moments can leave hit testing with stale geometry, so use a direct
     /// Window Server snapshot instead.
+    ///
+    /// Unlike ``rebuildWindowBoundsLookup(from:)``, this method intentionally
+    /// omits the managed-items fallback. During a section transition the cached
+    /// bounds are stale (items have moved on/off screen while keeping the same
+    /// window ID), so appending them here would corrupt rather than improve the
+    /// lookup. The trade-off is that an item not yet reported by the Window
+    /// Server immediately after a transition may be briefly unhittable; that
+    /// window is typically sub-frame and acceptable given the correctness gain.
     private func rebuildWindowBoundsLookupFromCurrentLayout() {
         let allWindowIDs = Bridging.getMenuBarWindowList(option: [
             .onScreen, .activeSpace, .itemsOnly,
@@ -696,15 +704,16 @@ extension HIDEventManager {
     // MARK: Handle Show On Click
 
     private func handleShowOnClick(appState: AppState, screen: NSScreen, clickLocation: CGPoint, isDoubleClick: Bool = false) {
+        guard appState.settings.general.showOnClick else {
+            return
+        }
+
         guard isMouseInsideEmptyMenuBarSpace(appState: appState, screen: screen) else {
             return
         }
 
         if isDoubleClick {
-            guard
-                appState.settings.general.showOnClick,
-                appState.settings.general.showOnDoubleClick
-            else {
+            guard appState.settings.general.showOnDoubleClick else {
                 return
             }
             Task {
@@ -715,10 +724,6 @@ extension HIDEventManager {
                 }
             }
         } else {
-            guard appState.settings.general.showOnClick else {
-                return
-            }
-
             if NSEvent.modifierFlags.contains(.control) {
                 handleSecondaryContextMenu(appState: appState, screen: screen)
                 return

--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -42,6 +42,10 @@ final class HIDEventManager: ObservableObject {
     /// The currently pending show-on-hover delay task.
     private var hoverTask: Task<Void, any Error>?
 
+    /// The currently pending hover action, used to avoid restarting the same
+    /// delay window on every small mouse move inside the same region.
+    private var pendingHoverAction: HoverAction?
+
     /// The pending task that clears the temporary show-on-click guard.
     private var clickTask: Task<Void, Never>?
 
@@ -66,6 +70,11 @@ final class HIDEventManager: ObservableObject {
 
     /// The number of times the manager has been told to stop.
     private var disableCount = 0
+
+    private enum HoverAction {
+        case show
+        case hide
+    }
 
     /// Timestamp of the last `stopAll()` call, used by the health check
     /// to detect a stuck disabled state.
@@ -348,6 +357,32 @@ final class HIDEventManager: ObservableObject {
         windowBoundsLock.withLock { $0 = entries }
     }
 
+    /// Rebuilds the bounds lookup using the current on-screen menu bar layout.
+    ///
+    /// Section show/hide changes often keep the same window IDs while moving
+    /// items on or off screen. Rebuilding from the last item cache in those
+    /// moments can leave hit testing with stale geometry, so use a direct
+    /// Window Server snapshot instead.
+    private func rebuildWindowBoundsLookupFromCurrentLayout() {
+        let allWindowIDs = Bridging.getMenuBarWindowList(option: [
+            .onScreen, .activeSpace, .itemsOnly,
+        ])
+
+        let entries = allWindowIDs.compactMap { windowID -> (windowID: CGWindowID, bounds: CGRect)? in
+            guard let bounds = Bridging.getWindowBounds(for: windowID) else {
+                return nil
+            }
+
+            guard bounds.width <= Self.maxReasonableItemWidth else {
+                return nil
+            }
+
+            return (windowID: windowID, bounds: bounds)
+        }
+
+        windowBoundsLock.withLock { $0 = entries }
+    }
+
     /// Configures the internal observers for the manager.
     private func configureCancellables() {
         var c = Set<AnyCancellable>()
@@ -360,7 +395,7 @@ final class HIDEventManager: ObservableObject {
                 appState.settings.advanced.$showMenuBarTooltips,
                 appState.settings.displaySettings.$configurations
             )
-            .sink { [weak self] _, _, _ in
+            .sink { [weak self] showOnHover, _, _ in
                 guard let self, isEnabled else {
                     return
                 }
@@ -368,6 +403,33 @@ final class HIDEventManager: ObservableObject {
                     mouseMovedTap.start()
                 } else {
                     mouseMovedTap.stop()
+                }
+
+                if !showOnHover {
+                    hoverTask?.cancel()
+                    hoverTask = nil
+                    pendingHoverAction = nil
+                    return
+                }
+
+                appState.menuBarManager.showOnHoverAllowed = true
+                hoverTask?.cancel()
+                hoverTask = nil
+                pendingHoverAction = nil
+
+                Task { @MainActor [weak self, weak appState] in
+                    try? await Task.sleep(for: .milliseconds(50))
+                    guard
+                        let self,
+                        let appState,
+                        isEnabled,
+                        appState.settings.general.showOnHover,
+                        appState.menuBarManager.showOnHoverAllowed,
+                        let screen = NSScreen.screenWithMouse ?? bestScreen(appState: appState)
+                    else {
+                        return
+                    }
+                    handleShowOnHover(appState: appState, screen: screen)
                 }
             }
             .store(in: &c)
@@ -388,12 +450,14 @@ final class HIDEventManager: ObservableObject {
             Publishers.MergeMany(
                 appState.menuBarManager.sections.map { $0.controlItem.$state.replace(with: ()) }
             )
+            // Ignore the initial Published emissions during startup. The item manager
+            // performs its own initial cache pass in AppState setup, and letting the
+            // section-state observer fire immediately causes an extra full menu-bar
+            // scan to preempt startup readiness.
+            .dropFirst(appState.menuBarManager.sections.count)
             .debounce(for: .milliseconds(200), scheduler: DispatchQueue.main)
-            .sink { [weak appState] in
-                guard let appState else { return }
-                Task {
-                    await appState.itemManager.cacheItemsIfNeeded()
-                }
+            .sink { [weak self] in
+                self?.rebuildWindowBoundsLookupFromCurrentLayout()
             }
             .store(in: &c)
 
@@ -901,8 +965,6 @@ extension HIDEventManager {
 
         let delay = appState.settings.advanced.showOnHoverDelay
 
-        hoverTask?.cancel()
-
         if hiddenSection.isHidden {
             guard
                 isMouseInsideEmptyMenuBarSpace(
@@ -910,10 +972,25 @@ extension HIDEventManager {
                     screen: screen
                 )
             else {
+                if pendingHoverAction == .show {
+                    hoverTask?.cancel()
+                    hoverTask = nil
+                    pendingHoverAction = nil
+                }
                 return
             }
+            guard pendingHoverAction != .show else {
+                return
+            }
+            hoverTask?.cancel()
+            pendingHoverAction = .show
             hoverTask = Task {
-                defer { hoverTask = nil }
+                defer {
+                    hoverTask = nil
+                    if pendingHoverAction == .show {
+                        pendingHoverAction = nil
+                    }
+                }
                 try await Task.sleep(for: .seconds(delay))
                 // Make sure the mouse is still inside.
                 guard
@@ -931,10 +1008,25 @@ extension HIDEventManager {
                 !isMouseInsideMenuBar(appState: appState, screen: screen),
                 !isMouseInsideIceBar(appState: appState)
             else {
+                if pendingHoverAction == .hide {
+                    hoverTask?.cancel()
+                    hoverTask = nil
+                    pendingHoverAction = nil
+                }
                 return
             }
+            guard pendingHoverAction != .hide else {
+                return
+            }
+            hoverTask?.cancel()
+            pendingHoverAction = .hide
             hoverTask = Task {
-                defer { hoverTask = nil }
+                defer {
+                    hoverTask = nil
+                    if pendingHoverAction == .hide {
+                        pendingHoverAction = nil
+                    }
+                }
                 try await Task.sleep(for: .seconds(delay))
                 // Make sure the mouse is still outside.
                 guard
@@ -1167,6 +1259,19 @@ extension HIDEventManager {
         return applicationMenuFrame.contains(mouseLocation)
     }
 
+    /// Returns `true` when the current mouse location hits a cached menu bar item
+    /// bounds entry. This is the fast path used by hover/click hit testing.
+    private func isMouseInsideCachedMenuBarItem() -> Bool {
+        guard let mouseLocation = MouseHelpers.locationCoreGraphics else {
+            return false
+        }
+
+        let entries = windowBoundsLock.withLock { $0 }
+        return entries.contains { entry in
+            entry.bounds.contains(mouseLocation)
+        }
+    }
+
     /// A Boolean value that indicates whether the mouse pointer is within
     /// the bounds of a menu bar item.
     func isMouseInsideMenuBarItem(appState _: AppState, screen _: NSScreen) -> Bool {
@@ -1177,10 +1282,7 @@ extension HIDEventManager {
         // Use the pre-built bounds lookup table, which is rebuilt
         // whenever the item cache changes. This avoids per-event
         // IPC calls to the Window Server.
-        let entries = windowBoundsLock.withLock { $0 }
-        let cacheHit = entries.contains { entry in
-            entry.bounds.contains(mouseLocation)
-        }
+        let cacheHit = isMouseInsideCachedMenuBarItem()
 
         // If we found a hit in the cache, return early.
         if cacheHit {
@@ -1257,7 +1359,7 @@ extension HIDEventManager {
         }
 
         return !isInAppMenu
-            && !isMouseInsideMenuBarItem(appState: appState, screen: screen)
+            && !isMouseInsideCachedMenuBarItem()
             && !isMouseInsideIceIcon(appState: appState)
     }
 

--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -46,6 +46,12 @@ final class HIDEventManager: ObservableObject {
     /// clear state that belongs to a newer one.
     private var hoverTaskToken: UUID?
 
+    /// A short-lived recovery task that repeatedly re-evaluates show-on-hover
+    /// right after the setting is enabled, so the first hover does not depend
+    /// on a later mouse-moved event or the periodic health check.
+    private var hoverRearmTask: Task<Void, Never>?
+    private var hoverRearmTaskToken: UUID?
+
     /// The currently pending hover action, used to avoid restarting the same
     /// delay window on every small mouse move inside the same region.
     private var pendingHoverAction: HoverAction?
@@ -410,6 +416,9 @@ final class HIDEventManager: ObservableObject {
                 }
 
                 if !showOnHover {
+                    hoverRearmTask?.cancel()
+                    hoverRearmTask = nil
+                    hoverRearmTaskToken = nil
                     hoverTask?.cancel()
                     hoverTask = nil
                     hoverTaskToken = nil
@@ -418,25 +427,13 @@ final class HIDEventManager: ObservableObject {
                 }
 
                 appState.menuBarManager.showOnHoverAllowed = true
+                hoverRearmTask?.cancel()
+                hoverRearmTaskToken = nil
                 hoverTask?.cancel()
                 hoverTask = nil
                 hoverTaskToken = nil
                 pendingHoverAction = nil
-
-                Task { @MainActor [weak self, weak appState] in
-                    try? await Task.sleep(for: .milliseconds(50))
-                    guard
-                        let self,
-                        let appState,
-                        isEnabled,
-                        appState.settings.general.showOnHover,
-                        appState.menuBarManager.showOnHoverAllowed,
-                        let screen = NSScreen.screenWithMouse ?? bestScreen(appState: appState)
-                    else {
-                        return
-                    }
-                    handleShowOnHover(appState: appState, screen: screen)
-                }
+                scheduleHoverRearmChecks(appState: appState)
             }
             .store(in: &c)
 
@@ -565,6 +562,9 @@ final class HIDEventManager: ObservableObject {
         }
         disableCount += 1
         lastStopTimestamp = .now
+        hoverRearmTask?.cancel()
+        hoverRearmTask = nil
+        hoverRearmTaskToken = nil
         disarmShowOnClickGuard()
         dismissMenuBarTooltip()
     }
@@ -573,6 +573,75 @@ final class HIDEventManager: ObservableObject {
 // MARK: - Handler Methods
 
 extension HIDEventManager {
+    private func isMouseNearMenuBar(screen: NSScreen, verticalPadding: CGFloat = 80) -> Bool {
+        guard
+            let mouseLocation = MouseHelpers.locationAppKit,
+            let menuBarHeight = screen.getMenuBarHeight()
+        else {
+            return false
+        }
+
+        return mouseLocation.x >= screen.frame.minX
+            && mouseLocation.x <= screen.frame.maxX
+            && mouseLocation.y <= screen.frame.maxY
+            && mouseLocation.y >= screen.frame.maxY - menuBarHeight - verticalPadding
+    }
+
+    private func scheduleHoverRearmChecks(appState: AppState) {
+        let taskToken = UUID()
+        hoverRearmTaskToken = taskToken
+        hoverRearmTask = Task { @MainActor [weak self, weak appState] in
+            guard let self, let appState else {
+                return
+            }
+
+            defer {
+                if hoverRearmTaskToken == taskToken {
+                    hoverRearmTask = nil
+                    hoverRearmTaskToken = nil
+                }
+            }
+
+            for attempt in 0 ..< 12 {
+                do {
+                    try await Task.sleep(for: attempt == 0 ? .milliseconds(50) : .milliseconds(200))
+                } catch {
+                    return
+                }
+
+                guard
+                    hoverRearmTaskToken == taskToken,
+                    isEnabled,
+                    appState.settings.general.showOnHover,
+                    appState.menuBarManager.showOnHoverAllowed
+                else {
+                    return
+                }
+
+                if needsMouseMovedTap(appState: appState) {
+                    _ = mouseMovedTap.ensureValid()
+                    mouseMovedTap.start()
+                }
+
+                guard let screen = NSScreen.screenWithMouse ?? bestScreen(appState: appState) else {
+                    continue
+                }
+
+                guard isMouseNearMenuBar(screen: screen) else {
+                    return
+                }
+
+                handleShowOnHover(appState: appState, screen: screen)
+
+                if pendingHoverAction == .show ||
+                    !(appState.menuBarManager.section(withName: .hidden)?.isHidden ?? true)
+                {
+                    return
+                }
+            }
+        }
+    }
+
     // MARK: Handle Show On Click
 
     private func handleShowOnClick(appState: AppState, screen: NSScreen, isDoubleClick: Bool = false) {

--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -63,6 +63,10 @@ final class HIDEventManager: ObservableObject {
     /// The pending task that clears the temporary show-on-click guard.
     private var clickTask: Task<Void, Never>?
 
+    /// Identity token for the current click task so a late/re-armed task
+    /// cannot call expireShowOnClickGuard after it has been superseded.
+    private var clickTaskToken: UUID?
+
     /// The deadline for the temporary show-on-click protection region.
     private var showOnClickGuardDeadline: ContinuousClock.Instant?
 
@@ -753,6 +757,8 @@ extension HIDEventManager {
         showOnClickGuardTap.start()
 
         clickTask?.cancel()
+        let token = UUID()
+        clickTaskToken = token
         clickTask = Task { [weak self] in
             do {
                 try await Task.sleep(for: .seconds(NSEvent.doubleClickInterval))
@@ -760,6 +766,7 @@ extension HIDEventManager {
                 return
             }
             await MainActor.run {
+                guard self?.clickTaskToken == token else { return }
                 self?.expireShowOnClickGuard()
             }
         }
@@ -774,6 +781,7 @@ extension HIDEventManager {
             showOnClickGuardRegion = nil
             showOnClickGuardDisplayID = nil
             clickTask = nil
+            clickTaskToken = nil
             return
         }
 
@@ -791,6 +799,7 @@ extension HIDEventManager {
 
         clickTask?.cancel()
         clickTask = nil
+        clickTaskToken = nil
         showOnClickGuardDeadline = nil
         showOnClickGuardRegion = nil
         showOnClickGuardDisplayID = nil

--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -156,8 +156,21 @@ final class HIDEventManager: ObservableObject {
     private(set) lazy var mouseDownMonitor = EventMonitor.universal(
         for: [.leftMouseDown, .rightMouseDown]
     ) { [weak self] event in
-        guard let self, isEnabled, let appState, let screen = bestScreen(appState: appState)
-        else {
+        guard let self, isEnabled, let appState else {
+            return event
+        }
+        // Prefer the screen the mouse is physically on so clicks on the external
+        // monitor's menu bar are processed against the correct display geometry.
+        // Fall back to the active-menu-bar screen when the mouse screen has no
+        // visible menu bar (e.g. a fullscreen app is suppressing it), which
+        // preserves the original guard against acting on inactive menu bars.
+        let mouseScreen = NSScreen.screenWithMouse ?? NSScreen.main
+        let screen: NSScreen
+        if let s = mouseScreen, s.getMenuBarHeight() != nil {
+            screen = s
+        } else if let s = bestScreen(appState: appState) {
+            screen = s
+        } else {
             return event
         }
         switch event.type {
@@ -1277,12 +1290,16 @@ extension HIDEventManager {
 // MARK: - Helper Methods
 
 extension HIDEventManager {
-    /// Returns the best screen to use for event manager calculations.
+    /// Returns the best screen to use for hover, scroll, and tooltip calculations.
     ///
     /// Always returns the screen that currently owns the active menu bar.
     /// This prevents showing the hidden section or IceBar on a monitor
     /// whose menu bar is inactive (e.g. when another monitor has a
     /// fullscreen app), where clicking icons would have no effect.
+    ///
+    /// For mouse-down events, `mouseDownMonitor` resolves the screen from
+    /// `NSScreen.screenWithMouse` instead so that clicks on a secondary
+    /// display's menu bar are evaluated against the correct display geometry.
     func bestScreen(appState _: AppState) -> NSScreen? {
         NSScreen.screenWithActiveMenuBar ?? NSScreen.main
     }

--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -777,7 +777,10 @@ extension HIDEventManager {
 
         // Validate (and recreate if needed) before enabling; a stale Mach port
         // would silently no-op on start() and leave the guard tap inactive.
-        showOnClickGuardTap.ensureValid()
+        guard showOnClickGuardTap.ensureValid() else {
+            disarmShowOnClickGuard()
+            return
+        }
         showOnClickGuardTap.start()
 
         clickTask?.cancel()

--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -74,12 +74,9 @@ final class HIDEventManager: ObservableObject {
     /// guard consumed a left-mouse-down.
     private var shouldSwallowShowOnClickMouseUp = false
 
-    /// Whether the guard should be torn down immediately after the matching
-    /// swallowed mouse-up arrives.
-    private var shouldDisarmShowOnClickGuardOnMouseUp = false
-
-    /// Whether guard teardown is pending until the swallowed mouse-up arrives.
-    private var shouldDisarmShowOnClickGuardWhenMouseUpArrives = false
+    /// Whether guard teardown should occur once the swallowed mouse-up arrives.
+    /// Consolidates the two previous deferred-disarm flags.
+    private var pendingDisarmOnMouseUp = false
 
     /// The number of times the manager has been told to stop.
     private var disableCount = 0
@@ -264,12 +261,12 @@ final class HIDEventManager: ObservableObject {
             return event
         }
 
+        expireShowOnClickGuardIfNeeded()
+
         if event.type == .leftMouseUp, shouldSwallowShowOnClickMouseUp {
             shouldSwallowShowOnClickMouseUp = false
-            let shouldDisarm = shouldDisarmShowOnClickGuardOnMouseUp ||
-                shouldDisarmShowOnClickGuardWhenMouseUpArrives
-            shouldDisarmShowOnClickGuardOnMouseUp = false
-            shouldDisarmShowOnClickGuardWhenMouseUpArrives = false
+            let shouldDisarm = pendingDisarmOnMouseUp
+            pendingDisarmOnMouseUp = false
             if shouldDisarm {
                 disarmShowOnClickGuard()
             }
@@ -298,7 +295,7 @@ final class HIDEventManager: ObservableObject {
            alwaysHiddenSection.isEnabled
         {
             alwaysHiddenSection.show()
-            shouldDisarmShowOnClickGuardOnMouseUp = true
+            pendingDisarmOnMouseUp = true
         }
 
         return nil
@@ -574,6 +571,10 @@ final class HIDEventManager: ObservableObject {
         hoverRearmTask?.cancel()
         hoverRearmTask = nil
         hoverRearmTaskToken = nil
+        hoverTask?.cancel()
+        hoverTask = nil
+        hoverTaskToken = nil
+        pendingHoverAction = nil
         disarmShowOnClickGuard()
         dismissMenuBarTooltip()
     }
@@ -729,8 +730,7 @@ extension HIDEventManager {
         showOnClickGuardDisplayID = screen.displayID
         showOnClickGuardDeadline = .now + .seconds(NSEvent.doubleClickInterval)
         shouldSwallowShowOnClickMouseUp = false
-        shouldDisarmShowOnClickGuardOnMouseUp = false
-        shouldDisarmShowOnClickGuardWhenMouseUpArrives = false
+        pendingDisarmOnMouseUp = false
 
         showOnClickGuardTap.start()
 
@@ -749,7 +749,9 @@ extension HIDEventManager {
 
     private func expireShowOnClickGuard() {
         if shouldSwallowShowOnClickMouseUp {
-            shouldDisarmShowOnClickGuardWhenMouseUpArrives = true
+            // Mouse button is still held; defer full teardown until the
+            // swallowed mouse-up arrives so the tap stays active.
+            pendingDisarmOnMouseUp = true
             showOnClickGuardDeadline = nil
             showOnClickGuardRegion = nil
             showOnClickGuardDisplayID = nil
@@ -765,7 +767,7 @@ extension HIDEventManager {
         // This keeps the CGEventTap active until the swallowed mouse-up is processed
         // and prevents stray mouse-up delivery.
         if shouldSwallowShowOnClickMouseUp {
-            shouldDisarmShowOnClickGuardOnMouseUp = true
+            pendingDisarmOnMouseUp = true
             return
         }
 
@@ -775,23 +777,32 @@ extension HIDEventManager {
         showOnClickGuardRegion = nil
         showOnClickGuardDisplayID = nil
         shouldSwallowShowOnClickMouseUp = false
-        shouldDisarmShowOnClickGuardOnMouseUp = false
-        shouldDisarmShowOnClickGuardWhenMouseUpArrives = false
+        pendingDisarmOnMouseUp = false
         showOnClickGuardTap.stop()
     }
 
+    /// Tears down the guard if its deadline has passed. Call this before
+    /// reading `isShowOnClickGuardActive` in contexts that need to react
+    /// to expiry (e.g. the tap callback, hit-test helpers).
+    private func expireShowOnClickGuardIfNeeded() {
+        guard let deadline = showOnClickGuardDeadline, deadline <= .now else {
+            return
+        }
+        expireShowOnClickGuard()
+    }
+
+    /// Pure read — returns whether the guard is currently armed and within its
+    /// deadline. Does not mutate state; call `expireShowOnClickGuardIfNeeded()`
+    /// first if expiry should be applied.
     private var isShowOnClickGuardActive: Bool {
         guard let deadline = showOnClickGuardDeadline else {
             return false
         }
-        if deadline > .now {
-            return showOnClickGuardRegion != nil
-        }
-        disarmShowOnClickGuard()
-        return false
+        return deadline > .now && showOnClickGuardRegion != nil
     }
 
     private func isPointInsideShowOnClickGuardRegion(_ point: CGPoint) -> Bool {
+        expireShowOnClickGuardIfNeeded()
         guard isShowOnClickGuardActive,
               let region = showOnClickGuardRegion,
               let displayID = showOnClickGuardDisplayID
@@ -1106,8 +1117,9 @@ extension HIDEventManager {
                     }
                 }
                 try await Task.sleep(for: .seconds(delay))
-                // Make sure the mouse is still inside.
+                // Make sure the manager is still enabled and the mouse is still inside.
                 guard
+                    isEnabled,
                     isMouseInsideEmptyMenuBarSpace(
                         appState: appState,
                         screen: screen
@@ -1148,8 +1160,9 @@ extension HIDEventManager {
                     }
                 }
                 try await Task.sleep(for: .seconds(delay))
-                // Make sure the mouse is still outside.
+                // Make sure the manager is still enabled and the mouse is still outside.
                 guard
+                    isEnabled,
                     !isMouseInsideMenuBar(appState: appState, screen: screen),
                     !isMouseInsideIceBar(appState: appState)
                 else {

--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -719,12 +719,12 @@ extension HIDEventManager {
                 return
             }
 
-            if NSEvent.modifierFlags == .control {
+            if NSEvent.modifierFlags.contains(.control) {
                 handleSecondaryContextMenu(appState: appState, screen: screen)
                 return
             }
 
-            if NSEvent.modifierFlags == .option {
+            if NSEvent.modifierFlags.contains(.option) {
                 if appState.settings.advanced.useOptionClickToShowAlwaysHiddenSection,
                    let alwaysHiddenSection = appState.menuBarManager.section(withName: .alwaysHidden),
                    alwaysHiddenSection.isEnabled

--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -52,6 +52,10 @@ final class HIDEventManager: ObservableObject {
     private var hoverRearmTask: Task<Void, Never>?
     private var hoverRearmTaskToken: UUID?
 
+    /// Tracks the last seen value of showOnHover so the CombineLatest3 sink
+    /// can restrict rearm logic to false→true transitions only.
+    private var lastShowOnHover: Bool?
+
     /// The currently pending hover action, used to avoid restarting the same
     /// delay window on every small mouse move inside the same region.
     private var pendingHoverAction: HoverAction?
@@ -424,6 +428,8 @@ final class HIDEventManager: ObservableObject {
                     mouseMovedTap.stop()
                 }
 
+                defer { lastShowOnHover = showOnHover }
+
                 if !showOnHover {
                     hoverRearmTask?.cancel()
                     hoverRearmTask = nil
@@ -435,8 +441,16 @@ final class HIDEventManager: ObservableObject {
                     return
                 }
 
+                // Only rearm when showOnHover transitions false→true; skip the
+                // rearm path when other inputs (tooltips, display config) change
+                // while showOnHover was already enabled.
+                guard lastShowOnHover != true else {
+                    return
+                }
+
                 appState.menuBarManager.showOnHoverAllowed = true
                 hoverRearmTask?.cancel()
+                hoverRearmTask = nil
                 hoverRearmTaskToken = nil
                 hoverTask?.cancel()
                 hoverTask = nil

--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -155,7 +155,9 @@ final class HIDEventManager: ObservableObject {
             // show-on-click or smart rehide (the click belongs to the app menu)
             let isAppMenuClick = handleApplicationMenuClickThrough(appState: appState, screen: screen)
             if !isAppMenuClick {
-                handleShowOnClick(appState: appState, screen: screen, isDoubleClick: event.clickCount > 1)
+                // Capture the click location synchronously from the event.
+                let clickLocation = NSEvent.mouseLocation
+                handleShowOnClick(appState: appState, screen: screen, clickLocation: clickLocation, isDoubleClick: event.clickCount > 1)
                 handleSmartRehide(with: event, appState: appState, screen: screen)
             }
         case .rightMouseDown:
@@ -455,14 +457,16 @@ final class HIDEventManager: ObservableObject {
             // When any section's control item state changes, the menu bar layout shifts.
             // Merge all sections into a single publisher so only one cache refresh fires
             // per layout change batch, regardless of how many sections change at once.
+            // Drop the initial emission per publisher so MergeMany no longer relies on
+            // a global dropFirst count and rebuildWindowBoundsLookupFromCurrentLayout()
+            // runs only for real updates.
             Publishers.MergeMany(
-                appState.menuBarManager.sections.map { $0.controlItem.$state.replace(with: ()) }
+                appState.menuBarManager.sections.map {
+                    $0.controlItem.$state
+                        .dropFirst()
+                        .replace(with: ())
+                }
             )
-            // Ignore the initial Published emissions during startup. The item manager
-            // performs its own initial cache pass in AppState setup, and letting the
-            // section-state observer fire immediately causes an extra full menu-bar
-            // scan to preempt startup readiness.
-            .dropFirst(appState.menuBarManager.sections.count)
             .debounce(for: .milliseconds(200), scheduler: DispatchQueue.main)
             .sink { [weak self] in
                 self?.rebuildWindowBoundsLookupFromCurrentLayout()
@@ -649,7 +653,7 @@ extension HIDEventManager {
 
     // MARK: Handle Show On Click
 
-    private func handleShowOnClick(appState: AppState, screen: NSScreen, isDoubleClick: Bool = false) {
+    private func handleShowOnClick(appState: AppState, screen: NSScreen, clickLocation: CGPoint, isDoubleClick: Bool = false) {
         guard isMouseInsideEmptyMenuBarSpace(appState: appState, screen: screen) else {
             return
         }
@@ -698,7 +702,7 @@ extension HIDEventManager {
                     hiddenSection.toggle()
 
                     if shouldArmGuard {
-                        armShowOnClickGuard(screen: screen)
+                        armShowOnClickGuard(screen: screen, at: clickLocation)
                     } else {
                         disarmShowOnClickGuard()
                     }
@@ -707,11 +711,8 @@ extension HIDEventManager {
         }
     }
 
-    private func armShowOnClickGuard(screen: NSScreen) {
-        guard
-            let clickLocation = MouseHelpers.locationAppKit,
-            let menuBarHeight = screen.getMenuBarHeight()
-        else {
+    private func armShowOnClickGuard(screen: NSScreen, at clickLocation: CGPoint) {
+        guard let menuBarHeight = screen.getMenuBarHeight() else {
             disarmShowOnClickGuard()
             return
         }
@@ -760,6 +761,14 @@ extension HIDEventManager {
     }
 
     private func disarmShowOnClickGuard() {
+        // If we're waiting for a swallowed mouse-up, defer disarming until it arrives.
+        // This keeps the CGEventTap active until the swallowed mouse-up is processed
+        // and prevents stray mouse-up delivery.
+        if shouldSwallowShowOnClickMouseUp {
+            shouldDisarmShowOnClickGuardOnMouseUp = true
+            return
+        }
+
         clickTask?.cancel()
         clickTask = nil
         showOnClickGuardDeadline = nil

--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -770,6 +770,9 @@ extension HIDEventManager {
         showOnClickGuardDeadline = .now + .seconds(NSEvent.doubleClickInterval)
         guardMouseUpState = .idle
 
+        // Validate (and recreate if needed) before enabling; a stale Mach port
+        // would silently no-op on start() and leave the guard tap inactive.
+        showOnClickGuardTap.ensureValid()
         showOnClickGuardTap.start()
 
         clickTask?.cancel()

--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -42,6 +42,28 @@ final class HIDEventManager: ObservableObject {
     /// The currently pending show-on-hover delay task.
     private var hoverTask: Task<Void, any Error>?
 
+    /// The pending task that clears the temporary show-on-click guard.
+    private var clickTask: Task<Void, Never>?
+
+    /// The deadline for the temporary show-on-click protection region.
+    private var showOnClickGuardDeadline: ContinuousClock.Instant?
+
+    /// The temporary protected region around the first click that revealed
+    /// hidden items. Clicks inside this region are intercepted until the
+    /// system double-click window expires.
+    private var showOnClickGuardRegion: CGRect?
+
+    /// The display hosting the current protected region.
+    private var showOnClickGuardDisplayID: CGDirectDisplayID?
+
+    /// Whether the next left-mouse-up should also be swallowed after the
+    /// guard consumed a left-mouse-down.
+    private var shouldSwallowShowOnClickMouseUp = false
+
+    /// Whether the guard should be torn down immediately after the matching
+    /// swallowed mouse-up arrives.
+    private var shouldDisarmShowOnClickGuardOnMouseUp = false
+
     /// The number of times the manager has been told to stop.
     private var disableCount = 0
 
@@ -202,6 +224,58 @@ final class HIDEventManager: ObservableObject {
             handleShowOnScroll(with: event, appState: appState, screen: screen)
         }
         return event
+    }
+
+    /// Active tap that temporarily swallows clicks in the protected region
+    /// after a first show-on-click reveal, so a double-click can still be
+    /// recognized even though hidden items have appeared under the cursor.
+    private(set) lazy var showOnClickGuardTap = EventTap(
+        label: "showOnClickGuardTap",
+        types: [.leftMouseDown, .leftMouseUp],
+        location: .sessionEventTap,
+        placement: .headInsertEventTap,
+        option: .defaultTap
+    ) { [weak self] _, event in
+        guard let self else {
+            return event
+        }
+
+        if event.type == .leftMouseUp, shouldSwallowShowOnClickMouseUp {
+            shouldSwallowShowOnClickMouseUp = false
+            let shouldDisarm = shouldDisarmShowOnClickGuardOnMouseUp
+            shouldDisarmShowOnClickGuardOnMouseUp = false
+            if shouldDisarm {
+                disarmShowOnClickGuard()
+            }
+            return nil
+        }
+
+        guard isEnabled, let appState, isShowOnClickGuardActive else {
+            return event
+        }
+
+        guard event.type == .leftMouseDown else {
+            return event
+        }
+
+        guard isPointInsideShowOnClickGuardRegion(NSEvent.mouseLocation) else {
+            return event
+        }
+
+        shouldSwallowShowOnClickMouseUp = true
+
+        let clickState = event.getIntegerValueField(.mouseEventClickState)
+        if clickState > 1,
+           appState.settings.general.showOnClick,
+           appState.settings.general.showOnDoubleClick,
+           let alwaysHiddenSection = appState.menuBarManager.section(withName: .alwaysHidden),
+           alwaysHiddenSection.isEnabled
+        {
+            alwaysHiddenSection.show()
+            shouldDisarmShowOnClickGuardOnMouseUp = true
+        }
+
+        return nil
     }
 
     // MARK: All Monitors
@@ -421,6 +495,7 @@ final class HIDEventManager: ObservableObject {
         }
         disableCount += 1
         lastStopTimestamp = .now
+        disarmShowOnClickGuard()
         dismissMenuBarTooltip()
     }
 }
@@ -471,10 +546,92 @@ extension HIDEventManager {
                 if let hiddenSection = appState.menuBarManager.section(withName: .hidden),
                    hiddenSection.isEnabled
                 {
+                    let shouldArmGuard =
+                        appState.settings.general.showOnDoubleClick
+                        && hiddenSection.isHidden
+                        && (appState.menuBarManager.section(withName: .alwaysHidden)?.isEnabled ?? false)
+
                     hiddenSection.toggle()
+
+                    if shouldArmGuard {
+                        armShowOnClickGuard(screen: screen)
+                    } else {
+                        disarmShowOnClickGuard()
+                    }
                 }
             }
         }
+    }
+
+    private func armShowOnClickGuard(screen: NSScreen) {
+        guard
+            let clickLocation = MouseHelpers.locationAppKit,
+            let menuBarHeight = screen.getMenuBarHeight()
+        else {
+            disarmShowOnClickGuard()
+            return
+        }
+
+        let protectionWidth = max(44, menuBarHeight * 2)
+        let protectionHeight = menuBarHeight + 6
+        let minY = screen.frame.maxY - menuBarHeight - 3
+        showOnClickGuardRegion = CGRect(
+            x: clickLocation.x - protectionWidth / 2,
+            y: minY,
+            width: protectionWidth,
+            height: protectionHeight
+        )
+        showOnClickGuardDisplayID = screen.displayID
+        showOnClickGuardDeadline = .now + .seconds(NSEvent.doubleClickInterval)
+        shouldSwallowShowOnClickMouseUp = false
+        shouldDisarmShowOnClickGuardOnMouseUp = false
+
+        showOnClickGuardTap.start()
+
+        clickTask?.cancel()
+        clickTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(NSEvent.doubleClickInterval))
+            await MainActor.run {
+                self?.disarmShowOnClickGuard()
+            }
+        }
+    }
+
+    private func disarmShowOnClickGuard() {
+        clickTask?.cancel()
+        clickTask = nil
+        showOnClickGuardDeadline = nil
+        showOnClickGuardRegion = nil
+        showOnClickGuardDisplayID = nil
+        shouldSwallowShowOnClickMouseUp = false
+        shouldDisarmShowOnClickGuardOnMouseUp = false
+        showOnClickGuardTap.stop()
+    }
+
+    private var isShowOnClickGuardActive: Bool {
+        guard let deadline = showOnClickGuardDeadline else {
+            return false
+        }
+        if deadline > .now {
+            return showOnClickGuardRegion != nil
+        }
+        disarmShowOnClickGuard()
+        return false
+    }
+
+    private func isPointInsideShowOnClickGuardRegion(_ point: CGPoint) -> Bool {
+        guard isShowOnClickGuardActive,
+              let region = showOnClickGuardRegion,
+              let displayID = showOnClickGuardDisplayID
+        else {
+            return false
+        }
+
+        guard NSScreen.screenWithMouse?.displayID == displayID else {
+            return false
+        }
+
+        return region.contains(point)
     }
 
     // MARK: Handle Smart Rehide

--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -78,6 +78,9 @@ final class HIDEventManager: ObservableObject {
     /// swallowed mouse-up arrives.
     private var shouldDisarmShowOnClickGuardOnMouseUp = false
 
+    /// Whether guard teardown is pending until the swallowed mouse-up arrives.
+    private var shouldDisarmShowOnClickGuardWhenMouseUpArrives = false
+
     /// The number of times the manager has been told to stop.
     private var disableCount = 0
 
@@ -261,8 +264,10 @@ final class HIDEventManager: ObservableObject {
 
         if event.type == .leftMouseUp, shouldSwallowShowOnClickMouseUp {
             shouldSwallowShowOnClickMouseUp = false
-            let shouldDisarm = shouldDisarmShowOnClickGuardOnMouseUp
+            let shouldDisarm = shouldDisarmShowOnClickGuardOnMouseUp ||
+                shouldDisarmShowOnClickGuardWhenMouseUpArrives
             shouldDisarmShowOnClickGuardOnMouseUp = false
+            shouldDisarmShowOnClickGuardWhenMouseUpArrives = false
             if shouldDisarm {
                 disarmShowOnClickGuard()
             }
@@ -724,6 +729,7 @@ extension HIDEventManager {
         showOnClickGuardDeadline = .now + .seconds(NSEvent.doubleClickInterval)
         shouldSwallowShowOnClickMouseUp = false
         shouldDisarmShowOnClickGuardOnMouseUp = false
+        shouldDisarmShowOnClickGuardWhenMouseUpArrives = false
 
         showOnClickGuardTap.start()
 
@@ -735,9 +741,22 @@ extension HIDEventManager {
                 return
             }
             await MainActor.run {
-                self?.disarmShowOnClickGuard()
+                self?.expireShowOnClickGuard()
             }
         }
+    }
+
+    private func expireShowOnClickGuard() {
+        if shouldSwallowShowOnClickMouseUp {
+            shouldDisarmShowOnClickGuardWhenMouseUpArrives = true
+            showOnClickGuardDeadline = nil
+            showOnClickGuardRegion = nil
+            showOnClickGuardDisplayID = nil
+            clickTask = nil
+            return
+        }
+
+        disarmShowOnClickGuard()
     }
 
     private func disarmShowOnClickGuard() {
@@ -748,6 +767,7 @@ extension HIDEventManager {
         showOnClickGuardDisplayID = nil
         shouldSwallowShowOnClickMouseUp = false
         shouldDisarmShowOnClickGuardOnMouseUp = false
+        shouldDisarmShowOnClickGuardWhenMouseUpArrives = false
         showOnClickGuardTap.stop()
     }
 

--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -1470,7 +1470,7 @@ extension HIDEventManager {
         }
 
         return !isInAppMenu
-            && !isMouseInsideCachedMenuBarItem()
+            && !isMouseInsideMenuBarItem(appState: appState, screen: screen)
             && !isMouseInsideIceIcon(appState: appState)
     }
 

--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -70,13 +70,19 @@ final class HIDEventManager: ObservableObject {
     /// The display hosting the current protected region.
     private var showOnClickGuardDisplayID: CGDirectDisplayID?
 
-    /// Whether the next left-mouse-up should also be swallowed after the
-    /// guard consumed a left-mouse-down.
-    private var shouldSwallowShowOnClickMouseUp = false
+    /// Tracks the state of the swallow/disarm lifecycle for the click guard tap.
+    private enum GuardMouseUpState {
+        /// No mouse-down has been swallowed; guard tap is idle between clicks.
+        case idle
+        /// A mouse-down was swallowed; swallow the matching mouse-up but keep
+        /// the guard armed afterward (double-click window still open).
+        case swallowing
+        /// A mouse-down was swallowed and teardown is pending; swallow the
+        /// matching mouse-up then fully disarm the guard.
+        case swallowingThenDisarm
+    }
 
-    /// Whether guard teardown should occur once the swallowed mouse-up arrives.
-    /// Consolidates the two previous deferred-disarm flags.
-    private var pendingDisarmOnMouseUp = false
+    private var guardMouseUpState: GuardMouseUpState = .idle
 
     /// The number of times the manager has been told to stop.
     private var disableCount = 0
@@ -263,11 +269,10 @@ final class HIDEventManager: ObservableObject {
 
         expireShowOnClickGuardIfNeeded()
 
-        if event.type == .leftMouseUp, shouldSwallowShowOnClickMouseUp {
-            shouldSwallowShowOnClickMouseUp = false
-            let shouldDisarm = pendingDisarmOnMouseUp
-            pendingDisarmOnMouseUp = false
-            if shouldDisarm {
+        if event.type == .leftMouseUp, guardMouseUpState != .idle {
+            let state = guardMouseUpState
+            guardMouseUpState = .idle
+            if state == .swallowingThenDisarm {
                 disarmShowOnClickGuard()
             }
             return nil
@@ -285,8 +290,6 @@ final class HIDEventManager: ObservableObject {
             return event
         }
 
-        shouldSwallowShowOnClickMouseUp = true
-
         let clickState = event.getIntegerValueField(.mouseEventClickState)
         if clickState > 1,
            appState.settings.general.showOnClick,
@@ -295,7 +298,9 @@ final class HIDEventManager: ObservableObject {
            alwaysHiddenSection.isEnabled
         {
             alwaysHiddenSection.show()
-            pendingDisarmOnMouseUp = true
+            guardMouseUpState = .swallowingThenDisarm
+        } else {
+            guardMouseUpState = .swallowing
         }
 
         return nil
@@ -729,8 +734,7 @@ extension HIDEventManager {
         )
         showOnClickGuardDisplayID = screen.displayID
         showOnClickGuardDeadline = .now + .seconds(NSEvent.doubleClickInterval)
-        shouldSwallowShowOnClickMouseUp = false
-        pendingDisarmOnMouseUp = false
+        guardMouseUpState = .idle
 
         showOnClickGuardTap.start()
 
@@ -748,10 +752,10 @@ extension HIDEventManager {
     }
 
     private func expireShowOnClickGuard() {
-        if shouldSwallowShowOnClickMouseUp {
+        if guardMouseUpState != .idle {
             // Mouse button is still held; defer full teardown until the
             // swallowed mouse-up arrives so the tap stays active.
-            pendingDisarmOnMouseUp = true
+            guardMouseUpState = .swallowingThenDisarm
             showOnClickGuardDeadline = nil
             showOnClickGuardRegion = nil
             showOnClickGuardDisplayID = nil
@@ -765,9 +769,9 @@ extension HIDEventManager {
     private func disarmShowOnClickGuard() {
         // If we're waiting for a swallowed mouse-up, defer disarming until it arrives.
         // This keeps the CGEventTap active until the swallowed mouse-up is processed
-        // and prevents stray mouse-up delivery.
-        if shouldSwallowShowOnClickMouseUp {
-            pendingDisarmOnMouseUp = true
+        // and prevents a stray mouse-up being delivered to the system.
+        if guardMouseUpState != .idle {
+            guardMouseUpState = .swallowingThenDisarm
             return
         }
 
@@ -776,8 +780,7 @@ extension HIDEventManager {
         showOnClickGuardDeadline = nil
         showOnClickGuardRegion = nil
         showOnClickGuardDisplayID = nil
-        shouldSwallowShowOnClickMouseUp = false
-        pendingDisarmOnMouseUp = false
+        guardMouseUpState = .idle
         showOnClickGuardTap.stop()
     }
 

--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -42,6 +42,10 @@ final class HIDEventManager: ObservableObject {
     /// The currently pending show-on-hover delay task.
     private var hoverTask: Task<Void, any Error>?
 
+    /// Identity token for the current hover task so an older task cannot
+    /// clear state that belongs to a newer one.
+    private var hoverTaskToken: UUID?
+
     /// The currently pending hover action, used to avoid restarting the same
     /// delay window on every small mouse move inside the same region.
     private var pendingHoverAction: HoverAction?
@@ -408,6 +412,7 @@ final class HIDEventManager: ObservableObject {
                 if !showOnHover {
                     hoverTask?.cancel()
                     hoverTask = nil
+                    hoverTaskToken = nil
                     pendingHoverAction = nil
                     return
                 }
@@ -415,6 +420,7 @@ final class HIDEventManager: ObservableObject {
                 appState.menuBarManager.showOnHoverAllowed = true
                 hoverTask?.cancel()
                 hoverTask = nil
+                hoverTaskToken = nil
                 pendingHoverAction = nil
 
                 Task { @MainActor [weak self, weak appState] in
@@ -654,7 +660,11 @@ extension HIDEventManager {
 
         clickTask?.cancel()
         clickTask = Task { [weak self] in
-            try? await Task.sleep(for: .seconds(NSEvent.doubleClickInterval))
+            do {
+                try await Task.sleep(for: .seconds(NSEvent.doubleClickInterval))
+            } catch {
+                return
+            }
             await MainActor.run {
                 self?.disarmShowOnClickGuard()
             }
@@ -975,6 +985,7 @@ extension HIDEventManager {
                 if pendingHoverAction == .show {
                     hoverTask?.cancel()
                     hoverTask = nil
+                    hoverTaskToken = nil
                     pendingHoverAction = nil
                 }
                 return
@@ -984,11 +995,16 @@ extension HIDEventManager {
             }
             hoverTask?.cancel()
             pendingHoverAction = .show
+            let taskToken = UUID()
+            hoverTaskToken = taskToken
             hoverTask = Task {
                 defer {
-                    hoverTask = nil
-                    if pendingHoverAction == .show {
-                        pendingHoverAction = nil
+                    if hoverTaskToken == taskToken {
+                        hoverTask = nil
+                        hoverTaskToken = nil
+                        if pendingHoverAction == .show {
+                            pendingHoverAction = nil
+                        }
                     }
                 }
                 try await Task.sleep(for: .seconds(delay))
@@ -1011,6 +1027,7 @@ extension HIDEventManager {
                 if pendingHoverAction == .hide {
                     hoverTask?.cancel()
                     hoverTask = nil
+                    hoverTaskToken = nil
                     pendingHoverAction = nil
                 }
                 return
@@ -1020,11 +1037,16 @@ extension HIDEventManager {
             }
             hoverTask?.cancel()
             pendingHoverAction = .hide
+            let taskToken = UUID()
+            hoverTaskToken = taskToken
             hoverTask = Task {
                 defer {
-                    hoverTask = nil
-                    if pendingHoverAction == .hide {
-                        pendingHoverAction = nil
+                    if hoverTaskToken == taskToken {
+                        hoverTask = nil
+                        hoverTaskToken = nil
+                        if pendingHoverAction == .hide {
+                            pendingHoverAction = nil
+                        }
                     }
                 }
                 try await Task.sleep(for: .seconds(delay))

--- a/Thaw/Main/AppState.swift
+++ b/Thaw/Main/AppState.swift
@@ -100,7 +100,7 @@ final class AppState: ObservableObject {
         hidEventManager.performSetup(with: self)
         diagLog.debug("setupTask: starting itemManager setup")
         await itemManager.performSetup(with: self)
-        diagLog.debug("setupTask: itemManager setup complete, invalidating menuBarHeightCache")
+        diagLog.debug("setupTask: itemManager setup scheduled, invalidating menuBarHeightCache")
         NSScreen.invalidateMenuBarHeightCache()
         diagLog.debug("setupTask: starting imageCache setup")
         imageCache.performSetup(with: self)

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItem.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItem.swift
@@ -285,9 +285,81 @@ extension MenuBarItem {
     ///   - option: Options that filter the returned list. Pass an empty option set
     ///     to return all available menu bar items.
     @MainActor
-    static func getMenuBarItems(on display: CGDirectDisplayID? = nil, option: ListOption) async -> [MenuBarItem] {
+    private static func assignStableInstanceIndices(
+        to items: inout [MenuBarItem],
+        using windows: [WindowInfo]
+    ) {
+        // Final pass: assign instance indices to allow individual identification
+        // of items with the same (namespace, title). Sort by windowID within each
+        // group so that indices are stable regardless of item position changes
+        // (e.g. dragging between sections). This prevents image cache collisions
+        // caused by instanceIndex values swapping between cache cycles.
+        var groups = [String: [Int]]()
+        for i in 0 ..< items.count {
+            let key = "\(items[i].tag.namespace):\(items[i].tag.title)"
+            groups[key, default: []].append(i)
+        }
+        for (_, indices) in groups where indices.count > 1 {
+            let sorted = indices.sorted { items[$0].windowID < items[$1].windowID }
+            for (instanceIndex, itemIndex) in sorted.enumerated() where instanceIndex > 0 {
+                if let sourcePID = items[itemIndex].sourcePID {
+                    items[itemIndex] = MenuBarItem(
+                        uncheckedItemWindow: windows[itemIndex],
+                        sourcePID: sourcePID,
+                        instanceIndex: instanceIndex
+                    )
+                } else {
+                    items[itemIndex] = MenuBarItem(
+                        uncheckedItemWindow: windows[itemIndex],
+                        instanceIndex: instanceIndex
+                    )
+                }
+            }
+        }
+    }
+
+    @available(macOS 26.0, *)
+    @MainActor
+    private static func makeItemsWithoutResolvingSourcePID(
+        from windows: [WindowInfo]
+    ) -> [MenuBarItem] {
+        var items = windows.map { window in
+            if let title = window.title, title.hasPrefix("Thaw.ControlItem.") {
+                let ccBundleID = "com.apple.controlcenter"
+                if window.owningApplication?.bundleIdentifier == ccBundleID ||
+                    window.ownerPID == ProcessInfo.processInfo.processIdentifier
+                {
+                    return MenuBarItem(
+                        uncheckedItemWindow: window,
+                        sourcePID: ProcessInfo.processInfo.processIdentifier
+                    )
+                }
+            }
+
+            return MenuBarItem(uncheckedItemWindow: window, sourcePID: nil)
+        }
+
+        assignStableInstanceIndices(to: &items, using: windows)
+        let nilPIDCount = items.filter { $0.sourcePID == nil }.count
+        diagLog.debug(
+            "getMenuBarItemsExperimental: created \(items.count) items without sourcePID resolution, \(nilPIDCount) unresolved"
+        )
+        return items
+    }
+
+    @available(macOS 26.0, *)
+    @MainActor
+    private static func getMenuBarItemsExperimental(
+        on display: CGDirectDisplayID?,
+        option: ListOption,
+        resolveSourcePID: Bool
+    ) async -> [MenuBarItem] {
         let windows = getMenuBarItemWindows(on: display, option: option)
         diagLog.debug("getMenuBarItems: processing \(windows.count) windows for source PID resolution")
+
+        guard resolveSourcePID else {
+            return makeItemsWithoutResolvingSourcePID(from: windows)
+        }
 
         var items = await withTaskGroup(of: (Int, MenuBarItem).self) { group in
             for (index, window) in windows.enumerated() {
@@ -379,26 +451,7 @@ extension MenuBarItem {
             }
         }
 
-        // Final pass: assign instance indices to allow individual identification
-        // of items with the same (namespace, title). Sort by windowID within each
-        // group so that indices are stable regardless of item position changes
-        // (e.g. dragging between sections). This prevents image cache collisions
-        // caused by instanceIndex values swapping between cache cycles.
-        var groups = [String: [Int]]()
-        for i in 0 ..< items.count {
-            let key = "\(items[i].tag.namespace):\(items[i].tag.title)"
-            groups[key, default: []].append(i)
-        }
-        for (_, indices) in groups where indices.count > 1 {
-            let sorted = indices.sorted { items[$0].windowID < items[$1].windowID }
-            for (instanceIndex, itemIndex) in sorted.enumerated() where instanceIndex > 0 {
-                if let sourcePID = items[itemIndex].sourcePID {
-                    items[itemIndex] = MenuBarItem(uncheckedItemWindow: windows[itemIndex], sourcePID: sourcePID, instanceIndex: instanceIndex)
-                } else {
-                    items[itemIndex] = MenuBarItem(uncheckedItemWindow: windows[itemIndex], instanceIndex: instanceIndex)
-                }
-            }
-        }
+        assignStableInstanceIndices(to: &items, using: windows)
 
         let nilPIDItems = items.filter { $0.sourcePID == nil }
         if !nilPIDItems.isEmpty {
@@ -408,6 +461,31 @@ extension MenuBarItem {
         } else {
             diagLog.debug("getMenuBarItems: created \(items.count) items, all with resolved sourcePID")
         }
+        return items
+    }
+
+    /// Creates and returns a list of menu bar items for the given display.
+    ///
+    /// - Parameters:
+    ///   - display: An identifier for a display. Pass `nil` to return the menu bar
+    ///     items across all available displays.
+    ///   - option: Options that filter the returned list. Pass an empty option set
+    ///     to return all available menu bar items.
+    @MainActor
+    static func getMenuBarItems(
+        on display: CGDirectDisplayID? = nil,
+        option: ListOption,
+        resolveSourcePID: Bool = true
+    ) async -> [MenuBarItem] {
+        diagLog.debug(
+            "getMenuBarItems: starting (resolveSourcePID=\(resolveSourcePID))"
+        )
+        let items = await getMenuBarItemsExperimental(
+            on: display,
+            option: option,
+            resolveSourcePID: resolveSourcePID
+        )
+        diagLog.debug("getMenuBarItems: returned \(items.count) items")
         return items
     }
 }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItem.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItem.swift
@@ -311,6 +311,7 @@ extension MenuBarItem {
                 } else {
                     items[itemIndex] = MenuBarItem(
                         uncheckedItemWindow: windows[itemIndex],
+                        sourcePID: nil,
                         instanceIndex: instanceIndex
                     )
                 }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -762,7 +762,7 @@ final class MenuBarItemManager: ObservableObject {
             guard let self else { return }
             await self.initialCacheTask?.value
             do {
-                if .now < deadline {
+                if deadline > .now {
                     try await Task.sleep(until: deadline, clock: .continuous)
                 }
             } catch {
@@ -4191,7 +4191,9 @@ extension MenuBarItemManager {
                 resolvedPIDs = await withTaskGroup(of: pid_t?.self, returning: Set<pid_t>.self) { group in
                     for window in unresolvedWindows {
                         group.addTask {
-                            await MenuBarItemService.Connection.shared.sourcePID(for: window)
+                            try? await Task<pid_t?, any Error>.withTimeout(.seconds(2)) {
+                                await MenuBarItemService.Connection.shared.sourcePID(for: window)
+                            }
                         }
                     }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -4095,32 +4095,128 @@ extension MenuBarItemManager {
             return await existingTask.value
         }
 
-        let task = Task.detached(priority: .utility) { () -> Bool in
-            // Get all menu bar items that are currently on screen.
-            let items = await MenuBarItem.getMenuBarItems(option: .onScreen)
-            let sourcePIDs = Set(items.compactMap { $0.sourcePID })
+        let cachedItems = itemCache.managedItems.filter(\.isOnScreen)
+        let controlCenterBundleID = MenuBarItemTag.Namespace.controlCenter.description
 
+        let task = Task.detached(priority: .utility) { () -> Bool in
             // Get all on-screen windows.
             let windows = WindowInfo.createWindows(option: .onScreen)
-
-            MenuBarItemManager.diagLog.debug("Checking for open menus - Found \(items.count) menu bar items with PIDs: \(sourcePIDs)")
-
-            // Check if any of the items' owning applications have a menu-related window.
-            let result = windows.contains { window in
-                // Skip Control Center windows as they can be falsely detected when hovering
-                guard window.owningApplication?.bundleIdentifier != MenuBarItemTag.Namespace.controlCenter.description else {
-                    MenuBarItemManager.diagLog.debug("Skipping Control Center window: PID \(window.ownerPID), title: \(window.title ?? "nil")")
+            let potentialMenuWindows = windows.filter { window in
+                guard window.isMenuRelated, window.title?.isEmpty ?? true else {
                     return false
                 }
+                guard window.owningApplication?.bundleIdentifier != controlCenterBundleID else {
+                    MenuBarItemManager.diagLog.debug(
+                        "Skipping Control Center window: PID \(window.ownerPID), title: \(window.title ?? "nil")"
+                    )
+                    return false
+                }
+                return true
+            }
 
-                let isMenuOpen = sourcePIDs.contains(window.ownerPID) && window.isMenuRelated && (window.title?.isEmpty ?? true)
+            guard !potentialMenuWindows.isEmpty else {
+                MenuBarItemManager.diagLog.debug(
+                    "Menu open check: no candidate menu windows on screen"
+                )
+                return false
+            }
+
+            let fastPathPIDs = Set(cachedItems.compactMap { item -> pid_t? in
+                if let sourcePID = item.sourcePID {
+                    return sourcePID
+                }
+                guard item.owningApplication?.bundleIdentifier != controlCenterBundleID else {
+                    return nil
+                }
+                return item.ownerPID
+            })
+
+            MenuBarItemManager.diagLog.debug(
+                """
+                Checking for open menus - fast path with \(cachedItems.count) cached menu bar items, \
+                \(fastPathPIDs.count) candidate PIDs, \(potentialMenuWindows.count) candidate menu windows
+                """
+            )
+
+            let fastPathResult = potentialMenuWindows.contains { window in
+                let isMenuOpen = fastPathPIDs.contains(window.ownerPID)
                 if isMenuOpen {
-                    MenuBarItemManager.diagLog.debug("Found open menu window: PID \(window.ownerPID), owner: \(window.ownerName as NSObject?), title: \(window.title ?? "nil"), isMenuRelated: \(window.isMenuRelated)")
+                    MenuBarItemManager.diagLog.debug(
+                        """
+                        Found open menu window on fast path: PID \(window.ownerPID), \
+                        owner: \(window.ownerName as NSObject?), title: \(window.title ?? "nil"), \
+                        isMenuRelated: \(window.isMenuRelated)
+                        """
+                    )
                 }
                 return isMenuOpen
             }
 
-            MenuBarItemManager.diagLog.debug("Menu open check result: \(result)")
+            if fastPathResult {
+                MenuBarItemManager.diagLog.debug("Menu open check result: true (fast path)")
+                return true
+            }
+
+            let unresolvedWindows = WindowInfo.createWindows(
+                from: cachedItems.compactMap { item in
+                    guard item.sourcePID == nil, !item.isControlItem else {
+                        return nil
+                    }
+                    guard item.owningApplication?.bundleIdentifier == controlCenterBundleID else {
+                        return nil
+                    }
+                    return item.windowID
+                }
+            )
+
+            guard !unresolvedWindows.isEmpty else {
+                MenuBarItemManager.diagLog.debug("Menu open check result: false (fast path)")
+                return false
+            }
+
+            MenuBarItemManager.diagLog.debug(
+                "Menu open check: precise fallback resolving \(unresolvedWindows.count) unresolved window source PIDs"
+            )
+
+            let resolvedPIDs: Set<pid_t>
+            if #available(macOS 26.0, *) {
+                resolvedPIDs = await withTaskGroup(of: pid_t?.self, returning: Set<pid_t>.self) { group in
+                    for window in unresolvedWindows {
+                        group.addTask {
+                            await MenuBarItemService.Connection.shared.sourcePID(for: window)
+                        }
+                    }
+
+                    var pids = Set<pid_t>()
+                    for await pid in group {
+                        if let pid {
+                            pids.insert(pid)
+                        }
+                    }
+                    return pids
+                }
+            } else {
+                resolvedPIDs = []
+            }
+
+            let precisePIDs = fastPathPIDs.union(resolvedPIDs)
+            let result = potentialMenuWindows.contains { window in
+                let isMenuOpen = precisePIDs.contains(window.ownerPID)
+                if isMenuOpen {
+                    MenuBarItemManager.diagLog.debug(
+                        """
+                        Found open menu window on precise fallback: PID \(window.ownerPID), \
+                        owner: \(window.ownerName as NSObject?), title: \(window.title ?? "nil"), \
+                        isMenuRelated: \(window.isMenuRelated)
+                        """
+                    )
+                }
+                return isMenuOpen
+            }
+
+            MenuBarItemManager.diagLog.debug(
+                "Menu open check result: \(result) (precise fallback with \(resolvedPIDs.count) resolved PIDs)"
+            )
             return result
         }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -718,6 +718,11 @@ final class MenuBarItemManager: ObservableObject {
                             "performSetup: fast initial cache succeeded on retry \(attempt)"
                         )
                     }
+                    // Fast path succeeded; kick off authoritative PID resolution
+                    // concurrently so we don't block restore logic.
+                    Task { @MainActor [weak self] in
+                        await self?.cacheItemsRegardless(resolveSourcePID: true)
+                    }
                     break
                 }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -780,6 +780,9 @@ final class MenuBarItemManager: ObservableObject {
             // may have stamped lastMoveOperationTimestamp during settling; without this
             // flag the final restore would be silently skipped by the 5 s cooldown.
             await cacheItemsRegardless(skipRecentMoveCheck: true, resolveSourcePID: false)
+            // Final authoritative recache that resolves source PIDs so items used later
+            // (which read item.sourcePID ?? item.ownerPID) reflect the true source PID.
+            await cacheItemsRegardless(resolveSourcePID: true)
         }
         MenuBarItemManager.diagLog.debug("performSetup: MenuBarItemManager setup complete")
     }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -702,12 +702,15 @@ final class MenuBarItemManager: ObservableObject {
         configureCancellables(with: appState)
         initialCacheTask?.cancel()
         MenuBarItemManager.diagLog.debug("performSetup: scheduling initial cacheItemsRegardless off the startup critical path")
-        let initialCacheTask = Task { @MainActor [weak self] in
+        self.initialCacheTask = Task { @MainActor [weak self] in
             guard let self else { return }
             MenuBarItemManager.diagLog.debug(
                 "performSetup: initial cacheItemsRegardless started (fast path without sourcePID resolution)"
             )
             for attempt in 1 ... 10 {
+                if Task.isCancelled {
+                    return
+                }
                 await cacheItemsRegardless(resolveSourcePID: false)
                 if itemCache.displayID != nil {
                     if attempt > 1 {
@@ -721,11 +724,16 @@ final class MenuBarItemManager: ObservableObject {
                 MenuBarItemManager.diagLog.debug(
                     "performSetup: fast initial cache missing control items on attempt \(attempt), retrying shortly"
                 )
-                try? await Task.sleep(for: .milliseconds(100))
+                do {
+                    try await Task.sleep(for: .milliseconds(100))
+                } catch is CancellationError {
+                    return
+                } catch {
+                    return
+                }
             }
             MenuBarItemManager.diagLog.debug("performSetup: initial cache complete, items in cache: visible=\(itemCache[.visible].count), hidden=\(itemCache[.hidden].count), alwaysHidden=\(itemCache[.alwaysHidden].count), managedItems=\(itemCache.managedItems.count)")
         }
-        self.initialCacheTask = initialCacheTask
         // Suppress restore and section-order saves for a settling period after launch.
         // During login (system uptime < 60 s) many apps load over ~30 s, each triggering
         // a cache cycle; without this guard every launch notification causes a restore
@@ -752,7 +760,7 @@ final class MenuBarItemManager: ObservableObject {
         // interleaved with notification-triggered cache cycles between them.
         startupSettlingTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            await initialCacheTask.value
+            await self.initialCacheTask?.value
             do {
                 if .now < deadline {
                     try await Task.sleep(until: deadline, clock: .continuous)
@@ -4084,10 +4092,10 @@ extension MenuBarItemManager {
 
         if let cachedAt = menuOpenCheckCachedAt,
            cachedAt.duration(to: .now) <= cacheFreshness,
-           let cachedResult = menuOpenCheckCachedResult
+           menuOpenCheckCachedResult == true
         {
-            MenuBarItemManager.diagLog.debug("Menu open check: using cached result \(cachedResult)")
-            return cachedResult
+            MenuBarItemManager.diagLog.debug("Menu open check: using cached result true")
+            return true
         }
 
         if let existingTask = menuOpenCheckTask {
@@ -4223,8 +4231,13 @@ extension MenuBarItemManager {
         menuOpenCheckTask = task
         let result = await task.value
         menuOpenCheckTask = nil
-        menuOpenCheckCachedResult = result
-        menuOpenCheckCachedAt = .now
+        if result {
+            menuOpenCheckCachedResult = true
+            menuOpenCheckCachedAt = .now
+        } else {
+            menuOpenCheckCachedResult = nil
+            menuOpenCheckCachedAt = nil
+        }
         return result
     }
 }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -132,6 +132,14 @@ final class MenuBarItemManager: ObservableObject {
     /// Storage for internal observers.
     private var cancellables = Set<AnyCancellable>()
 
+    /// The currently running "is any menu open" probe, reused so concurrent
+    /// smart-rehide callers do not all trigger their own full menu-bar scan.
+    private var menuOpenCheckTask: Task<Bool, Never>?
+
+    /// The most recent open-menu probe result and its timestamp.
+    private var menuOpenCheckCachedResult: Bool?
+    private var menuOpenCheckCachedAt: ContinuousClock.Instant?
+
     /// Timer for lightweight periodic cache checks.
     private var cacheTickCancellable: AnyCancellable?
 
@@ -157,6 +165,9 @@ final class MenuBarItemManager: ObservableObject {
     /// subsequent performSetup() call can cancel the previous settling period
     /// before starting a new one, preventing multiple concurrent settling tasks.
     private var startupSettlingTask: Task<Void, Never>?
+    /// Handle to the initial cache warm-up task. The first full cache can be
+    /// expensive on dense menu bars, so it runs off the startup critical path.
+    private var initialCacheTask: Task<Void, Never>?
     /// Absolute deadline for the current startup settling period. Stored so
     /// that a re-entry of performSetup() (e.g. permission re-grant) can
     /// preserve any remaining time from the original period rather than
@@ -688,10 +699,33 @@ final class MenuBarItemManager: ObservableObject {
         // On first launch (no known identifiers), avoid auto-relocating the leftmost item
         // so everything remains in the hidden section until the user interacts.
         suppressNextNewLeftmostItemRelocation = knownItemIdentifiers.isEmpty
-        MenuBarItemManager.diagLog.debug("performSetup: calling initial cacheItemsRegardless")
-        await cacheItemsRegardless()
-        MenuBarItemManager.diagLog.debug("performSetup: initial cache complete, items in cache: visible=\(itemCache[.visible].count), hidden=\(itemCache[.hidden].count), alwaysHidden=\(itemCache[.alwaysHidden].count), managedItems=\(itemCache.managedItems.count)")
         configureCancellables(with: appState)
+        initialCacheTask?.cancel()
+        MenuBarItemManager.diagLog.debug("performSetup: scheduling initial cacheItemsRegardless off the startup critical path")
+        let initialCacheTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            MenuBarItemManager.diagLog.debug(
+                "performSetup: initial cacheItemsRegardless started (fast path without sourcePID resolution)"
+            )
+            for attempt in 1 ... 10 {
+                await cacheItemsRegardless(resolveSourcePID: false)
+                if itemCache.displayID != nil {
+                    if attempt > 1 {
+                        MenuBarItemManager.diagLog.debug(
+                            "performSetup: fast initial cache succeeded on retry \(attempt)"
+                        )
+                    }
+                    break
+                }
+
+                MenuBarItemManager.diagLog.debug(
+                    "performSetup: fast initial cache missing control items on attempt \(attempt), retrying shortly"
+                )
+                try? await Task.sleep(for: .milliseconds(100))
+            }
+            MenuBarItemManager.diagLog.debug("performSetup: initial cache complete, items in cache: visible=\(itemCache[.visible].count), hidden=\(itemCache[.hidden].count), alwaysHidden=\(itemCache[.alwaysHidden].count), managedItems=\(itemCache.managedItems.count)")
+        }
+        self.initialCacheTask = initialCacheTask
         // Suppress restore and section-order saves for a settling period after launch.
         // During login (system uptime < 60 s) many apps load over ~30 s, each triggering
         // a cache cycle; without this guard every launch notification causes a restore
@@ -718,8 +752,11 @@ final class MenuBarItemManager: ObservableObject {
         // interleaved with notification-triggered cache cycles between them.
         startupSettlingTask = Task { @MainActor [weak self] in
             guard let self else { return }
+            await initialCacheTask.value
             do {
-                try await Task.sleep(until: deadline, clock: .continuous)
+                if .now < deadline {
+                    try await Task.sleep(until: deadline, clock: .continuous)
+                }
             } catch {
                 // Cancelled by a subsequent performSetup() call; exit without
                 // touching shared state — the new call manages isInStartupSettling.
@@ -728,11 +765,13 @@ final class MenuBarItemManager: ObservableObject {
             }
             isInStartupSettling = false
             settlingDeadline = nil
-            MenuBarItemManager.diagLog.debug("performSetup: startup settling period ended, running restore")
+            MenuBarItemManager.diagLog.debug(
+                "performSetup: startup settling period ended, running fast restore without sourcePID resolution"
+            )
             // skipRecentMoveCheck: true — relocateNewLeftmostItems/relocatePendingItems
             // may have stamped lastMoveOperationTimestamp during settling; without this
             // flag the final restore would be silently skipped by the 5 s cooldown.
-            await cacheItemsRegardless(skipRecentMoveCheck: true)
+            await cacheItemsRegardless(skipRecentMoveCheck: true, resolveSourcePID: false)
         }
         MenuBarItemManager.diagLog.debug("performSetup: MenuBarItemManager setup complete")
     }
@@ -1193,9 +1232,12 @@ extension MenuBarItemManager {
     /// arranging them into valid positions if needed.
     func cacheItemsRegardless(
         _ currentItemWindowIDs: [CGWindowID]? = nil,
-        skipRecentMoveCheck: Bool = false
+        skipRecentMoveCheck: Bool = false,
+        resolveSourcePID: Bool = true
     ) async {
-        MenuBarItemManager.diagLog.debug("cacheItemsRegardless: entering (skipRecentMoveCheck=\(skipRecentMoveCheck), hasCurrentItemWindowIDs=\(currentItemWindowIDs != nil))")
+        MenuBarItemManager.diagLog.debug(
+            "cacheItemsRegardless: entering (skipRecentMoveCheck=\(skipRecentMoveCheck), hasCurrentItemWindowIDs=\(currentItemWindowIDs != nil), resolveSourcePID=\(resolveSourcePID))"
+        )
         await cacheActor.runCacheTask { [weak self] in
             defer {
                 self?.backgroundCacheContinuation?.resume()
@@ -1221,14 +1263,20 @@ extension MenuBarItemManager {
             let displayID = Bridging.getActiveMenuBarDisplayID()
             MenuBarItemManager.diagLog.debug("cacheItemsRegardless: displayID=\(displayID.map { "\($0)" } ?? "nil"), previousWindowIDs count=\(previousWindowIDs.count)")
 
-            var items = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+            var items = await MenuBarItem.getMenuBarItems(
+                option: .activeSpace,
+                resolveSourcePID: resolveSourcePID
+            )
 
             if items.isEmpty {
                 // Retry once after a small delay if we got zero items. This can happen
                 // due to transient WindowServer glitches or during display reconfigurations.
                 MenuBarItemManager.diagLog.warning("cacheItemsRegardless: getMenuBarItems returned ZERO items, retrying in 250ms...")
                 try? await Task.sleep(for: .milliseconds(250))
-                items = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+                items = await MenuBarItem.getMenuBarItems(
+                    option: .activeSpace,
+                    resolveSourcePID: resolveSourcePID
+                )
             }
 
             MenuBarItemManager.diagLog.debug("cacheItemsRegardless: getMenuBarItems returned \(items.count) items")
@@ -4032,31 +4080,55 @@ extension MenuBarItemManager {
     /// Returns a Boolean value that indicates whether any menu bar item
     /// currently has a menu open.
     func isAnyMenuBarItemMenuOpen() async -> Bool {
-        // Get all menu bar items that are currently on screen.
-        let items = await MenuBarItem.getMenuBarItems(option: .onScreen)
-        let sourcePIDs = Set(items.compactMap { $0.sourcePID })
+        let cacheFreshness: Duration = .milliseconds(250)
 
-        // Get all on-screen windows.
-        let windows = WindowInfo.createWindows(option: .onScreen)
-
-        MenuBarItemManager.diagLog.debug("Checking for open menus - Found \(items.count) menu bar items with PIDs: \(sourcePIDs)")
-
-        // Check if any of the items' owning applications have a menu-related window.
-        let result = windows.contains { window in
-            // Skip Control Center windows as they can be falsely detected when hovering
-            guard window.owningApplication?.bundleIdentifier != MenuBarItemTag.Namespace.controlCenter.description else {
-                MenuBarItemManager.diagLog.debug("Skipping Control Center window: PID \(window.ownerPID), title: \(window.title ?? "nil")")
-                return false
-            }
-
-            let isMenuOpen = sourcePIDs.contains(window.ownerPID) && window.isMenuRelated && (window.title?.isEmpty ?? true)
-            if isMenuOpen {
-                MenuBarItemManager.diagLog.debug("Found open menu window: PID \(window.ownerPID), owner: \(window.ownerName as NSObject?), title: \(window.title ?? "nil"), isMenuRelated: \(window.isMenuRelated)")
-            }
-            return isMenuOpen
+        if let cachedAt = menuOpenCheckCachedAt,
+           cachedAt.duration(to: .now) <= cacheFreshness,
+           let cachedResult = menuOpenCheckCachedResult
+        {
+            MenuBarItemManager.diagLog.debug("Menu open check: using cached result \(cachedResult)")
+            return cachedResult
         }
 
-        MenuBarItemManager.diagLog.debug("Menu open check result: \(result)")
+        if let existingTask = menuOpenCheckTask {
+            MenuBarItemManager.diagLog.debug("Menu open check: joining in-flight probe")
+            return await existingTask.value
+        }
+
+        let task = Task.detached(priority: .utility) { () -> Bool in
+            // Get all menu bar items that are currently on screen.
+            let items = await MenuBarItem.getMenuBarItems(option: .onScreen)
+            let sourcePIDs = Set(items.compactMap { $0.sourcePID })
+
+            // Get all on-screen windows.
+            let windows = WindowInfo.createWindows(option: .onScreen)
+
+            MenuBarItemManager.diagLog.debug("Checking for open menus - Found \(items.count) menu bar items with PIDs: \(sourcePIDs)")
+
+            // Check if any of the items' owning applications have a menu-related window.
+            let result = windows.contains { window in
+                // Skip Control Center windows as they can be falsely detected when hovering
+                guard window.owningApplication?.bundleIdentifier != MenuBarItemTag.Namespace.controlCenter.description else {
+                    MenuBarItemManager.diagLog.debug("Skipping Control Center window: PID \(window.ownerPID), title: \(window.title ?? "nil")")
+                    return false
+                }
+
+                let isMenuOpen = sourcePIDs.contains(window.ownerPID) && window.isMenuRelated && (window.title?.isEmpty ?? true)
+                if isMenuOpen {
+                    MenuBarItemManager.diagLog.debug("Found open menu window: PID \(window.ownerPID), owner: \(window.ownerName as NSObject?), title: \(window.title ?? "nil"), isMenuRelated: \(window.isMenuRelated)")
+                }
+                return isMenuOpen
+            }
+
+            MenuBarItemManager.diagLog.debug("Menu open check result: \(result)")
+            return result
+        }
+
+        menuOpenCheckTask = task
+        let result = await task.value
+        menuOpenCheckTask = nil
+        menuOpenCheckCachedResult = result
+        menuOpenCheckCachedAt = .now
         return result
     }
 }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -782,7 +782,9 @@ final class MenuBarItemManager: ObservableObject {
             await cacheItemsRegardless(skipRecentMoveCheck: true, resolveSourcePID: false)
             // Final authoritative recache that resolves source PIDs so items used later
             // (which read item.sourcePID ?? item.ownerPID) reflect the true source PID.
-            await cacheItemsRegardless(resolveSourcePID: true)
+            // skipRecentMoveCheck: true ensures this pass is never suppressed by the
+            // 1-second recent-move cooldown stamped by the fast restore above.
+            await cacheItemsRegardless(skipRecentMoveCheck: true, resolveSourcePID: true)
         }
         MenuBarItemManager.diagLog.debug("performSetup: MenuBarItemManager setup complete")
     }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemServiceConnection.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemServiceConnection.swift
@@ -187,7 +187,8 @@ extension MenuBarItemService {
                             switch result {
                             case let .success(message):
                                 do {
-                                    try cont.resume(returning: message.decode(as: Response.self))
+                                    let decoded = try message.decode(as: Response.self)
+                                    cont.resume(returning: decoded)
                                 } catch {
                                     self.diagLog.error(
                                         "XPC reply decode failed for request \(String(describing: request)): \(error)"
@@ -202,10 +203,10 @@ extension MenuBarItemService {
                             }
                         }
                     } catch {
+                        diagLog.error(
+                            "XPC session send failed for request \(String(describing: request)): \(error)"
+                        )
                         if let cont = box.withLock({ $0.take() }) {
-                            diagLog.error(
-                                "XPC session send failed for request \(String(describing: request)): \(error)"
-                            )
                             cont.resume(returning: nil)
                         }
                     }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemServiceConnection.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemServiceConnection.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import os.lock
+import XPC
 
 // MARK: - MenuBarItemService.Connection
 
@@ -43,35 +44,30 @@ extension MenuBarItemService {
         func start() async {
             diagLog.debug("Starting MenuBarItemService connection")
 
-            await withCheckedContinuation { continuation in
-                guard let response = session.send(request: .start) else {
-                    diagLog.error("Start request returned nil")
-                    continuation.resume()
-                    return
-                }
-                if case .start = response {
-                    continuation.resume()
-                } else {
-                    diagLog.error("Start request returned invalid response \(String(describing: response))")
-                    continuation.resume()
-                }
+            let response = await session.sendAsync(request: .start)
+            guard let response else {
+                diagLog.error("Start request returned nil")
+                return
+            }
+            if case .start = response {
+                // success
+            } else {
+                diagLog.error("Start request returned invalid response \(String(describing: response))")
             }
         }
 
         /// Returns the source process identifier for the given window.
         func sourcePID(for window: WindowInfo) async -> pid_t? {
-            await withCheckedContinuation { continuation in
-                guard let response = session.send(request: .sourcePID(window)) else {
-                    diagLog.error("Source PID request returned nil")
-                    continuation.resume(returning: nil)
-                    return
-                }
-                if case let .sourcePID(pid) = response {
-                    continuation.resume(returning: pid)
-                } else {
-                    diagLog.error("Source PID request returned invalid response \(String(describing: response))")
-                    continuation.resume(returning: nil)
-                }
+            let response = await session.sendAsync(request: .sourcePID(window))
+            guard let response else {
+                diagLog.error("Source PID request returned nil")
+                return nil
+            }
+            if case let .sourcePID(pid) = response {
+                return pid
+            } else {
+                diagLog.error("Source PID request returned invalid response \(String(describing: response))")
+                return nil
             }
         }
     }
@@ -147,22 +143,80 @@ extension MenuBarItemService {
             storage.withLock { $0.cancel(reason: reason) }
         }
 
-        /// Sends the given request to the service and returns the response.
-        func send(request: Request) -> Response? {
-            let session: XPCSession
+        /// Sends the given request to the service asynchronously and returns the response.
+        ///
+        /// Uses the non-blocking `XPCSession.send(_:replyHandler:)` API so that Swift
+        /// cooperative-thread-pool threads are never stranded on a blocking C call.
+        /// The continuation is protected by a shared `OSAllocatedUnfairLock`-guarded
+        /// box so that exactly one of (reply handler) or (cancellation handler) resumes
+        /// it. This lets upstream `Task` cancellation (e.g. from `Task.withTimeout`)
+        /// unblock the caller immediately without stranding a thread.
+        func sendAsync(request: Request) async -> Response? {
+            let xpcSession: XPCSession
             do {
-                session = try storage.withLock { try $0.getSession() }
+                xpcSession = try storage.withLock { try $0.getSession() }
             } catch {
                 diagLog.error("Failed to get or create XPC session: \(error)")
                 return nil
             }
 
-            do {
-                let reply = try session.sendSync(request)
-                return try reply.decode(as: Response.self)
-            } catch {
-                diagLog.error("XPC session send failed for request \(String(describing: request)): \(error)")
-                return nil
+            // Shared mutable box: holds the continuation until one of the two
+            // racing paths (reply handler vs. cancellation handler) claims it.
+            // Setting the stored value to nil is the "claim" — whichever path
+            // wins claims it and resumes; the other path sees nil and does nothing.
+            typealias Cont = CheckedContinuation<Response?, Never>
+            let box = OSAllocatedUnfairLock<Cont?>(initialState: nil)
+
+            return await withTaskCancellationHandler {
+                await withCheckedContinuation { (continuation: Cont) in
+                    // Store the continuation so the cancellation handler can reach it.
+                    box.withLock { $0 = continuation }
+
+                    // Fast path: task was cancelled before we stored the continuation,
+                    // so the onCancel handler already fired and saw nil. Claim & resume.
+                    if Task.isCancelled {
+                        if let cont = box.withLock({ $0.take() }) {
+                            cont.resume(returning: nil)
+                        }
+                        return
+                    }
+
+                    do {
+                        try xpcSession.send(request) { (result: Result<XPCReceivedMessage, XPCRichError>) in
+                            guard let cont = box.withLock({ $0.take() }) else { return }
+                            switch result {
+                            case let .success(message):
+                                do {
+                                    try cont.resume(returning: message.decode(as: Response.self))
+                                } catch {
+                                    self.diagLog.error(
+                                        "XPC reply decode failed for request \(String(describing: request)): \(error)"
+                                    )
+                                    cont.resume(returning: nil)
+                                }
+                            case let .failure(error):
+                                self.diagLog.error(
+                                    "XPC session send failed for request \(String(describing: request)): \(error)"
+                                )
+                                cont.resume(returning: nil)
+                            }
+                        }
+                    } catch {
+                        if let cont = box.withLock({ $0.take() }) {
+                            diagLog.error(
+                                "XPC session send failed for request \(String(describing: request)): \(error)"
+                            )
+                            cont.resume(returning: nil)
+                        }
+                    }
+                }
+            } onCancel: {
+                // Fired on an arbitrary thread when the enclosing Task is cancelled.
+                // Claim the continuation and resume it immediately so the caller is
+                // unblocked. The XPC reply handler will see the box is empty and no-op.
+                if let cont = box.withLock({ $0.take() }) {
+                    cont.resume(returning: nil)
+                }
             }
         }
     }

--- a/Thaw/MenuBar/MenuBarManager.swift
+++ b/Thaw/MenuBar/MenuBarManager.swift
@@ -126,6 +126,11 @@ final class MenuBarManager: ObservableObject {
 
         // Handle the `focusedApp` and `smart` rehide strategies.
         NSWorkspace.shared.publisher(for: \.frontmostApplication)
+            // Ignore the initial value during app startup. Treating the
+            // current frontmost app as a "focus change" immediately on launch
+            // triggers an expensive menu-open scan before the item manager
+            // has even finished its first cache pass.
+            .dropFirst()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 if

--- a/Thaw/Utilities/ConcurrencyHelpers.swift
+++ b/Thaw/Utilities/ConcurrencyHelpers.swift
@@ -36,8 +36,8 @@ extension Task {
     /// - Returns: The result of the operation, if successful.
     static func withTimeout<C: Clock>(
         _ timeout: C.Instant.Duration,
-        tolerance: C.Instant.Duration?,
-        clock: C,
+        tolerance: C.Instant.Duration? = nil,
+        clock: C = .continuous,
         operation: sending @escaping @isolated(any) () async throws -> Success
     ) async throws -> Success {
         try await withThrowingTaskGroup(of: Success.self) { group in


### PR DESCRIPTION
## Summary

This PR fixes a race in `Show on click` when `Double-click for always-hidden` is enabled.

Previously, the first click could reveal hidden items immediately, and the second click of a double-click would often land on one of those newly revealed items instead of being treated as the second click on empty menu bar space.

## What changed

- keep the current single-click behavior: the first click still reveals hidden items immediately
- add a temporary protected region centered on the first click location
- keep that protected region active for the system `NSEvent.doubleClickInterval`
- swallow left-clicks inside that region during the double-click window so newly revealed items cannot steal the second click
- if the second click is a double-click, show the always-hidden section
- automatically remove the protection once the double-click window expires

## Why

The previous behavior made double-click unreliable because the UI changed under the cursor after the first click.  
That meant the second click could hit a newly revealed menu bar item instead of continuing the original click sequence.

Using a first-click protection region avoids relying on menu bar item positions that may still be updating right after reveal, and keeps the second click associated with the original interaction.

## Result

- single-click still feels immediate
- the second click is no longer stolen by newly revealed hidden items
- double-click to show always-hidden is more reliable
- the implementation no longer depends on stale hidden-item bounds for guarding the second click

## Testing

Tested locally by building a signed Debug app and verifying that:

- a single click still reveals hidden items immediately
- the area around the first click is temporarily protected during the system double-click interval
- a double-click no longer falls through to newly revealed hidden items
- always-hidden can still be revealed by double-click

## Note

While working on this, I also noticed a separate startup-time issue: both `Show on hover` and `Show on click` can feel noticeably slow right after launch.

I have not included a fix for that in this PR, since the cause seems more involved and likely unrelated to the double-click guard itself. My current impression is that the startup path around input handling, menu bar state, and initial item/setup work is more complex than this PR should try to address.

I plan to investigate that separately and will see if I can narrow it down into a smaller, focused follow-up fix.



09:35


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent hover show/hide races with tokenized delayed tasks and add a click-guard to avoid accidental single-click reveals.

* **Performance / Startup**
  * Non-blocking, multi-pass item warm‑up and skipped initial frontmost-app trigger to avoid startup work.

* **Behavior**
  * More accurate menu-bar hit-testing and bounds rebuilds; stable ordering for duplicated items and optional faster item discovery that can skip process resolution.

* **Reliability**
  * IPC moved to async/await with cancellation-safe reply handling.

* **Chores**
  * Timeout helper accepts optional parameters for simpler calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->