### PR TITLE
refactor: eliminate code duplication in MenuBarSection.Name.localized

### DIFF
--- a/Thaw/MenuBar/MenuBarSection.swift
+++ b/Thaw/MenuBar/MenuBarSection.swift
@@ -37,11 +37,7 @@ final class MenuBarSection {
 
         /// Localized string key representation.
         var localized: LocalizedStringKey {
-            switch self {
-            case .visible: "Visible"
-            case .hidden: "Hidden"
-            case .alwaysHidden: "Always-Hidden"
-            }
+            LocalizedStringKey(displayString)
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

Eliminates code duplication in `MenuBarSection.Name.localized` property by making it use `displayString` instead of duplicating the same switch statement.

Refs #316 

## PR Type

- [ ] Bugfix
- [ ] CI/CD related changes
- [x] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [x] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What is the current behavior?

The `localized` property (line 39) and `displayString` property (line 21) in `MenuBarSection.Name` enum have identical implementations, violating the DRY (Don't Repeat Yourself) principle.

**Benefits:**
- Removes 5 lines of duplicate code
- Single source of truth for string values
- Easier to maintain (changes only need to be made in one place)
- Zero performance overhead
- Maintains full localization support (strings are already in `Localizable.xcstrings`)

## PR Checklist

- [x] I've built and run the app locally
- [x] I've checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [x] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

### Technical Details

The change is safe because:
1. `LocalizedStringKey` automatically looks up translations in `Localizable.xcstrings`
2. All three strings ("Visible", "Hidden", "Always-Hidden") are already defined in the localization file with full translations
3. The behavior is identical to the previous implementation
4. Build succeeds with no errors or warnings related to this change

### Files Changed

- `Thaw/MenuBar/MenuBarSection.swift` (lines 39-41)

### Notes for reviewers

This is a straightforward refactoring that eliminates code duplication. The functionality remains exactly the same - `LocalizedStringKey(displayString)` produces the same result as the previous switch statement. The localization system will still find and use the translated strings from `Localizable.xcstrings`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized code structure for improved maintainability with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->