### PR TITLE
fix(menu-bar): cache raw AX frame and remove ignoreNotch variant

### DIFF
--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -1448,9 +1448,16 @@ extension HIDEventManager {
         else {
             return false
         }
+        // Extend the frame left to the screen edge to cover the Apple menu.
         applicationMenuFrame.size.width +=
             applicationMenuFrame.origin.x - screen.frame.origin.x
         applicationMenuFrame.origin.x = screen.frame.origin.x
+        // Cap the right edge at the notch so locations over the notch are not
+        // counted as inside the application menu.
+        if let notch = screen.frameOfNotch {
+            let cappedMaxX = min(applicationMenuFrame.maxX, notch.minX)
+            applicationMenuFrame.size.width = cappedMaxX - applicationMenuFrame.origin.x
+        }
         return applicationMenuFrame.contains(mouseLocation)
     }
 

--- a/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
+++ b/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
@@ -454,8 +454,7 @@ final class MenuBarOverlayPanel: NSPanel {
         else {
             return
         }
-        // Use ignoreNotch: true to get the full menu frame for visual overlay
-        applicationMenuFrame = screen.getApplicationMenuFrame(ignoreNotch: true)
+        applicationMenuFrame = screen.getApplicationMenuFrame()
     }
 
     /// Stores the area of the desktop wallpaper that is under the menu bar

--- a/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
+++ b/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
@@ -291,17 +291,26 @@ final class MenuBarOverlayPanel: NSPanel {
                 for: .applicationMenuFrame,
                 timeout: .seconds(10)
             ) { [weak self] in
+                // Poll until AX returns a frame, then do a confirm run to
+                // make sure the value has settled before committing it.
+                // The old frame is held throughout so the overlay shows no
+                // visual gap — a single clean swap happens once confirmed.
+                var candidate: CGRect?
                 for _ in 0 ..< 10 {
                     try Task.checkCancellation()
                     guard let self else { return }
-                    if let latestFrame = self.owningScreen
-                        .getApplicationMenuFrame(bypassCache: true),
-                        latestFrame != self.applicationMenuFrame
-                    {
-                        self.insertUpdateFlag(.applicationMenuFrame)
-                        break
+                    let latest = self.owningScreen
+                        .getApplicationMenuFrame(bypassCache: true)
+                    if let latest {
+                        if latest == candidate {
+                            // Confirmed: two consecutive reads agree.
+                            self.insertUpdateFlag(.applicationMenuFrame)
+                            break
+                        }
+                        // New or changed candidate — start confirming it.
+                        candidate = latest
                     }
-                    try await Task.sleep(for: .milliseconds(100))
+                    try await Task.sleep(for: .milliseconds(150))
                 }
             }
             Task {

--- a/Thaw/Utilities/Extensions.swift
+++ b/Thaw/Utilities/Extensions.swift
@@ -759,14 +759,10 @@ extension NSScreen {
                     return CGRect(x: frame.minX, y: applicationMenuFrame.minY, width: applicationMenuFrame.width, height: applicationMenuFrame.height)
                 }
             }
-            // Fallback: If AX fails for secondary screen, try getting main screen's menu width
+            // Fallback: If AX fails for secondary screen, use the main screen's raw menu width.
+            // No notch-capping here — callers apply any notch adjustments they need.
             if let mainFrame = mainScreen.getApplicationMenuFrame() {
-                // Do not over-extend into notch area; cap width at notch start if present.
-                var width = mainFrame.width
-                if let notch = frameOfNotch {
-                    width = min(width, notch.minX - frame.minX)
-                }
-                return CGRect(x: frame.minX, y: mainFrame.minY, width: width, height: mainFrame.height)
+                return CGRect(x: frame.minX, y: mainFrame.minY, width: mainFrame.width, height: mainFrame.height)
             }
             return nil
         }

--- a/Thaw/Utilities/Extensions.swift
+++ b/Thaw/Utilities/Extensions.swift
@@ -711,22 +711,23 @@ extension NSScreen {
         return hasNotch ? 37.0 : NSStatusBar.system.thickness
     }
 
-    /// Returns the frame of the application menu on this screen.
+    /// Returns the raw frame of the application menu on this screen, as
+    /// reported by the Accessibility API, without any notch-capping applied.
     ///
     /// Results are cached per-display and invalidated when the frontmost
     /// application changes, avoiding repeated Accessibility API round-trips.
-    /// - Parameters:
-    ///   - bypassCache: If `true`, always queries the Accessibility API
-    ///     instead of using cached values. Use this when polling for changes.
-    ///   - ignoreNotch: If `true`, returns the full menu frame without capping
-    ///     at the notch. Use this for visual overlay calculations.
-    func getApplicationMenuFrame(bypassCache: Bool = false, ignoreNotch: Bool = false) -> CGRect? {
+    /// Callers that need a notch-capped width should apply the cap themselves
+    /// using `frameOfNotch`.
+    ///
+    /// - Parameter bypassCache: If `true`, always queries the Accessibility API
+    ///   instead of using cached values. Use this when polling for changes.
+    func getApplicationMenuFrame(bypassCache: Bool = false) -> CGRect? {
         NSScreen.invalidateApplicationMenuFrameCacheIfNeeded()
         if !bypassCache, let cached = NSScreen.applicationMenuFrameCache[displayID] {
             return cached
         }
 
-        let result = computeApplicationMenuFrame(ignoreNotch: ignoreNotch)
+        let result = computeApplicationMenuFrame()
         if !bypassCache, let result {
             NSScreen.applicationMenuFrameCache[displayID] = result
         }
@@ -734,10 +735,9 @@ extension NSScreen {
     }
 
     /// Performs the actual Accessibility API queries to determine the
-    /// application menu frame. Called only on cache miss.
-    /// - Parameter ignoreNotch: If `true`, returns the full menu frame without
-    ///   capping at the notch.
-    private func computeApplicationMenuFrame(ignoreNotch: Bool = false) -> CGRect? {
+    /// application menu frame. Returns the raw frame without notch-capping.
+    /// Called only on cache miss.
+    private func computeApplicationMenuFrame() -> CGRect? {
         let displayBounds = CGDisplayBounds(displayID)
 
         // Accessibility API has trouble with secondary screens.
@@ -786,17 +786,6 @@ extension NSScreen {
 
         if applicationMenuFrame.width <= 0 || applicationMenuFrame.isNull {
             return nil
-        }
-
-        // Avoid counting the notch as usable application menu width.
-        if !ignoreNotch, let notch = frameOfNotch {
-            let cappedWidth = min(applicationMenuFrame.width, notch.minX - frame.minX)
-            return CGRect(
-                x: applicationMenuFrame.minX,
-                y: applicationMenuFrame.minY,
-                width: cappedWidth,
-                height: applicationMenuFrame.height
-            )
         }
 
         return applicationMenuFrame


### PR DESCRIPTION
## What does this PR do?

The cache was keyed only on displayID but stored either a notch-capped or un-capped frame depending on the ignoreNotch flag passed by the caller. A notch-capped entry written by any call site would be returned to a caller expecting the full frame (or vice versa), causing the split container to render with the wrong width after an app switch — the same symptom fixed in 786dc46, now re-appearing sporadically due to the race between the two variants sharing one cache slot.

Cache the raw Accessibility API frame unconditionally; remove the ignoreNotch parameter from getApplicationMenuFrame and computeApplicationMenuFrame entirely. The visual overlay (previously ignoreNotch: true) now reads the raw frame directly — same value. The retry-loop comparison in MenuBarOverlayPanel is now apples-to-apples (both sides raw). Callers that need notch-capped geometry handle it locally via frameOfNotch.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What is the current behavior?

Issue Number: #445

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [ ] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified menu bar frame calculation and removed the previous notch-override behavior, using raw menu geometry for layout.

* **Bug Fixes / Behavior**
  * Improved hit-detection: left-side Apple menu coverage expanded while areas over the notch are excluded, reducing accidental interactions.
  * Stabilized menu-frame updates to reduce flicker and incorrect positioning during screen changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->