### PR TITLE
fix: hide dependent settings when always-hidden section is disabled

### DIFF
--- a/Thaw/MenuBar/ControlItem/ControlItem.swift
+++ b/Thaw/MenuBar/ControlItem/ControlItem.swift
@@ -566,17 +566,6 @@ final class ControlItem {
             // Running this from a Task seems to improve the visual
             // responsiveness of the status item's button.
             Task { [appState] in
-                if
-                    !appState.settings.advanced.useOptionClickToShowAlwaysHiddenSection,
-                    event.clickCount > 1,
-                    identifier == .visible,
-                    let alwaysHidden = menuBarManager.section(withName: .alwaysHidden),
-                    alwaysHidden.isEnabled
-                {
-                    alwaysHidden.show()
-                    return
-                }
-
                 if modifierFlags.contains(.control) {
                     showMenu()
                     return

--- a/Thaw/Settings/SettingsPanes/AdvancedSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/AdvancedSettingsPane.swift
@@ -39,7 +39,9 @@ struct AdvancedSettingsPane: View {
         IceForm {
             IceSection("Menu Bar Sections") {
                 enableAlwaysHiddenSection
-                useOptionClickToShowAlwaysHiddenSection
+                if settings.enableAlwaysHiddenSection {
+                    useOptionClickToShowAlwaysHiddenSection
+                }
                 showAllSectionsOnUserDrag
                 sectionDividerStyle
             }

--- a/Thaw/Settings/SettingsPanes/GeneralSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/GeneralSettingsPane.swift
@@ -172,7 +172,7 @@ struct GeneralSettingsPane: View {
             Toggle("Show on click", isOn: $settings.showOnClick)
                 .annotation("Click an empty area of the menu bar to show hidden menu bar items.")
 
-            if settings.showOnClick {
+            if settings.showOnClick && appState.settings.advanced.enableAlwaysHiddenSection {
                 Toggle("Double-click for always-hidden", isOn: $settings.showOnDoubleClick)
                     .annotation("Double-click an empty area of the menu bar to show always-hidden menu bar items.")
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu bar left-click behavior when the always-hidden section is active, refining control interactions and flow logic.

* **Settings**
  * Refined visibility of always-hidden section settings—related toggles now appear only when the feature is enabled, improving interface clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->