### PR TITLE
fix(icebar): make item reveal reliable under CPU load

### DIFF
--- a/Thaw/MenuBar/IceBar/IceBar.swift
+++ b/Thaw/MenuBar/IceBar/IceBar.swift
@@ -526,17 +526,28 @@ private struct IceBarItemView: View {
             }
             let clickStartTime = Date.now
             IceBarItemView.diagLog.debug("leftClick: user clicked \(item.logString)")
+            let panel = menuBarManager.iceBarPanel
             menuBarManager.section(withName: section)?.hide()
             Task {
-                try await Task.sleep(for: .milliseconds(25))
+                // Wait until the IceBar panel is fully closed before checking
+                // item visibility. A blind 25 ms sleep is not enough under
+                // CPU load — the panel can still be on-screen when
+                // isWindowOnScreen runs, causing the wrong branch to be taken.
+                await waitForPanelClosed(panel, timeout: .milliseconds(200))
                 if Bridging.isWindowOnScreen(item.windowID) {
                     try await itemManager.click(item: item, with: .left)
                     let duration = Date.now.timeIntervalSince(clickStartTime)
                     IceBarItemView.diagLog.debug("leftClick: ✓ completed in \(Int(duration * 1000))ms (on-screen path)")
                 } else {
-                    await itemManager.temporarilyShow(item: item, clickingWith: .left, on: displayID, fastPath: true)
+                    let ok = await itemManager.temporarilyShow(item: item, clickingWith: .left, on: displayID, fastPath: true)
+                    if !ok {
+                        // Fallback: item moved into view but click failed.
+                        // Try one direct click with live bounds.
+                        IceBarItemView.diagLog.warning("leftClick: temp-show click failed, attempting fallback click")
+                        try? await itemManager.click(item: item, with: .left)
+                    }
                     let duration = Date.now.timeIntervalSince(clickStartTime)
-                    IceBarItemView.diagLog.debug("leftClick: ✓ completed in \(Int(duration * 1000))ms (temp-show path)")
+                    IceBarItemView.diagLog.debug("leftClick: ✓ completed in \(Int(duration * 1000))ms (temp-show path, ok=\(ok))")
                 }
             }
         }
@@ -547,15 +558,34 @@ private struct IceBarItemView: View {
             guard let itemManager, let menuBarManager else {
                 return
             }
+            let panel = menuBarManager.iceBarPanel
             menuBarManager.section(withName: section)?.hide()
             Task {
-                try await Task.sleep(for: .milliseconds(25))
+                await waitForPanelClosed(panel, timeout: .milliseconds(200))
                 if Bridging.isWindowOnScreen(item.windowID) {
                     try await itemManager.click(item: item, with: .right)
                 } else {
-                    await itemManager.temporarilyShow(item: item, clickingWith: .right, on: displayID, fastPath: true)
+                    let ok = await itemManager.temporarilyShow(item: item, clickingWith: .right, on: displayID, fastPath: true)
+                    if !ok {
+                        IceBarItemView.diagLog.warning("rightClick: temp-show click failed, attempting fallback click")
+                        try? await itemManager.click(item: item, with: .right)
+                    }
                 }
             }
+        }
+    }
+
+    /// Polls until `panel.isVisible` is false or `timeout` elapses.
+    /// Enforces a minimum 10 ms wait so the run loop can process the
+    /// `orderOut` call from `section.hide()`.
+    private func waitForPanelClosed(_ panel: IceBarPanel, timeout: Duration) async {
+        let pollInterval = Duration.milliseconds(10)
+        let deadline = ContinuousClock.now + timeout
+        // Always wait at least one poll interval so the orderOut has a
+        // chance to propagate through the window server.
+        try? await Task.sleep(for: pollInterval)
+        while panel.isVisible, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: pollInterval)
         }
     }
 

--- a/Thaw/MenuBar/IceBar/IceBar.swift
+++ b/Thaw/MenuBar/IceBar/IceBar.swift
@@ -539,15 +539,16 @@ private struct IceBarItemView: View {
                     let duration = Date.now.timeIntervalSince(clickStartTime)
                     IceBarItemView.diagLog.debug("leftClick: ✓ completed in \(Int(duration * 1000))ms (on-screen path)")
                 } else {
-                    let ok = await itemManager.temporarilyShow(item: item, clickingWith: .left, on: displayID, fastPath: true)
-                    if !ok {
-                        // Fallback: item moved into view but click failed.
-                        // Try one direct click with live bounds.
+                    let result = await itemManager.temporarilyShow(item: item, clickingWith: .left, on: displayID, fastPath: true)
+                    if result == .movedButClickFailed {
+                        // Item is visible but the synthetic click failed.
+                        // Try a direct click with live bounds — only safe because
+                        // the move succeeded and the icon is on-screen.
                         IceBarItemView.diagLog.warning("leftClick: temp-show click failed, attempting fallback click")
                         try? await itemManager.click(item: item, with: .left)
                     }
                     let duration = Date.now.timeIntervalSince(clickStartTime)
-                    IceBarItemView.diagLog.debug("leftClick: ✓ completed in \(Int(duration * 1000))ms (temp-show path, ok=\(ok))")
+                    IceBarItemView.diagLog.debug("leftClick: ✓ completed in \(Int(duration * 1000))ms (temp-show path, result=\(result))")
                 }
             }
         }
@@ -565,8 +566,8 @@ private struct IceBarItemView: View {
                 if Bridging.isWindowOnScreen(item.windowID) {
                     try await itemManager.click(item: item, with: .right)
                 } else {
-                    let ok = await itemManager.temporarilyShow(item: item, clickingWith: .right, on: displayID, fastPath: true)
-                    if !ok {
+                    let result = await itemManager.temporarilyShow(item: item, clickingWith: .right, on: displayID, fastPath: true)
+                    if result == .movedButClickFailed {
                         IceBarItemView.diagLog.warning("rightClick: temp-show click failed, attempting fallback click")
                         try? await itemManager.click(item: item, with: .right)
                     }

--- a/Thaw/MenuBar/IceBar/IceBar.swift
+++ b/Thaw/MenuBar/IceBar/IceBar.swift
@@ -539,16 +539,12 @@ private struct IceBarItemView: View {
                     let duration = Date.now.timeIntervalSince(clickStartTime)
                     IceBarItemView.diagLog.debug("leftClick: ✓ completed in \(Int(duration * 1000))ms (on-screen path)")
                 } else {
+                    // temporarilyShow handles move, click, and fallback click
+                    // internally so that shownInterfaceWindow is always captured
+                    // regardless of which click attempt succeeds.
                     let result = await itemManager.temporarilyShow(item: item, clickingWith: .left, on: displayID, fastPath: true)
-                    if result == .movedButClickFailed {
-                        // Item is visible but the synthetic click failed.
-                        // Try a direct click with live bounds — only safe because
-                        // the move succeeded and the icon is on-screen.
-                        IceBarItemView.diagLog.warning("leftClick: temp-show click failed, attempting fallback click")
-                        try? await itemManager.click(item: item, with: .left)
-                    }
                     let duration = Date.now.timeIntervalSince(clickStartTime)
-                    IceBarItemView.diagLog.debug("leftClick: ✓ completed in \(Int(duration * 1000))ms (temp-show path, result=\(result))")
+                    IceBarItemView.diagLog.debug("leftClick: completed in \(Int(duration * 1000))ms (temp-show path, result=\(result))")
                 }
             }
         }
@@ -567,10 +563,7 @@ private struct IceBarItemView: View {
                     try await itemManager.click(item: item, with: .right)
                 } else {
                     let result = await itemManager.temporarilyShow(item: item, clickingWith: .right, on: displayID, fastPath: true)
-                    if result == .movedButClickFailed {
-                        IceBarItemView.diagLog.warning("rightClick: temp-show click failed, attempting fallback click")
-                        try? await itemManager.click(item: item, with: .right)
-                    }
+                    IceBarItemView.diagLog.debug("rightClick: temp-show result=\(result)")
                 }
             }
         }
@@ -579,6 +572,10 @@ private struct IceBarItemView: View {
     /// Polls until `panel.isVisible` is false or `timeout` elapses.
     /// Enforces a minimum 10 ms wait so the run loop can process the
     /// `orderOut` call from `section.hide()`.
+    ///
+    /// Must run on the main actor: `NSPanel.isVisible` is a UIKit/AppKit
+    /// property and is only safe to read from the main thread.
+    @MainActor
     private func waitForPanelClosed(_ panel: IceBarPanel, timeout: Duration) async {
         let pollInterval = Duration.milliseconds(10)
         let deadline = ContinuousClock.now + timeout

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -3125,9 +3125,33 @@ extension MenuBarItemManager {
             }
         } catch {
             MenuBarItemManager.diagLog.error("Error showing item: \(error)")
-            pendingRelocations.removeValue(forKey: tagIdentifier)
-            pendingReturnDestinations.removeValue(forKey: tagIdentifier)
-            persistPendingRelocations()
+
+            // Check whether the item actually left its original section despite
+            // the move throwing. move() can throw after a partial reposition
+            // (e.g. retry loop exhausted after validateItemPositionAfterMove ran),
+            // leaving the item somewhere other than originalSection.
+            let currentSection = itemCache.address(for: item.tag)?.section
+            let itemHasMoved = currentSection != nil && currentSection != originalSection
+
+            if itemHasMoved {
+                // The item is no longer where it started — keep the rehide
+                // metadata so the persistent-relocation path can restore it
+                // when the app relaunches or the rehide timer fires.
+                MenuBarItemManager.diagLog.warning("move() threw but item \(item.logString) is no longer in \(originalSection) — preserving pending rehide metadata")
+                // pendingRelocations already set above; re-assert return destination
+                // in case it was not yet written (guard-exit paths above this block).
+                pendingReturnDestinations[tagIdentifier] = [
+                    "neighbor": neighborTag.tagIdentifier,
+                    "position": position,
+                ]
+                persistPendingRelocations()
+            } else {
+                // Item never moved — safe to discard the speculative metadata.
+                pendingRelocations.removeValue(forKey: tagIdentifier)
+                pendingReturnDestinations.removeValue(forKey: tagIdentifier)
+                persistPendingRelocations()
+            }
+
             return .showFailed
         }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -2322,9 +2322,9 @@ extension MenuBarItemManager {
         warpCursorAfter: Bool = true
     ) async throws {
         do {
-            try await eventSemaphore.wait(timeout: .seconds(5))
+            try await eventSemaphore.wait(timeout: .milliseconds(1500))
         } catch is SimpleSemaphore.TimeoutError {
-            MenuBarItemManager.diagLog.error("eventSemaphore timed out in postMoveEvents, forcing signal and retrying")
+            MenuBarItemManager.diagLog.error("eventSemaphore timed out (1.5s) in postMoveEvents, forcing signal and retrying")
             await eventSemaphore.signal()
             throw EventError.cannotComplete
         }
@@ -2607,11 +2607,13 @@ extension MenuBarItemManager {
     ///   - item: The menu bar item to click.
     ///   - mouseButton: The mouse button to click the item with.
     private func postClickEvents(item: MenuBarItem, mouseButton: CGMouseButton) async throws {
-        // Try to acquire semaphore with timeout
+        // Try to acquire semaphore with timeout. 1.5 s is enough for any
+        // legitimate in-flight operation to finish; the old 5 s budget meant
+        // a 3-attempt click could block for up to 15 s on a busy system.
         do {
-            try await eventSemaphore.wait(timeout: .seconds(5))
+            try await eventSemaphore.wait(timeout: .milliseconds(1500))
         } catch is SimpleSemaphore.TimeoutError {
-            MenuBarItemManager.diagLog.error("eventSemaphore timed out in postClickEvents for \(item.logString), forcing signal and retrying")
+            MenuBarItemManager.diagLog.error("eventSemaphore timed out (1.5s) in postClickEvents for \(item.logString), forcing signal and retrying")
             await eventSemaphore.signal()
             throw EventError.cannotComplete
         }
@@ -2692,7 +2694,16 @@ extension MenuBarItemManager {
     /// - Parameters:
     ///   - item: The menu bar item to click.
     ///   - mouseButton: The mouse button to click the item with.
-    func click(item: MenuBarItem, with mouseButton: CGMouseButton, skipInputPause: Bool = false) async throws {
+    /// Clicks a menu bar item with the given mouse button.
+    ///
+    /// - Parameters:
+    ///   - item: The menu bar item to click.
+    ///   - mouseButton: The mouse button to click the item with.
+    ///   - skipInputPause: Skip waiting for user input to pause.
+    ///   - maxAttempts: Maximum number of click attempts (default 3).
+    ///     Pass `1` from `temporarilyShow` so a single failure returns
+    ///     immediately and the caller's fallback path fires promptly.
+    func click(item: MenuBarItem, with mouseButton: CGMouseButton, skipInputPause: Bool = false, maxAttempts: Int = 3) async throws {
         guard let appState else {
             throw EventError.cannotComplete
         }
@@ -2713,7 +2724,7 @@ extension MenuBarItemManager {
             appState.hidEventManager.startAll()
         }
 
-        let maxAttempts = 3 // Reduced from 4 to minimize accumulated delay
+        let maxAttempts = max(1, maxAttempts)
         let attemptStartTime = Date.now
         for n in 1 ... maxAttempts {
             guard !Task.isCancelled else {
@@ -3163,7 +3174,11 @@ extension MenuBarItemManager {
         let idsBeforeClick = Set(Bridging.getWindowList(option: .onScreen))
 
         do {
-            try await click(item: clickItem, with: mouseButton, skipInputPause: true)
+            // Single attempt: the item is already at a known-good position with
+            // fresh bounds. If it fails, return false immediately so the caller
+            // (IceBarItemView) fires a fallback click with default retry count
+            // rather than spending 3× the semaphore timeout here.
+            try await click(item: clickItem, with: mouseButton, skipInputPause: true, maxAttempts: 1)
         } catch {
             MenuBarItemManager.diagLog.error("Error clicking item: \(error)")
             // Icon is now visible but the click failed. Return false so the

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -2986,27 +2986,35 @@ extension MenuBarItemManager {
             }
     }
 
-    /// Temporarily shows the given item.
-    ///
-    /// The item is cached and returned to its original location after approximately
-    /// 15 seconds, though it may be sooner (e.g., when switching apps) or later
-    /// due to the smart rehide logic (e.g., +1s for recent user input, +3s when
-    /// a menu is open).
-    ///
-    /// - Parameters:
-    ///   - item: The item to temporarily show.
-    ///   - mouseButton: The mouse button to click the item with.
-    ///   - displayID: The display identifier to show the item on.
+    /// The result of a ``temporarilyShow(item:clickingWith:on:fastPath:)`` call.
+    enum TemporaryShowResult {
+        /// The item was never moved — a precondition failed (missing state,
+        /// no return destination, no anchor, or the move itself failed).
+        /// The item is still hidden; do **not** attempt a fallback click.
+        case showFailed
+        /// The item was moved into the visible area **and** the synthetic
+        /// click completed successfully.
+        case movedAndClicked
+        /// The item was moved into the visible area but the synthetic click
+        /// failed. The icon is now visible; callers may attempt a fallback
+        /// click using live bounds.
+        case movedButClickFailed
+    }
+
     /// Temporarily moves `item` into the visible area next to the Ice icon,
     /// clicks it, then schedules a rehide.
     ///
-    /// - Returns: `true` if the item was successfully moved **and** clicked;
-    ///   `false` if either step failed (the caller may attempt a fallback click).
-    @discardableResult
-    func temporarilyShow(item: MenuBarItem, clickingWith mouseButton: CGMouseButton, on displayID: CGDirectDisplayID? = nil, fastPath: Bool = false) async -> Bool {
+    /// The item is returned to its original location after approximately
+    /// 15 seconds, though it may be sooner (e.g. when switching apps) or
+    /// later due to the smart rehide logic.
+    ///
+    /// - Returns: A ``TemporaryShowResult`` describing whether the move and
+    ///   click succeeded. Only act on ``TemporaryShowResult/movedButClickFailed``
+    ///   for fallback clicks — the item is hidden for every other non-success case.
+    func temporarilyShow(item: MenuBarItem, clickingWith mouseButton: CGMouseButton, on displayID: CGDirectDisplayID? = nil, fastPath: Bool = false) async -> TemporaryShowResult {
         guard let appState else {
             MenuBarItemManager.diagLog.error("Missing AppState, so not showing \(item.logString)")
-            return false
+            return .showFailed
         }
 
         MenuBarItemManager.diagLog.debug("temporarilyShow: started for \(item.logString)")
@@ -3051,7 +3059,7 @@ extension MenuBarItemManager {
 
         guard let returnInfo = getReturnDestination(for: item, in: items) else {
             MenuBarItemManager.diagLog.error("No return destination for \(item.logString) on display \(resolvedDisplayID)")
-            return false
+            return .showFailed
         }
 
         // Prefer inserting to the left of the Thaw/visible control item so the icon appears
@@ -3065,7 +3073,7 @@ extension MenuBarItemManager {
             let alert = NSAlert()
             alert.messageText = String(localized: "Not enough room to show \"\(item.displayName)\"")
             alert.runModal()
-            return false
+            return .showFailed
         }
 
         let moveDestination: MoveDestination = .leftOfItem(anchor)
@@ -3116,7 +3124,7 @@ extension MenuBarItemManager {
             pendingRelocations.removeValue(forKey: tagIdentifier)
             pendingReturnDestinations.removeValue(forKey: tagIdentifier)
             persistPendingRelocations()
-            return false
+            return .showFailed
         }
 
         let context = TemporarilyShownItemContext(
@@ -3184,9 +3192,9 @@ extension MenuBarItemManager {
             try await click(item: clickItem, with: mouseButton, skipInputPause: true, maxAttempts: 1)
         } catch {
             MenuBarItemManager.diagLog.error("Error clicking item: \(error)")
-            // Icon is now visible but the click failed. Return false so the
-            // caller can attempt a fallback click with live bounds.
-            return false
+            // Icon is now visible but the click failed. Return .movedButClickFailed
+            // so the caller can attempt a fallback click with live bounds.
+            return .movedButClickFailed
         }
 
         await eventSleep(for: .milliseconds(100))
@@ -3197,7 +3205,7 @@ extension MenuBarItemManager {
             window.ownerPID == clickPID && !idsBeforeClick.contains(window.windowID)
         }
 
-        return true
+        return .movedAndClicked
     }
 
     /// Resolves the best move destination for returning a temporarily shown

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -2322,10 +2322,12 @@ extension MenuBarItemManager {
         warpCursorAfter: Bool = true
     ) async throws {
         do {
-            try await eventSemaphore.wait(timeout: .milliseconds(1500))
+            try await eventSemaphore.wait(timeout: .milliseconds(3500))
         } catch is SimpleSemaphore.TimeoutError {
-            MenuBarItemManager.diagLog.error("eventSemaphore timed out (1.5s) in postMoveEvents, forcing signal and retrying")
-            await eventSemaphore.signal()
+            // wait(timeout:) already restores the semaphore count via cancelWaiter
+            // when it times out — do NOT call signal() here or the semaphore
+            // is over-released and two callers can hold it simultaneously.
+            MenuBarItemManager.diagLog.error("eventSemaphore timed out (3.5s) in postMoveEvents")
             throw EventError.cannotComplete
         }
         defer { Task.detached { [eventSemaphore] in await eventSemaphore.signal() } }
@@ -2607,14 +2609,15 @@ extension MenuBarItemManager {
     ///   - item: The menu bar item to click.
     ///   - mouseButton: The mouse button to click the item with.
     private func postClickEvents(item: MenuBarItem, mouseButton: CGMouseButton) async throws {
-        // Try to acquire semaphore with timeout. 1.5 s is enough for any
-        // legitimate in-flight operation to finish; the old 5 s budget meant
-        // a 3-attempt click could block for up to 15 s on a busy system.
+        // Try to acquire semaphore with timeout. 3.5 s covers legitimate slow
+        // operations (adaptive click cap is 1000 ms × 2 for double mouseUp =
+        // ~2 s of event work plus overhead). wait(timeout:) already restores
+        // the semaphore count via cancelWaiter on timeout — do NOT call
+        // signal() in the catch block or the semaphore is over-released.
         do {
-            try await eventSemaphore.wait(timeout: .milliseconds(1500))
+            try await eventSemaphore.wait(timeout: .milliseconds(3500))
         } catch is SimpleSemaphore.TimeoutError {
-            MenuBarItemManager.diagLog.error("eventSemaphore timed out (1.5s) in postClickEvents for \(item.logString), forcing signal and retrying")
-            await eventSemaphore.signal()
+            MenuBarItemManager.diagLog.error("eventSemaphore timed out (3.5s) in postClickEvents for \(item.logString)")
             throw EventError.cannotComplete
         }
         defer { Task.detached { [eventSemaphore] in await eventSemaphore.signal() } }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -2583,8 +2583,12 @@ extension MenuBarItemManager {
             }
         }
 
-        // After all attempts, validate the final position
+        // All attempts exhausted without confirmed position. Run the stuck-item
+        // validator first (recovers x=-1 blocks), then throw so callers know
+        // the item did not reach the destination.
         await validateItemPositionAfterMove(item: item, destination: destination, on: resolvedDisplayID)
+        MenuBarItemManager.diagLog.error("move: all \(maxAttempts) attempt(s) exhausted without verifying \(item.logString) reached \(destination.logString)")
+        throw EventError.cannotComplete
     }
 }
 
@@ -3183,24 +3187,34 @@ extension MenuBarItemManager {
         }
 
         let idsBeforeClick = Set(Bridging.getWindowList(option: .onScreen))
+        let clickPID = clickItem.sourcePID ?? clickItem.ownerPID
 
         do {
             // Single attempt: the item is already at a known-good position with
-            // fresh bounds. If it fails, return false immediately so the caller
-            // (IceBarItemView) fires a fallback click with default retry count
+            // fresh bounds. If it fails, fall through to the fallback path below
             // rather than spending 3× the semaphore timeout here.
             try await click(item: clickItem, with: mouseButton, skipInputPause: true, maxAttempts: 1)
         } catch {
-            MenuBarItemManager.diagLog.error("Error clicking item: \(error)")
-            // Icon is now visible but the click failed. Return .movedButClickFailed
-            // so the caller can attempt a fallback click with live bounds.
-            return .movedButClickFailed
+            MenuBarItemManager.diagLog.error("Error clicking item (first attempt): \(error) — attempting fallback click")
+
+            // Fallback: re-fetch live bounds and retry with default attempt count.
+            // We stay inside temporarilyShow so that idsBeforeClick and context
+            // remain in scope — shownInterfaceWindow can still be captured if
+            // the fallback succeeds, keeping isShowingInterface accurate for
+            // the rehide logic.
+            do {
+                try await click(item: clickItem, with: mouseButton, skipInputPause: true)
+            } catch {
+                MenuBarItemManager.diagLog.error("Fallback click also failed for \(item.logString): \(error)")
+                // Icon is visible but both click attempts failed.
+                return .movedButClickFailed
+            }
         }
 
+        // Capture the popup window opened by whichever click path succeeded.
         await eventSleep(for: .milliseconds(100))
         let windowsAfterClick = WindowInfo.createWindows(option: .onScreen)
 
-        let clickPID = clickItem.sourcePID ?? clickItem.ownerPID
         context.shownInterfaceWindow = windowsAfterClick.first { window in
             window.ownerPID == clickPID && !idsBeforeClick.contains(window.windowID)
         }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -2922,6 +2922,30 @@ extension MenuBarItemManager {
         }
     }
 
+    /// Waits until the item's Window Server origin differs from `previousOrigin`,
+    /// or until `timeout` elapses.
+    ///
+    /// Used on the fast path of `temporarilyShow` as a lightweight alternative
+    /// to `waitForItemPositionToSettle`: we only need to confirm the Window
+    /// Server has applied the new position — we don't need two consecutive
+    /// identical readings.
+    private nonisolated func waitForItemToLeaveOrigin(
+        item: MenuBarItem,
+        previousOrigin: CGPoint,
+        timeout: Duration
+    ) async {
+        let pollInterval = Duration.milliseconds(15)
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            await eventSleep(for: pollInterval)
+            if let currentOrigin = Bridging.getWindowBounds(for: item.windowID)?.origin,
+               currentOrigin != previousOrigin
+            {
+                return
+            }
+        }
+    }
+
     /// Schedules a timer for the given interval that rehides the
     /// temporarily shown items when fired.
     private func runRehideTimer(for interval: TimeInterval? = nil) {
@@ -2959,10 +2983,16 @@ extension MenuBarItemManager {
     ///   - item: The item to temporarily show.
     ///   - mouseButton: The mouse button to click the item with.
     ///   - displayID: The display identifier to show the item on.
-    func temporarilyShow(item: MenuBarItem, clickingWith mouseButton: CGMouseButton, on displayID: CGDirectDisplayID? = nil, fastPath: Bool = false) async {
+    /// Temporarily moves `item` into the visible area next to the Ice icon,
+    /// clicks it, then schedules a rehide.
+    ///
+    /// - Returns: `true` if the item was successfully moved **and** clicked;
+    ///   `false` if either step failed (the caller may attempt a fallback click).
+    @discardableResult
+    func temporarilyShow(item: MenuBarItem, clickingWith mouseButton: CGMouseButton, on displayID: CGDirectDisplayID? = nil, fastPath: Bool = false) async -> Bool {
         guard let appState else {
             MenuBarItemManager.diagLog.error("Missing AppState, so not showing \(item.logString)")
-            return
+            return false
         }
 
         MenuBarItemManager.diagLog.debug("temporarilyShow: started for \(item.logString)")
@@ -3007,7 +3037,7 @@ extension MenuBarItemManager {
 
         guard let returnInfo = getReturnDestination(for: item, in: items) else {
             MenuBarItemManager.diagLog.error("No return destination for \(item.logString) on display \(resolvedDisplayID)")
-            return
+            return false
         }
 
         // Prefer inserting to the left of the Thaw/visible control item so the icon appears
@@ -3021,7 +3051,7 @@ extension MenuBarItemManager {
             let alert = NSAlert()
             alert.messageText = String(localized: "Not enough room to show \"\(item.displayName)\"")
             alert.runModal()
-            return
+            return false
         }
 
         let moveDestination: MoveDestination = .leftOfItem(anchor)
@@ -3052,12 +3082,18 @@ extension MenuBarItemManager {
 
         MenuBarItemManager.diagLog.debug("Temporarily showing \(item.logString) on display \(resolvedDisplayID)")
 
+        // Capture the item's origin before the move so the fast-path settle
+        // can detect when the Window Server has applied the new position.
+        let preMoveOrigin = Bridging.getWindowBounds(for: item.windowID)?.origin
+
         do {
             if fastPath {
-                // Single attempt move — the first attempt always repositions the item
-                // close enough. Skipping retries eliminates the visible jitter from
-                // the 8-attempt retry loop with exponentially increasing timeouts.
-                try await move(item: item, to: moveDestination, on: resolvedDisplayID, skipInputPause: true, maxMoveAttempts: 1)
+                // Two-attempt move on the fast path. The first attempt almost always
+                // repositions the item correctly; the second is a cheap safety net for
+                // the rare case where the event cycle is dropped under CPU load.
+                // Keeping retries at 2 (vs. the default 8) avoids the visible jitter
+                // from a long retry loop while still tolerating one bad cycle.
+                try await move(item: item, to: moveDestination, on: resolvedDisplayID, skipInputPause: true, maxMoveAttempts: 2)
             } else {
                 try await move(item: item, to: moveDestination, on: resolvedDisplayID, skipInputPause: true)
             }
@@ -3066,7 +3102,7 @@ extension MenuBarItemManager {
             pendingRelocations.removeValue(forKey: tagIdentifier)
             pendingReturnDestinations.removeValue(forKey: tagIdentifier)
             persistPendingRelocations()
-            return
+            return false
         }
 
         let context = TemporarilyShownItemContext(
@@ -3087,9 +3123,22 @@ extension MenuBarItemManager {
 
         let clickItem: MenuBarItem
         if fastPath {
-            // Fast path: skip settle wait, re-fetch, and extra sleep to minimize
-            // the time the jittering icon is visible before the menu opens.
-            clickItem = item
+            // Fast path: lightweight settle (max 150 ms, 15 ms poll) so the
+            // click target coordinates are live rather than the pre-move bounds.
+            // This is shorter than the full waitForItemPositionToSettle (250 ms)
+            // to keep the IceBar click feel snappy.
+            if let preMoveOrigin {
+                await waitForItemToLeaveOrigin(item: item, previousOrigin: preMoveOrigin, timeout: .milliseconds(150))
+            }
+
+            // Re-fetch the item so getCurrentBounds inside postClickEvents
+            // uses a fresh window reference rather than the stale pre-move struct.
+            let refreshedItems = await MenuBarItem.getMenuBarItems(on: resolvedDisplayID, option: .onScreen)
+            clickItem = refreshedItems.first(where: { $0.windowID == item.windowID }) ??
+                refreshedItems.first(where: {
+                    $0.tag.matchesIgnoringWindowID(item.tag) &&
+                        ($0.sourcePID ?? $0.ownerPID) == (item.sourcePID ?? item.ownerPID)
+                }) ?? item
         } else {
             // Wait for the item's position to stabilize after the move. Some
             // apps need time to process the window relocation before they can
@@ -3117,7 +3166,9 @@ extension MenuBarItemManager {
             try await click(item: clickItem, with: mouseButton, skipInputPause: true)
         } catch {
             MenuBarItemManager.diagLog.error("Error clicking item: \(error)")
-            return
+            // Icon is now visible but the click failed. Return false so the
+            // caller can attempt a fallback click with live bounds.
+            return false
         }
 
         await eventSleep(for: .milliseconds(100))
@@ -3127,6 +3178,8 @@ extension MenuBarItemManager {
         context.shownInterfaceWindow = windowsAfterClick.first { window in
             window.ownerPID == clickPID && !idsBeforeClick.contains(window.windowID)
         }
+
+        return true
     }
 
     /// Resolves the best move destination for returning a temporarily shown

--- a/Thaw/MenuBar/Search/MenuBarSearchPanel.swift
+++ b/Thaw/MenuBar/Search/MenuBarSearchPanel.swift
@@ -688,16 +688,13 @@ private struct MenuBarSearchContentView: View {
             if Bridging.isWindowOnScreen(item.windowID) {
                 try await itemManager.click(item: item, with: .left)
             } else {
-                let result = await itemManager.temporarilyShow(
+                // temporarilyShow handles move, click, and fallback click
+                // internally so shownInterfaceWindow is always captured.
+                await itemManager.temporarilyShow(
                     item: item,
                     clickingWith: .left,
                     on: displayID
                 )
-                if result == .movedButClickFailed {
-                    // Item is visible but the synthetic click failed.
-                    // Try a direct click with live bounds.
-                    try? await itemManager.click(item: item, with: .left)
-                }
             }
         }
     }

--- a/Thaw/MenuBar/Search/MenuBarSearchPanel.swift
+++ b/Thaw/MenuBar/Search/MenuBarSearchPanel.swift
@@ -688,11 +688,16 @@ private struct MenuBarSearchContentView: View {
             if Bridging.isWindowOnScreen(item.windowID) {
                 try await itemManager.click(item: item, with: .left)
             } else {
-                await itemManager.temporarilyShow(
+                let result = await itemManager.temporarilyShow(
                     item: item,
                     clickingWith: .left,
                     on: displayID
                 )
+                if result == .movedButClickFailed {
+                    // Item is visible but the synthetic click failed.
+                    // Try a direct click with live bounds.
+                    try? await itemManager.click(item: item, with: .left)
+                }
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?

Replace the blind 25ms sleep before the on-screen check with a real panel-closed poll (10ms intervals, 200ms max) so the wrong click path is never taken while the IceBar window is still visible.

On the temp-show path: raise fast-path move attempts from 1 to 2, add a lightweight 150ms origin-change poll after the move before clicking, and re-fetch the item by windowID so click coordinates are live rather than pre-move. temporarilyShow now returns Bool so callers can fire a fallback click when the move succeeded but the click failed.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

## What is the current behavior?

Issue Number: #318, #240

## What is the new behavior?

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [ ] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable menu visibility checks using adaptive wait logic to avoid missed interactions
  * Improved temporary-show handling with clearer outcomes and enhanced logging
  * Faster, more responsive interaction timeouts to reduce stalls and avoid hangs
  * Tuned retry and fallback click behavior plus refreshed positioning for more accurate clicks

* **Documentation**
  * Added inline docs clarifying temporary-show/click behavior and fallbacks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->