### PR TITLE
fix: remove Material-era opacity reductions for Glass design

### DIFF
--- a/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
@@ -241,10 +241,10 @@ final class LayoutBarItemView: LayoutBarArrangedView {
             xRadius: Metrics.placeholderCornerRadius,
             yRadius: Metrics.placeholderCornerRadius
         )
-        NSColor.quaternaryLabelColor.withAlphaComponent(0.18).setFill()
+        NSColor.quaternaryLabelColor.withAlphaComponent(0.35).setFill()
         backgroundPath.fill()
 
-        NSColor.separatorColor.withAlphaComponent(0.35).setStroke()
+        NSColor.separatorColor.withAlphaComponent(0.6).setStroke()
         backgroundPath.lineWidth = 1
         backgroundPath.stroke()
 

--- a/Thaw/MenuBar/LayoutBar/LayoutBarNewItemsBadgeView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarNewItemsBadgeView.swift
@@ -70,10 +70,10 @@ final class LayoutBarNewItemsBadgeView: LayoutBarArrangedView {
         let fillColor: NSColor = isBright ? .black : .white
         let strokeColor: NSColor = isBright ? .black : .white
 
-        fillColor.withAlphaComponent(0.14).setFill()
+        fillColor.withAlphaComponent(0.25).setFill()
         pillPath.fill()
 
-        strokeColor.withAlphaComponent(0.45).setStroke()
+        strokeColor.withAlphaComponent(0.65).setStroke()
         pillPath.lineWidth = Metrics.borderWidth
         pillPath.stroke()
 

--- a/Thaw/MenuBar/LayoutBar/NotchIndicatorOverlay.swift
+++ b/Thaw/MenuBar/LayoutBar/NotchIndicatorOverlay.swift
@@ -76,19 +76,19 @@ struct NotchIndicatorOverlay: View {
     /// Color for diagonal stripes based on menu bar background brightness.
     private var stripeColor: Color {
         let isBright = isBrightForActiveScreen()
-        return isBright ? .black.opacity(0.25) : .white.opacity(0.25)
+        return isBright ? .black.opacity(0.5) : .white.opacity(0.5)
     }
 
     /// Border color based on menu bar background brightness.
     private var borderColor: Color {
         let isBright = isBrightForActiveScreen()
-        return isBright ? .black.opacity(0.4) : .white.opacity(0.4)
+        return isBright ? .black.opacity(0.65) : .white.opacity(0.65)
     }
 
     /// Text color based on menu bar background brightness.
     private var textColor: Color {
         let isBright = isBrightForActiveScreen()
-        return isBright ? .black.opacity(0.5) : .white.opacity(0.5)
+        return isBright ? .black : .white
     }
 
     /// Background color for the text pill, matching the menu bar background.

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -3015,6 +3015,7 @@ extension MenuBarItemManager {
     /// - Returns: A ``TemporaryShowResult`` describing whether the move and
     ///   click succeeded. Only act on ``TemporaryShowResult/movedButClickFailed``
     ///   for fallback clicks — the item is hidden for every other non-success case.
+    @discardableResult
     func temporarilyShow(item: MenuBarItem, clickingWith mouseButton: CGMouseButton, on displayID: CGDirectDisplayID? = nil, fastPath: Bool = false) async -> TemporaryShowResult {
         guard let appState else {
             MenuBarItemManager.diagLog.error("Missing AppState, so not showing \(item.logString)")

--- a/Thaw/MenuBar/Search/MenuBarSearchPanel.swift
+++ b/Thaw/MenuBar/Search/MenuBarSearchPanel.swift
@@ -516,7 +516,6 @@ private struct MenuBarSearchContentView: View {
             .padding(15)
 
             Divider()
-                .opacity(0.7)
                 .padding(.horizontal, 15)
         }
     }

--- a/Thaw/Settings/SettingsPanes/AboutSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/AboutSettingsPane.swift
@@ -99,7 +99,7 @@ struct AboutSettingsPane: View {
 
                     Text(Constants.copyrightString)
                         .font(.system(size: 14))
-                        .foregroundStyle(.secondary.opacity(0.67))
+                        .foregroundStyle(.secondary)
                 }
                 .fontWeight(.medium)
             }
@@ -157,7 +157,7 @@ struct AboutSettingsPane: View {
                 .font(.caption)
                 .monospacedDigit()
                 .foregroundStyle(.secondary)
-                .opacity(updatesManager.lastUpdateCheckDate == nil ? 0.5 : 1.0)
+                .opacity(updatesManager.lastUpdateCheckDate == nil ? 0.75 : 1.0)
         }
     }
 
@@ -167,7 +167,7 @@ struct AboutSettingsPane: View {
                 Button("Quit \(Constants.displayName)") {
                     NSApp.terminate(nil)
                 }
-                .foregroundStyle(.red.opacity(0.8))
+                .foregroundStyle(.red)
                 .buttonStyle(.plain)
 
                 Spacer()

--- a/Thaw/Settings/SettingsPanes/AboutSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/AboutSettingsPane.swift
@@ -43,11 +43,9 @@ struct AboutSettingsPane: View {
     }
 
     private func contentForm() -> some View {
-        IceForm(spacing: 0) {
+        IceForm {
             mainContent()
-
-            Spacer(minLength: 20)
-
+            Spacer()
             bottomBar()
         }
     }

--- a/Thaw/UI/IceUI/IceForm.swift
+++ b/Thaw/UI/IceUI/IceForm.swift
@@ -98,5 +98,5 @@ extension EdgeInsets {
 
 extension CGFloat {
     /// The default spacing for an ``IceForm``.
-    static let iceFormDefaultSpacing: CGFloat = 10
+    static let iceFormDefaultSpacing: CGFloat = 24
 }

--- a/Thaw/UI/IceUI/IceGradientPicker.swift
+++ b/Thaw/UI/IceUI/IceGradientPicker.swift
@@ -357,7 +357,7 @@ private struct IceGradientPickerHandle: View {
                 .fill(Color(cgColor: stop.color))
                 .glassEffect(.regular.interactive(), in: borderShape)
                 .overlay(
-                    borderShape.strokeBorder(isSelected ? AnyShapeStyle(.white.opacity(0.5)) : AnyShapeStyle(.separator.opacity(0.3)), lineWidth: 1.0)
+                    borderShape.strokeBorder(isSelected ? AnyShapeStyle(.white.opacity(0.5)) : AnyShapeStyle(.separator), lineWidth: 1.0)
                 )
                 .background(
                     isSelected ? AnyShapeStyle(.tint) : AnyShapeStyle(.clear),

--- a/Thaw/UI/IceUI/IceGroupBox.swift
+++ b/Thaw/UI/IceUI/IceGroupBox.swift
@@ -166,7 +166,7 @@ struct IceGroupBox<Header: View, Content: View, Footer: View>: View {
                 .padding(padding)
                 .glassEffect(.regular, in: backgroundShape)
                 .overlay(
-                    backgroundShape.strokeBorder(.separator.opacity(0.2), lineWidth: 0.5)
+                    backgroundShape.strokeBorder(.separator, lineWidth: 0.5)
                 )
                 .containerShape(backgroundShape)
 

--- a/Thaw/UI/IceUI/IceSection.swift
+++ b/Thaw/UI/IceUI/IceSection.swift
@@ -120,7 +120,7 @@ struct IceSection<Header: View, Content: View, Footer: View>: View {
                     .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
                     .overlay(
                         RoundedRectangle(cornerRadius: 20, style: .continuous)
-                            .strokeBorder(.separator.opacity(0.2), lineWidth: 0.5)
+                            .strokeBorder(.separator, lineWidth: 0.5)
                     )
                 } else {
                     contentLayout
@@ -190,7 +190,6 @@ private struct IceSectionLayout: _VariadicView_UnaryViewRoot {
 private struct IceSectionDivider: View {
     var body: some View {
         Divider()
-            .opacity(0.4)
             .padding(.horizontal, 4)
     }
 }

--- a/Thaw/UI/IceUI/IceSection.swift
+++ b/Thaw/UI/IceUI/IceSection.swift
@@ -128,7 +128,6 @@ struct IceSection<Header: View, Content: View, Footer: View>: View {
 
                 footerView
             }
-            .padding(.bottom, 24)
         }
     }
 

--- a/Thaw/UI/IceUI/IceSlider.swift
+++ b/Thaw/UI/IceUI/IceSlider.swift
@@ -97,12 +97,11 @@ struct IceSlider<Value: BinaryFloatingPoint, ValueLabel: View>: View {
                 }
             }
             .padding(.horizontal, 8)
-            .opacity(0.8)
             .frame(height: height)
         }
         .glassEffect(.regular, in: borderShape)
         .overlay(
-            borderShape.strokeBorder(.separator.opacity(0.15), lineWidth: 0.5)
+            borderShape.strokeBorder(.separator, lineWidth: 0.5)
         )
         .compactSliderDisabledHapticFeedback(true)
         .compactSliderSecondaryColor(

--- a/Thaw/UI/Views/BetaBadge.swift
+++ b/Thaw/UI/Views/BetaBadge.swift
@@ -21,7 +21,7 @@ struct BetaBadge: View {
             .padding(.vertical, 1)
             .background {
                 backgroundShape
-                    .fill(.foreground.opacity(0.25))
+                    .fill(.quaternary)
             }
             .foregroundStyle(.green)
     }

--- a/Thaw/UI/Views/HotkeyRecorder.swift
+++ b/Thaw/UI/Views/HotkeyRecorder.swift
@@ -221,7 +221,6 @@ private struct HotkeyRecorderButtonStyle: ButtonStyle {
         let isProminent = configuration.isPressed != isHighlighted
         borderShape
             .fill(isProminent ? .tertiary : .quaternary)
-            .opacity(isProminent ? 0.5 : 0.75)
             .overlay {
                 configuration.label
                     .lineLimit(1)


### PR DESCRIPTION
Remove opacity reductions from dividers, borders, and text elements
that made them nearly invisible on Apple's Liquid Glass surfaces.

System colors like .separator and .secondary already adapt correctly
to glass contexts without manual opacity adjustments.

Signed-off-by: Toni Förster <toni.foerster@icloud.com>## What does this PR do?

A brief description of the changes proposed in this pull request.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [x] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

## What is the current behavior?

What is happening now?
Issue Number: (if applicable, otherwise remove this line or write 'N/A')

## What is the new behavior?

What does this PR change or add?

## PR Checklist

- [ ] I’ve built and run the app locally
- [ ] I’ve checked for console errors or crashes
- [ ] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

Screenshots, notes, links to related issues/PRs, or anything useful for reviewers.

### Notes for reviewers

Anything you’d like reviewers to focus on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved visual contrast across UI components with refined opacity and color adjustments
  * Enhanced placeholder, badge, and border styling for better visibility
  * Updated spacing and layout for improved visual consistency
  * Streamlined component styling throughout the interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->