### PR TITLE
fix(rehide): prevent permanent semaphore saturation from stuck items

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -3057,13 +3057,13 @@ extension MenuBarItemManager {
             rehideCancellable?.cancel()
             await rehideTemporarilyShownItems(force: true, isCalledFromTemporarilyShow: true)
 
-            // If a different item is still stuck after force-rehide (all move
-            // attempts timed out — typically a dead PID or broken EventTap),
-            // proceeding would pile more semaphore-saturating move operations
-            // on top of already-broken state. Bail out early; the stuck item
-            // remains in temporarilyShownItemContexts for the rehide timer.
+            // Only treat contexts with rehideAttempts > 0 as genuinely stuck
+            // (move was attempted and failed). Contexts with rehideAttempts == 0
+            // but notFoundAttempts > 0 are merely not visible on the active
+            // space right now — they are transient and will retry fine.
+            // Bailing on notFound items would leave them permanently stranded.
             let stuckItems = temporarilyShownItemContexts.filter {
-                !$0.tag.matchesIgnoringWindowID(item.tag)
+                !$0.tag.matchesIgnoringWindowID(item.tag) && $0.rehideAttempts > 0
             }
             if !stuckItems.isEmpty {
                 MenuBarItemManager.diagLog.error(
@@ -3073,6 +3073,9 @@ extension MenuBarItemManager {
                     Avoiding further semaphore saturation.
                     """
                 )
+                // Re-arm the rehide timer so stuck contexts are retried rather
+                // than left stranded with no scheduled retry.
+                runRehideTimer()
                 return .showFailed
             }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -413,6 +413,34 @@ final class MenuBarItemManager: ObservableObject {
         }
     }
 
+    /// Prefix used in `pendingRelocations` values to mark items whose rehide
+    /// failed terminally in the current session. The suffix is the item's
+    /// `windowID` at the time of failure, used to detect app relaunches.
+    private static let waitForRelaunchPrefix = "waitForRelaunch:"
+
+    /// Returns a `pendingRelocations` sentinel value that suppresses same-session
+    /// move attempts. Encodes `windowID` so that a relaunch (new windowID) clears
+    /// the suppression automatically.
+    private func waitForRelaunchValue(windowID: CGWindowID, section: MenuBarSection.Name) -> String {
+        "\(Self.waitForRelaunchPrefix)\(windowID):\(sectionKey(for: section))"
+    }
+
+    /// Parses a `pendingRelocations` sentinel value.
+    /// Returns `(windowID, section)` if the value is a wait-for-relaunch entry,
+    /// or `nil` if it is a plain section key.
+    private func parseWaitForRelaunch(_ value: String) -> (windowID: CGWindowID, section: MenuBarSection.Name)? {
+        guard value.hasPrefix(Self.waitForRelaunchPrefix) else { return nil }
+        let payload = value.dropFirst(Self.waitForRelaunchPrefix.count)
+        // Format: "<windowID>:<sectionKey>"
+        guard let colonIndex = payload.firstIndex(of: ":") else { return nil }
+        let widString = String(payload[payload.startIndex ..< colonIndex])
+        let secString = String(payload[payload.index(after: colonIndex)...])
+        guard let wid = CGWindowID(widString),
+              let section = sectionName(for: secString)
+        else { return nil }
+        return (wid, section)
+    }
+
     /// Returns the effective section for newly detected menu bar items, falling back
     /// to hidden when the always-hidden section is currently disabled.
     var effectiveNewItemsSection: MenuBarSection.Name {
@@ -3493,14 +3521,24 @@ extension MenuBarItemManager {
                     // Per-call cap reached; schedule a longer-delay retry.
                     failedContexts.append(context)
                 } else {
-                    // Total cap reached — permanently drop this context.
-                    // pendingRelocations entry is preserved so the next cache
-                    // cycle (relocatePendingItems) can recover on restart.
+                    // Total cap reached — drop this context from same-session retries.
+                    // Overwrite the pendingRelocations entry with a waitForRelaunch
+                    // sentinel so relocatePendingItems() skips move() this session.
+                    // The sentinel encodes the current windowID; when the app
+                    // relaunches its status item gets a new windowID, clearing the
+                    // suppression automatically.
+                    let tagIdentifier = context.tag.tagIdentifier
+                    pendingRelocations[tagIdentifier] = waitForRelaunchValue(
+                        windowID: item.windowID,
+                        section: context.originalSection
+                    )
+                    persistPendingRelocations()
                     MenuBarItemManager.diagLog.error(
                         """
                         Giving up rehide for \(item.logString) after \
                         \(context.rehideAttempts) total attempts; \
-                        pendingRelocations will handle recovery on next launch
+                        marked waitForRelaunch — relocatePendingItems will \
+                        retry only after app relaunch (new windowID)
                         """
                     )
                 }
@@ -3783,7 +3821,33 @@ extension MenuBarItemManager {
             guard !activelyShownTags.contains(tagIdentifier) else {
                 continue
             }
-            guard let targetSection = sectionName(for: sectionString),
+
+            // Handle waitForRelaunch sentinel — item hit the rehide cap this
+            // session. Skip the move unless the app has relaunched (new windowID).
+            if let sentinel = parseWaitForRelaunch(sectionString) {
+                guard let item = items.first(where: { tagIdentifier == $0.tag.tagIdentifier }) else {
+                    // App not running at all — keep the entry for next launch.
+                    continue
+                }
+                if item.windowID == sentinel.windowID {
+                    // Same session / same window — skip to avoid re-saturating
+                    // the event semaphore with a known-broken move.
+                    MenuBarItemManager.diagLog.debug(
+                        "relocatePendingItems: skipping \(item.logString) — waitForRelaunch sentinel active (same windowID)"
+                    )
+                    continue
+                }
+                // WindowID changed — app relaunched. Promote back to a normal
+                // pending relocation so the regular move path runs below.
+                MenuBarItemManager.diagLog.info(
+                    "relocatePendingItems: \(item.logString) has new windowID — clearing waitForRelaunch sentinel"
+                )
+                pendingRelocations[tagIdentifier] = sectionKey(for: sentinel.section)
+                persistPendingRelocations()
+                // Fall through to the normal relocation logic with the promoted value.
+            }
+
+            guard let targetSection = sectionName(for: pendingRelocations[tagIdentifier] ?? sectionString),
                   targetSection != .visible
             else {
                 // Nothing to do if the original section was visible.

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -2332,6 +2332,15 @@ extension MenuBarItemManager {
         }
         defer { Task.detached { [eventSemaphore] in await eventSemaphore.signal() } }
 
+        // Fast-fail if the target process is dead. CGEvent.tapCreateForPid
+        // silently produces an invalid Mach port for dead PIDs, causing every
+        // scrombleEvent to time out and burn the full 3.5 s semaphore budget.
+        let eventPID = getEventPID(for: item)
+        if kill(eventPID, 0) == -1, errno == ESRCH {
+            MenuBarItemManager.diagLog.error("postMoveEvents: target PID \(eventPID) for \(item.logString) is dead — skipping move")
+            throw EventError.cannotComplete
+        }
+
         var itemOrigin = try await getCurrentBounds(for: item).origin
         let targetPoints = try await getTargetPoints(forMoving: item, to: destination, on: displayID)
         // Capture mouse location only when this call owns the cursor warp.
@@ -3048,9 +3057,25 @@ extension MenuBarItemManager {
             rehideCancellable?.cancel()
             await rehideTemporarilyShownItems(force: true, isCalledFromTemporarilyShow: true)
 
-            // If some items failed to rehide (e.g. move timed out), don't remove
-            // them from the contexts list. They will be retried by the rehide timer
-            // or the next temporarilyShow call.
+            // If a different item is still stuck after force-rehide (all move
+            // attempts timed out — typically a dead PID or broken EventTap),
+            // proceeding would pile more semaphore-saturating move operations
+            // on top of already-broken state. Bail out early; the stuck item
+            // remains in temporarilyShownItemContexts for the rehide timer.
+            let stuckItems = temporarilyShownItemContexts.filter {
+                !$0.tag.matchesIgnoringWindowID(item.tag)
+            }
+            if !stuckItems.isEmpty {
+                MenuBarItemManager.diagLog.error(
+                    """
+                    temporarilyShow: aborting — \(stuckItems.count) item(s) still stuck \
+                    after force-rehide: \(stuckItems.map { $0.tag }). \
+                    Avoiding further semaphore saturation.
+                    """
+                )
+                return .showFailed
+            }
+
             if temporarilyShownItemContexts.contains(where: { $0.tag.matchesIgnoringWindowID(item.tag) }) {
                 // The item we want to show is already in the temporary list.
                 // This can happen if the user clicks the same item twice very fast.
@@ -3454,13 +3479,27 @@ extension MenuBarItemManager {
                     \(error)
                     """
                 )
+                // Maximum total attempts across all timer rounds.
+                // 3 per-call attempts × 3 timer rounds = 9. Beyond this the
+                // item is permanently stuck (dead PID, broken EventTap, etc.)
+                // and retrying only keeps the event semaphore saturated.
+                let maxTotalRehideAttempts = 9
                 if context.rehideAttempts < 3 {
                     currentContexts.append(context) // Try again immediately.
-                } else {
-                    // Move failed 3 times with the item present. Reset and
-                    // schedule a longer-delay retry.
-                    context.rehideAttempts = 0
+                } else if context.rehideAttempts < maxTotalRehideAttempts {
+                    // Per-call cap reached; schedule a longer-delay retry.
                     failedContexts.append(context)
+                } else {
+                    // Total cap reached — permanently drop this context.
+                    // pendingRelocations entry is preserved so the next cache
+                    // cycle (relocatePendingItems) can recover on restart.
+                    MenuBarItemManager.diagLog.error(
+                        """
+                        Giving up rehide for \(item.logString) after \
+                        \(context.rehideAttempts) total attempts; \
+                        pendingRelocations will handle recovery on next launch
+                        """
+                    )
                 }
             }
         }


### PR DESCRIPTION
Dead or unresponsive processes caused postMoveEvents to burn 3.5s per attempt via a silent EventTap failure, locking up the event semaphore indefinitely and making every subsequent IceBar click fail until restart.

Add a kill(pid, 0) check in postMoveEvents to fast-fail immediately for dead PIDs instead of waiting out the full semaphore timeout.

Cap total rehide attempts at 9 (3 per-call × 3 timer rounds) in rehideTemporarilyShownItems — stop resetting rehideAttempts before failedContexts.append so the count accumulates across timer rounds. Once the cap is hit the context is permanently dropped; pendingRelocations is preserved for next-launch recovery via relocatePendingItems.

In temporarilyShow, return .showFailed immediately after force-rehide if any other item is still stuck, preventing new move operations from being queued on top of already-saturated semaphore state.

## What does this PR do?

A brief description of the changes proposed in this pull request.

## PR Type

- [ ] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path:

## What is the current behavior?

What is happening now?
Issue Number: (if applicable, otherwise remove this line or write 'N/A')

## What is the new behavior?

What does this PR change or add?

## PR Checklist

- [ ] I’ve built and run the app locally
- [ ] I’ve checked for console errors or crashes
- [ ] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

Screenshots, notes, links to related issues/PRs, or anything useful for reviewers.

### Notes for reviewers

Anything you’d like reviewers to focus on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented attempts to move items into processes that have exited, reducing failed moves.
  * Improved temporary-show handling so truly stuck items are detected, aborting and retrying shows when needed.
  * Capped total re-hide retries and deferred same-session relocations until the app restarts, improving stability and avoiding wasted retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->