### PR TITLE
fix(icebar): use live windowID check after sleep

### DIFF
--- a/Thaw/MenuBar/IceBar/IceBar.swift
+++ b/Thaw/MenuBar/IceBar/IceBar.swift
@@ -533,17 +533,7 @@ private struct IceBarItemView: View {
                 // item visibility. Uses KVO on isVisible so we resume as soon
                 // as the panel hides rather than busy-polling.
                 await panel.waitUntilClosed(timeout: .milliseconds(200))
-                // Re-fetch on-screen items and match by tag+PID rather than
-                // the cached windowID. After a long sleep macOS recycles
-                // CGWindowIDs, so item.windowID may belong to an unrelated
-                // window, causing isWindowOnScreen to return a false positive
-                // and the click to target the wrong window entirely.
-                let liveItems = await MenuBarItem.getMenuBarItems(on: displayID, option: .onScreen)
-                let liveItem = liveItems.first(where: {
-                    $0.tag.matchesIgnoringWindowID(item.tag) &&
-                        ($0.sourcePID ?? $0.ownerPID) == (item.sourcePID ?? item.ownerPID)
-                })
-                if let liveItem, Bridging.isWindowOnScreen(liveItem.windowID) {
+                if let liveItem = await liveOnScreenItem(matching: item, on: displayID) {
                     try await itemManager.click(item: liveItem, with: .left)
                     let duration = Date.now.timeIntervalSince(clickStartTime)
                     IceBarItemView.diagLog.debug("leftClick: ✓ completed in \(Int(duration * 1000))ms (on-screen path)")
@@ -568,14 +558,7 @@ private struct IceBarItemView: View {
             menuBarManager.section(withName: section)?.hide()
             Task {
                 await panel.waitUntilClosed(timeout: .milliseconds(200))
-                // Same stale-windowID guard as leftClickAction — re-fetch live
-                // items and match by tag+PID to get a post-wake windowID.
-                let liveItems = await MenuBarItem.getMenuBarItems(on: displayID, option: .onScreen)
-                let liveItem = liveItems.first(where: {
-                    $0.tag.matchesIgnoringWindowID(item.tag) &&
-                        ($0.sourcePID ?? $0.ownerPID) == (item.sourcePID ?? item.ownerPID)
-                })
-                if let liveItem, Bridging.isWindowOnScreen(liveItem.windowID) {
+                if let liveItem = await liveOnScreenItem(matching: item, on: displayID) {
                     try await itemManager.click(item: liveItem, with: .right)
                 } else {
                     let result = await itemManager.temporarilyShow(item: item, clickingWith: .right, on: displayID, fastPath: true)
@@ -583,6 +566,21 @@ private struct IceBarItemView: View {
                 }
             }
         }
+    }
+
+    /// Re-fetches on-screen items and returns the live `MenuBarItem` whose
+    /// tag+PID matches `item`, or `nil` if the item is not currently on-screen.
+    ///
+    /// Matching by tag+PID rather than the cached `windowID` guards against
+    /// CGWindowID recycling after a long system sleep, which would otherwise
+    /// cause `isWindowOnScreen` to return a false positive for an unrelated window.
+    private func liveOnScreenItem(matching item: MenuBarItem, on displayID: CGDirectDisplayID) async -> MenuBarItem? {
+        let liveItems = await MenuBarItem.getMenuBarItems(on: displayID, option: .onScreen)
+        guard let liveItem = liveItems.first(where: {
+            $0.tag.matchesIgnoringWindowID(item.tag) &&
+                ($0.sourcePID ?? $0.ownerPID) == (item.sourcePID ?? item.ownerPID)
+        }) else { return nil }
+        return Bridging.isWindowOnScreen(liveItem.windowID) ? liveItem : nil
     }
 
     private var image: NSImage? {

--- a/Thaw/MenuBar/IceBar/IceBar.swift
+++ b/Thaw/MenuBar/IceBar/IceBar.swift
@@ -533,8 +533,18 @@ private struct IceBarItemView: View {
                 // item visibility. Uses KVO on isVisible so we resume as soon
                 // as the panel hides rather than busy-polling.
                 await panel.waitUntilClosed(timeout: .milliseconds(200))
-                if Bridging.isWindowOnScreen(item.windowID) {
-                    try await itemManager.click(item: item, with: .left)
+                // Re-fetch on-screen items and match by tag+PID rather than
+                // the cached windowID. After a long sleep macOS recycles
+                // CGWindowIDs, so item.windowID may belong to an unrelated
+                // window, causing isWindowOnScreen to return a false positive
+                // and the click to target the wrong window entirely.
+                let liveItems = await MenuBarItem.getMenuBarItems(on: displayID, option: .onScreen)
+                let liveItem = liveItems.first(where: {
+                    $0.tag.matchesIgnoringWindowID(item.tag) &&
+                        ($0.sourcePID ?? $0.ownerPID) == (item.sourcePID ?? item.ownerPID)
+                })
+                if let liveItem, Bridging.isWindowOnScreen(liveItem.windowID) {
+                    try await itemManager.click(item: liveItem, with: .left)
                     let duration = Date.now.timeIntervalSince(clickStartTime)
                     IceBarItemView.diagLog.debug("leftClick: ✓ completed in \(Int(duration * 1000))ms (on-screen path)")
                 } else {
@@ -558,8 +568,15 @@ private struct IceBarItemView: View {
             menuBarManager.section(withName: section)?.hide()
             Task {
                 await panel.waitUntilClosed(timeout: .milliseconds(200))
-                if Bridging.isWindowOnScreen(item.windowID) {
-                    try await itemManager.click(item: item, with: .right)
+                // Same stale-windowID guard as leftClickAction — re-fetch live
+                // items and match by tag+PID to get a post-wake windowID.
+                let liveItems = await MenuBarItem.getMenuBarItems(on: displayID, option: .onScreen)
+                let liveItem = liveItems.first(where: {
+                    $0.tag.matchesIgnoringWindowID(item.tag) &&
+                        ($0.sourcePID ?? $0.ownerPID) == (item.sourcePID ?? item.ownerPID)
+                })
+                if let liveItem, Bridging.isWindowOnScreen(liveItem.windowID) {
+                    try await itemManager.click(item: liveItem, with: .right)
                 } else {
                     let result = await itemManager.temporarilyShow(item: item, clickingWith: .right, on: displayID, fastPath: true)
                     IceBarItemView.diagLog.debug("rightClick: temp-show result=\(result)")


### PR DESCRIPTION
After a long sleep macOS recycles CGWindowIDs. The cached item.windowID in IceBarItemView could belong to an unrelated on-screen window, causing isWindowOnScreen to return true and routing the click through the on-screen path instead of temporarilyShow — so the item was never revealed.

## What does this PR do?

A brief description of the changes proposed in this pull request.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [x] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path:

## What is the current behavior?

What is happening now?
Issue Number: (if applicable, otherwise remove this line or write 'N/A')

## What is the new behavior?

What does this PR change or add?

## PR Checklist

- [ ] I’ve built and run the app locally
- [ ] I’ve checked for console errors or crashes
- [ ] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

Screenshots, notes, links to related issues/PRs, or anything useful for reviewers.

### Notes for reviewers

Anything you’d like reviewers to focus on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable menu bar clicks: the app now re-checks which menu bar items are actually visible and targets the live on-screen item for left/right clicks when possible. If the live item isn’t confirmed visible, it falls back to the previous visibility path. This reduces failures caused by stale cached item references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->