### PR TITLE
ctrl opt click fix

### DIFF
--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -720,7 +720,7 @@ extension HIDEventManager {
                 if let alwaysHiddenSection = appState.menuBarManager.section(withName: .alwaysHidden),
                    alwaysHiddenSection.isEnabled
                 {
-                    alwaysHiddenSection.show()
+                    alwaysHiddenSection.toggle()
                 }
             }
         } else {
@@ -734,7 +734,7 @@ extension HIDEventManager {
                    let alwaysHiddenSection = appState.menuBarManager.section(withName: .alwaysHidden),
                    alwaysHiddenSection.isEnabled
                 {
-                    Task { alwaysHiddenSection.show() }
+                    Task { alwaysHiddenSection.toggle() }
                 }
                 return
             }
@@ -742,6 +742,17 @@ extension HIDEventManager {
             if let hiddenSection = appState.menuBarManager.section(withName: .hidden),
                hiddenSection.isEnabled
             {
+                // If the always-hidden section is currently showing via the Thaw
+                // Bar, a plain click should close it rather than switch the Thaw
+                // Bar to the hidden section.
+                if appState.menuBarManager.iceBarPanel.currentSection == .alwaysHidden,
+                   let alwaysHiddenSection = appState.menuBarManager.section(withName: .alwaysHidden)
+                {
+                    disarmShowOnClickGuard()
+                    Task { alwaysHiddenSection.hide() }
+                    return
+                }
+
                 let shouldArmGuard =
                     appState.settings.general.showOnDoubleClick
                         && hiddenSection.isHidden

--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -181,7 +181,7 @@ final class HIDEventManager: ObservableObject {
             if !isAppMenuClick {
                 // Capture the click location synchronously from the event.
                 let clickLocation = NSEvent.mouseLocation
-                handleShowOnClick(appState: appState, screen: screen, clickLocation: clickLocation, isDoubleClick: event.clickCount > 1)
+                handleShowOnClick(appState: appState, screen: screen, clickLocation: clickLocation, modifierFlags: event.modifierFlags, isDoubleClick: event.clickCount > 1)
                 handleSmartRehide(with: event, appState: appState, screen: screen)
             }
         case .rightMouseDown:
@@ -703,7 +703,7 @@ extension HIDEventManager {
 
     // MARK: Handle Show On Click
 
-    private func handleShowOnClick(appState: AppState, screen: NSScreen, clickLocation: CGPoint, isDoubleClick: Bool = false) {
+    private func handleShowOnClick(appState: AppState, screen: NSScreen, clickLocation: CGPoint, modifierFlags: NSEvent.ModifierFlags, isDoubleClick: Bool = false) {
         guard appState.settings.general.showOnClick else {
             return
         }
@@ -724,12 +724,12 @@ extension HIDEventManager {
                 }
             }
         } else {
-            if NSEvent.modifierFlags.contains(.control) {
+            if modifierFlags.contains(.control) {
                 handleSecondaryContextMenu(appState: appState, screen: screen)
                 return
             }
 
-            if NSEvent.modifierFlags.contains(.option) {
+            if modifierFlags.contains(.option) {
                 if appState.settings.advanced.useOptionClickToShowAlwaysHiddenSection,
                    let alwaysHiddenSection = appState.menuBarManager.section(withName: .alwaysHidden),
                    alwaysHiddenSection.isEnabled
@@ -1585,7 +1585,11 @@ extension HIDEventManager {
             let visibleSection = appState.menuBarManager.section(
                 withName: .visible
             ),
-            let iceIconFrame = visibleSection.controlItem.frame,
+            // Use the live window frame instead of the debounced controlItem.frame.
+            // controlItem.frame has a 50ms debounce and can be stale immediately
+            // after the context menu closes, causing hit-testing to incorrectly
+            // classify an icon click as empty-space and double-fire show/toggle.
+            let iceIconFrame = visibleSection.controlItem.window?.frame,
             let mouseLocation = MouseHelpers.locationAppKit
         else {
             return false


### PR DESCRIPTION
Two related issues where modifier clicks failed to reveal the always-hidden
section or show the context menu:

1. handleShowOnClick read NSEvent.modifierFlags (live HID state) after
   expensive AX and Window Server queries in isMouseInsideEmptyMenuBarSpace.
   The modifier key could be released by then, causing the click to fall
   through to a plain toggle. Fix: capture event.modifierFlags before the
   checks and pass the frozen value into handleShowOnClick, mirroring b89a6b4.

2. isMouseInsideIceIcon used controlItem.frame which is debounced 50ms from
   window KVO. After the ctrl-click context menu closed, the debounce left
   the frame stale, causing the icon click to be misclassified as empty space.
   handleShowOnClick and performAction both fired: show() then toggle() hid
   the section again — net result nothing. Fix: use controlItem.window?.frame
   (no debounce, always current) for hit-testing.

Signed-off-by: Toni Förster <toni.foerster@icloud.com>## What does this PR do?

A brief description of the changes proposed in this pull request.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path:

## What is the current behavior?

What is happening now?
Issue Number: (if applicable, otherwise remove this line or write 'N/A')

## What is the new behavior?

What does this PR change or add?

## PR Checklist

- [ ] I’ve built and run the app locally
- [ ] I’ve checked for console errors or crashes
- [ ] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

Screenshots, notes, links to related issues/PRs, or anything useful for reviewers.

### Notes for reviewers

Anything you’d like reviewers to focus on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced keyboard modifier key detection for click interactions
  * Improved icon click accuracy and detection
  * Refined hidden UI section interaction behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->