### PR TITLE
fix(menu-bar): confirm item-window before updating trailing shape

### DIFF
--- a/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
+++ b/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
@@ -759,15 +759,15 @@ private final class MenuBarOverlayPanelContentView: NSView {
         itemWindowsConfirmTask = Task { [weak self] in
             guard let self else { return }
             var candidate: [WindowInfo]?
+            var candidateWidth: CGFloat = 0
             for _ in 0 ..< 10 {
                 guard !Task.isCancelled else { return }
                 let latest = MenuBarItem.getMenuBarItemWindows(
                     on: displayID,
                     option: .onScreen
                 )
-                let latestWidth = latest.reduce(into: CGFloat(0)) { $0 += $1.bounds.width }
-                let candidateWidth = candidate?.reduce(into: CGFloat(0)) { $0 += $1.bounds.width }
-                if let candidateWidth, abs(latestWidth - candidateWidth) < 1 {
+                let latestWidth = latest.reduce(0) { $0 + $1.bounds.width }
+                if candidate != nil, abs(latestWidth - candidateWidth) < 1 {
                     // Two consecutive reads agree on total icon width — settled.
                     await MainActor.run {
                         guard !Task.isCancelled else { return }
@@ -778,6 +778,7 @@ private final class MenuBarOverlayPanelContentView: NSView {
                 }
                 // Different from candidate — start confirming the new snapshot.
                 candidate = latest
+                candidateWidth = latestWidth
                 try? await Task.sleep(for: .milliseconds(150))
             }
             // Exhausted retries — commit whatever we last saw rather than

--- a/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
+++ b/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
@@ -614,6 +614,12 @@ private final class MenuBarOverlayPanelContentView: NSView {
     /// being queried synchronously during each `draw(_:)` call.
     private var cachedItemWindows: [WindowInfo] = []
 
+    /// In-flight confirmation task for settling the trailing item-window cache
+    /// after an app switch. Cancelled and replaced whenever a new
+    /// applicationMenuFrame value arrives so that only the latest app's icon
+    /// layout is committed.
+    private var itemWindowsConfirmTask: Task<Void, Never>?
+
     /// The overlay panel that contains the content view.
     private var overlayPanel: MenuBarOverlayPanel? {
         window as? MenuBarOverlayPanel
@@ -683,10 +689,17 @@ private final class MenuBarOverlayPanelContentView: NSView {
             // Redraw whenever the application menu frame changes.
             // Also refresh cached item windows to pick up items added/removed
             // by other apps (e.g. status bar icons appearing or disappearing).
+            //
+            // The item windows are re-read with a two-read confirmation loop
+            // (mirroring the AX confirmation used for applicationMenuFrame) so
+            // that we never commit a transitional Window Server layout. The
+            // trailing shape shadow artefact on app-switch was caused by
+            // calling updateCachedItemWindows() synchronously here, before the
+            // icon windows had settled into their new positions.
             overlayPanel.$applicationMenuFrame
                 .sink { [weak self] _ in
-                    self?.updateCachedItemWindows()
-                    self?.needsDisplay = true
+                    guard let self, let screen = self.overlayPanel?.owningScreen else { return }
+                    self.scheduleItemWindowsConfirmation(for: screen)
                 }
                 .store(in: &c)
             // Redraw whenever the desktop wallpaper changes.
@@ -716,7 +729,13 @@ private final class MenuBarOverlayPanelContentView: NSView {
     }
 
     /// Refreshes the cached menu bar item windows from the Window Server.
+    ///
+    /// Calling this directly (e.g. from the controlItem frame-change path)
+    /// cancels any in-flight confirmation task so that a fresh synchronous read
+    /// always wins over a stale async one.
     private func updateCachedItemWindows() {
+        itemWindowsConfirmTask?.cancel()
+        itemWindowsConfirmTask = nil
         guard let screen = overlayPanel?.owningScreen else {
             cachedItemWindows = []
             return
@@ -725,6 +744,49 @@ private final class MenuBarOverlayPanelContentView: NSView {
             on: screen.displayID,
             option: .onScreen
         )
+    }
+
+    /// Starts an async confirmation task that re-reads menu bar item windows
+    /// until two consecutive reads return the same total width, then commits
+    /// the result. This mirrors the two-read AX confirmation used for
+    /// `applicationMenuFrame` and prevents the trailing shape from being drawn
+    /// with a stale (transitional) icon layout immediately after an app switch.
+    private func scheduleItemWindowsConfirmation(for screen: NSScreen) {
+        itemWindowsConfirmTask?.cancel()
+        itemWindowsConfirmTask = Task { [weak self] in
+            guard let self else { return }
+            var candidate: [WindowInfo]?
+            for _ in 0 ..< 10 {
+                guard !Task.isCancelled else { return }
+                let latest = MenuBarItem.getMenuBarItemWindows(
+                    on: screen.displayID,
+                    option: .onScreen
+                )
+                let latestWidth = latest.reduce(into: CGFloat(0)) { $0 += $1.bounds.width }
+                let candidateWidth = candidate?.reduce(into: CGFloat(0)) { $0 += $1.bounds.width }
+                if let candidateWidth, abs(latestWidth - candidateWidth) < 1 {
+                    // Two consecutive reads agree on total icon width — settled.
+                    await MainActor.run {
+                        guard !Task.isCancelled else { return }
+                        self.cachedItemWindows = latest
+                        self.needsDisplay = true
+                    }
+                    return
+                }
+                // Different from candidate — start confirming the new snapshot.
+                candidate = latest
+                try? await Task.sleep(for: .milliseconds(150))
+            }
+            // Exhausted retries — commit whatever we last saw rather than
+            // leaving the cache stale.
+            if let candidate {
+                await MainActor.run {
+                    guard !Task.isCancelled else { return }
+                    self.cachedItemWindows = candidate
+                    self.needsDisplay = true
+                }
+            }
+        }
     }
 
     /// Returns a path in the given rectangle, with the given end caps,

--- a/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
+++ b/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
@@ -752,6 +752,9 @@ private final class MenuBarOverlayPanelContentView: NSView {
     /// `applicationMenuFrame` and prevents the trailing shape from being drawn
     /// with a stale (transitional) icon layout immediately after an app switch.
     private func scheduleItemWindowsConfirmation(for screen: NSScreen) {
+        // Hoist displayID before entering the Task so that no AppKit
+        // (NSScreen) access occurs off the main thread.
+        let displayID = screen.displayID
         itemWindowsConfirmTask?.cancel()
         itemWindowsConfirmTask = Task { [weak self] in
             guard let self else { return }
@@ -759,7 +762,7 @@ private final class MenuBarOverlayPanelContentView: NSView {
             for _ in 0 ..< 10 {
                 guard !Task.isCancelled else { return }
                 let latest = MenuBarItem.getMenuBarItemWindows(
-                    on: screen.displayID,
+                    on: displayID,
                     option: .onScreen
                 )
                 let latestWidth = latest.reduce(into: CGFloat(0)) { $0 += $1.bounds.width }


### PR DESCRIPTION


The $applicationMenuFrame sink called updateCachedItemWindows() synchronously the instant the AX frame settled. The Window Server icon windows hadn't finished rearranging yet at that point, so pathForSplitShape drew the trailing shape with the previous app's icon widths — leaving a shadow/ghost on the right side of the split view after every app switch.

Replace the immediate synchronous read with scheduleItemWindowsConfirmation(), an async task that re-reads item windows until two consecutive reads agree on total icon width (150 ms apart, up to 10 iterations), then commits. This mirrors the two-read AX confirmation introduced for applicationMenuFrame in d125d97. The controlItem.$onScreenFrame path retains its synchronous read (fires after items have physically moved) and cancels any in-flight confirm task.

## What does this PR do?

A brief description of the changes proposed in this pull request.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path:

## What is the current behavior?

What is happening now?
Issue Number: (if applicable, otherwise remove this line or write 'N/A')

## What is the new behavior?

What does this PR change or add?

## PR Checklist

- [ ] I’ve built and run the app locally
- [ ] I’ve checked for console errors or crashes
- [ ] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

Screenshots, notes, links to related issues/PRs, or anything useful for reviewers.

### Notes for reviewers

Anything you’d like reviewers to focus on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced transient menu-bar icon-width glitches and flicker when switching apps by adding a background confirmation step that stabilizes measurements before redrawing.
  * Ensures immediate layout updates take precedence by cancelling pending background confirmations when a synchronous update is needed.
  * Gracefully commits the last observed layout if measurements never stabilize within retry limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->