### PR TITLE
fix: don't flash "Unable to display" while image cache is still loading

### DIFF
--- a/Thaw/MenuBar/IceBar/IceBar.swift
+++ b/Thaw/MenuBar/IceBar/IceBar.swift
@@ -459,7 +459,7 @@ private struct IceBarContentView: View {
                     .buttonStyle(.plain)
                     .foregroundStyle(.link)
                 } else {
-                    Text("Unable to display menu bar items")
+                    Text("Loading menu bar items…")
                     ProgressView()
                         .controlSize(.small)
                 }


### PR DESCRIPTION
## What does this PR do?

A brief description of the changes proposed in this pull request.

## PR Type

- [ ] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path:

## What is the current behavior?

What is happening now?
Issue Number: (if applicable, otherwise remove this line or write 'N/A')

## What is the new behavior?

What does this PR change or add?

## PR Checklist

- [ ] I’ve built and run the app locally
- [ ] I’ve checked for console errors or crashes
- [ ] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

Screenshots, notes, links to related issues/PRs, or anything useful for reviewers.

### Notes for reviewers

Anything you’d like reviewers to focus on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interim state messaging when menu bar items are loading. The system now displays "Loading menu bar items…" instead of "Unable to display menu bar items" while still fetching content, providing clearer feedback about the loading state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->