### PR TITLE
test(menu-bar): expand usableInlineWidth edge-case coverage

### DIFF
--- a/ThawTests/MenuBarSectionNameTests.swift
+++ b/ThawTests/MenuBarSectionNameTests.swift
@@ -162,4 +162,90 @@ final class MenuBarSectionNameTests: XCTestCase {
 
         XCTAssertEqual(width, 1152)
     }
+
+    // MARK: - usableInlineWidth
+
+    func testUsableInlineWidthFallsBackToScreenFrameMinXWhenAppMenuRightEdgeIsNil() {
+        let width = MenuBarSection.usableInlineWidth(
+            from: nil,
+            screenFrameMinX: 100,
+            screenVisibleMaxX: 1600,
+            notchFrame: nil
+        )
+
+        XCTAssertEqual(width, 1500)
+    }
+
+    func testUsableInlineWidthClampsAppMenuRightEdgeBelowScreenFrameMinX() {
+        // appMenuRightEdge(50) < screenFrameMinX(100) → clamped to 100
+        let width = MenuBarSection.usableInlineWidth(
+            from: 50,
+            screenFrameMinX: 100,
+            screenVisibleMaxX: 1600,
+            notchFrame: nil
+        )
+
+        XCTAssertEqual(width, 1500)
+    }
+
+    func testUsableInlineWidthReturnsZeroWhenScreenVisibleMaxXEqualsAppMenuRightEdgeNoNotch() {
+        let width = MenuBarSection.usableInlineWidth(
+            from: 1600,
+            screenFrameMinX: 0,
+            screenVisibleMaxX: 1600,
+            notchFrame: nil
+        )
+
+        XCTAssertEqual(width, 0)
+    }
+
+    func testUsableInlineWidthReturnsZeroWhenScreenVisibleMaxXIsLessThanAppMenuRightEdgeNoNotch() {
+        let width = MenuBarSection.usableInlineWidth(
+            from: 1700,
+            screenFrameMinX: 0,
+            screenVisibleMaxX: 1600,
+            notchFrame: nil
+        )
+
+        XCTAssertEqual(width, 0)
+    }
+
+    func testUsableInlineWidthClampsLeftRegionToZeroWhenNotchOverlapsAppMenu() {
+        // notchFrame.minX(300) - notchGap(24) = 276 < appMenuRightEdge(400) → leftWidth = 0
+        // rightWidth = max(0, 1600 - (500 + 24)) = 1076
+        let width = MenuBarSection.usableInlineWidth(
+            from: 400,
+            screenFrameMinX: 0,
+            screenVisibleMaxX: 1600,
+            notchFrame: CGRect(x: 300, y: 0, width: 200, height: 30)
+        )
+
+        XCTAssertEqual(width, 1076)
+    }
+
+    func testUsableInlineWidthClampsRightRegionToZeroWhenScreenEndsBeforeNotchEnds() {
+        // screenVisibleMaxX(920) < notchFrame.maxX(900) + notchGap(24) = 924 → rightWidth = 0
+        // leftWidth = max(0, 700 - 24 - 200) = 476
+        let width = MenuBarSection.usableInlineWidth(
+            from: 200,
+            screenFrameMinX: 0,
+            screenVisibleMaxX: 920,
+            notchFrame: CGRect(x: 700, y: 0, width: 200, height: 30)
+        )
+
+        XCTAssertEqual(width, 476)
+    }
+
+    func testUsableInlineWidthReturnsZeroWhenBothNotchRegionsCollapse() {
+        // appMenuRightEdge(750) > notchFrame.minX(700) - notchGap(24) → leftWidth = 0
+        // screenVisibleMaxX(910) < notchFrame.maxX(900) + notchGap(24) = 924 → rightWidth = 0
+        let width = MenuBarSection.usableInlineWidth(
+            from: 750,
+            screenFrameMinX: 0,
+            screenVisibleMaxX: 910,
+            notchFrame: CGRect(x: 700, y: 0, width: 200, height: 30)
+        )
+
+        XCTAssertEqual(width, 0)
+    }
 }


### PR DESCRIPTION
## What does this PR do?

Adds 7 unit tests for `MenuBarSection.usableInlineWidth(from:screenFrameMinX:screenVisibleMaxX:notchFrame:)` covering branches not previously exercised by the test suite. Test-only — no production code is modified.

## PR Type

- [ ] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What is the current behavior?

`MenuBarSection.usableInlineWidth` is the geometry helper used by `presentationMode()` to decide whether menu-bar items fit inline. It has several conditional branches (notch present / absent, optional `appMenuRightEdge`, two `max(0, ...)` clamps) but only one happy-path direct test (`testUsableInlineWidthAccountsForNotchGapOnBothSides`) plus indirect coverage via `presentationMode` tests. Several branches are unverified.

Issue Number: N/A

## What is the new behavior?

Adds direct coverage for the previously-untested branches:

1. `appMenuRightEdge == nil` — exercises the `?? screenFrameMinX` fallback (no-notch path).
2. `appMenuRightEdge < screenFrameMinX` — exercises the `max(screenFrameMinX, …)` lower-bound clamp (no-notch path).
3. `screenVisibleMaxX == clampedAppMenuRightEdge` — boundary; expects 0.
4. `screenVisibleMaxX < clampedAppMenuRightEdge` — would-be negative width clamps to 0.
5. Notch present, left region collapses: `notchFrame.minX − notchGap < clampedAppMenuRightEdge`.
6. Notch present, right region collapses: `screenVisibleMaxX < notchFrame.maxX + notchGap`.
7. Notch present, both regions collapse to 0.

## PR Checklist

- [ ] I've built and run the app locally  *(built; did not run the app — tests only)*
- [x] I've checked for console errors or crashes  *(N/A — no runtime changes)*
- [x] I've run relevant tests and they pass
- [x] I've added or updated tests (if applicable)
- [x] I've updated documentation as needed  *(N/A)*
- [x] I've verified localized strings work correctly (if i18n/l10n changes)  *(N/A)*

## Other information

- Pure additions to `ThawTests/MenuBarSectionNameTests.swift`. No production code touched.
- `swiftlint --strict ThawTests/MenuBarSectionNameTests.swift` and `swiftformat ThawTests/MenuBarSectionNameTests.swift` both clean.
- `xcodebuild -only-testing:ThawTests/MenuBarSectionNameTests test` reports `** TEST SUCCEEDED **` (29 tests, 0 failures).

### Notes for reviewers

Each test reproduces inputs that hit a single previously-untested branch in `usableInlineWidth`. Where the math isn't obvious from the method name (notch-region collapse cases), I left a short comment showing the arithmetic. No assertions about visual / runtime behavior — these are pure-function tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for menu bar section width calculations, covering edge cases including fallback behavior, boundary clamping, and notch-related width constraints to ensure robust behavior across various screen configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->