### PR TITLE
fix(menu-bar): re-check cache after app launch to sort late-arriving items

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -837,18 +837,17 @@ final class MenuBarItemManager: ObservableObject {
             guard let self else { return }
             MenuBarItemManager.diagLog.debug("App launched, refreshing cache for potential new items")
             Task { [weak self] in
-                guard let self else { return }
-                await self.cacheItemsRegardless()
+                await self?.cacheItemsRegardless()
                 // Many apps register their NSStatusItem more than 1s after
                 // didLaunch fires, so the initial cache pass above sees no
                 // new window IDs and relocateNewLeftmostItems no-ops. Re-check
                 // at +2.5s and +5s to catch late arrivals; cacheItemsIfNeeded
                 // bails when window IDs are unchanged, so this is cheap when
                 // the item already showed up on the first pass.
-                try? await Task.sleep(for: .seconds(2.5))
-                await self.cacheItemsIfNeeded()
-                try? await Task.sleep(for: .seconds(2.5))
-                await self.cacheItemsIfNeeded()
+                try await Task.sleep(for: .seconds(2.5))
+                await self?.cacheItemsIfNeeded()
+                try await Task.sleep(for: .seconds(2.5))
+                await self?.cacheItemsIfNeeded()
             }
         }
         .store(in: &c)

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -836,8 +836,19 @@ final class MenuBarItemManager: ObservableObject {
         .sink { [weak self] _ in
             guard let self else { return }
             MenuBarItemManager.diagLog.debug("App launched, refreshing cache for potential new items")
-            Task {
+            Task { [weak self] in
+                guard let self else { return }
                 await self.cacheItemsRegardless()
+                // Many apps register their NSStatusItem more than 1s after
+                // didLaunch fires, so the initial cache pass above sees no
+                // new window IDs and relocateNewLeftmostItems no-ops. Re-check
+                // at +2.5s and +5s to catch late arrivals; cacheItemsIfNeeded
+                // bails when window IDs are unchanged, so this is cheap when
+                // the item already showed up on the first pass.
+                try? await Task.sleep(for: .seconds(2.5))
+                await self.cacheItemsIfNeeded()
+                try? await Task.sleep(for: .seconds(2.5))
+                await self.cacheItemsIfNeeded()
             }
         }
         .store(in: &c)


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where new menu bar items were not auto-sorted into their configured section after the launching app registered its NSStatusItem. Previously the user had to open Settings → Layout to make the icon snap into place. Adds two staggered follow-up cache passes after `NSWorkspace.didLaunchApplicationNotification` so late-arriving items are caught and sorted automatically.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

N/A

## What is the current behavior?

When an app launches and registers a menu bar status item, Thaw subscribes to `NSWorkspace.didLaunchApplicationNotification` with a 1 s debounce and runs `cacheItemsRegardless()` once. Many apps (Dropbox, 1Password, sandboxed apps, SwiftUI `MenuBarExtra` apps) register their `NSStatusItem` more than 1 s after `didLaunch` fires, so the cache pass finds no new window IDs and `relocateNewLeftmostItems` no-ops. Nothing reschedules the check, so the icon sits in whatever section macOS dropped it into until the user opens Settings → Layout (which calls `cacheItemsRegardless(skipRecentMoveCheck: true)` and finally sorts the item).

Issue Number: N/A

## What is the new behavior?

The `didLaunchApplicationNotification` sink now schedules two follow-up `cacheItemsIfNeeded()` calls at +2.5 s and +5 s after the initial cache pass. The window-ID diff inside `cacheItemsIfNeeded` makes those retries cheap when the item already appeared on the first pass, and the existing `isDraggingMenuBarItem` / `lastMoveOperationOccurred` / `isInStartupSettling` guards still apply, so the retries do not interfere with user drags or the login-storm settling window. Late-arriving items are sorted by `relocateNewLeftmostItems` automatically, without the user opening Settings.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

Single-file change in `Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift` (lines 836–852, inside `configureCancellables`). Reuses the existing `cacheItemsRegardless` → `relocateNewLeftmostItems` pipeline; no new state, no new timers, no new observer types.

### Notes for reviewers

- The `2.5 s + 2.5 s` cadence was chosen to cover slow apps (Dropbox/1Password class) without becoming a periodic poll.
- Considered (and rejected) alternatives: increasing the 1 s debounce (slows the common case), wiring up the unused `cacheTickCancellable` periodic timer (always-on cost for a launch-window problem), and extending the `scheduleProfileResort` late-arrival path to non-profile users (would require parallel state for the no-profile case).
- To verify manually: quit a slow-launching status-bar app, relaunch it, and observe the icon snap into its configured section within ~5 s without opening Settings → Layout. Diagnostic log (`MenuBarItemManager.diagLog`) will show the initial `cacheItemsRegardless: entering` followed by two later cache entries and a `Relocated new leftmost items` line on whichever pass detected the item.                 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and initialization of menu bar items that register after app startup to ensure they appear reliably.
  * Added delayed cache checks to better catch late-arriving items during launch.
  * Prevented unintended actions after manager deallocation, improving memory safety and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->