### PR TITLE
fix spurious icon migrations

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -362,7 +362,7 @@ final class MenuBarItemManager: ObservableObject {
         for section in MenuBarSection.Name.allCases {
             // Start with current identifiers for this section (only primary items)
             var identifiers = cache[section]
-                .filter { !$0.isControlItem && $0.tag.instanceIndex == 0 }
+                .filter { !$0.isControlItem && $0.tag.instanceIndex == 0 && $0.sourcePID != nil }
                 .map(\.uniqueIdentifier)
 
             // Add identifiers from saved sections that are NOT currently in the cache
@@ -803,7 +803,6 @@ final class MenuBarItemManager: ObservableObject {
             // cascade. The original deadline plus a 5-second grace period
             // is the hard upper bound.
             let maxDeadline = deadline.advanced(by: .seconds(5))
-            var pidsResolved = false
 
             while !Task.isCancelled {
                 if ContinuousClock.now > maxDeadline {
@@ -814,12 +813,12 @@ final class MenuBarItemManager: ObservableObject {
                 }
 
                 await cacheItemsRegardless(skipRecentMoveCheck: true, resolveSourcePID: true)
+                let managedCount = itemCache.managedItems.count
                 let unresolved = itemCache.managedItems.filter { $0.sourcePID == nil }.count
-                if unresolved <= 1 {
+                if managedCount > 0 && unresolved <= 1 {
                     MenuBarItemManager.diagLog.debug(
-                        "performSetup: sourcePIDs resolved (\(unresolved) nil), ending settling early"
+                        "performSetup: sourcePIDs resolved (\(unresolved) nil, \(managedCount) items), ending settling early"
                     )
-                    pidsResolved = true
                     break
                 }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -349,7 +349,7 @@ final class MenuBarItemManager: ObservableObject {
         var allCurrentIdentifiers = Set<String>()
         var allCurrentBaseIdentifiers = Set<String>()
         for section in MenuBarSection.Name.allCases {
-            for item in cache[section] where !item.isControlItem && item.tag.instanceIndex == 0 {
+            for item in cache[section] where !item.isControlItem && item.tag.instanceIndex == 0 && item.sourcePID != nil {
                 let uniqueID = item.uniqueIdentifier
                 allCurrentIdentifiers.insert(uniqueID)
                 // Also track base identifier (without instanceIndex) to handle
@@ -947,7 +947,10 @@ extension MenuBarItemManager {
         /// If a task from a previous call to this method is currently
         /// running, that task is cancelled and replaced.
         func runCacheTask(_ operation: @escaping () async -> Void) async {
-            cacheTask.take()?.cancel()
+            if let existing = cacheTask.take() {
+                existing.cancel()
+                _ = await existing.value
+            }
             let task = Task(operation: operation)
             cacheTask = task
             await task.value
@@ -1337,6 +1340,11 @@ extension MenuBarItemManager {
 
             MenuBarItemManager.diagLog.debug("cacheItemsRegardless: getMenuBarItems returned \(items.count) items")
 
+            guard !Task.isCancelled else {
+                MenuBarItemManager.diagLog.debug("cacheItemsRegardless: cancelled after getMenuBarItems")
+                return
+            }
+
             if items.isEmpty {
                 MenuBarItemManager.diagLog.error("cacheItemsRegardless: getMenuBarItems returned ZERO items even after retry — this is the root cause of 'Loading menu bar items' being stuck")
             }
@@ -1380,7 +1388,17 @@ extension MenuBarItemManager {
 
             MenuBarItemManager.diagLog.debug("cacheItemsRegardless: found control items, hidden windowID=\(controlItems.hidden.windowID), alwaysHidden=\(controlItems.alwaysHidden.map { "\($0.windowID)" } ?? "nil")")
 
+            guard !Task.isCancelled else {
+                MenuBarItemManager.diagLog.debug("cacheItemsRegardless: cancelled after control item discovery")
+                return
+            }
+
             await enforceControlItemOrder(controlItems: controlItems)
+
+            guard !Task.isCancelled else {
+                MenuBarItemManager.diagLog.debug("cacheItemsRegardless: cancelled before relocateNewLeftmostItems")
+                return
+            }
 
             if await relocateNewLeftmostItems(
                 items,
@@ -3783,6 +3801,14 @@ extension MenuBarItemManager {
         persistKnownItemIdentifiers()
 
         let destination = newItemsMoveDestination(for: controlItems, among: items)
+
+        // Skip no-op moves: item is already in the target section.
+        var context = CacheContext(controlItems: controlItems, displayID: Bridging.getActiveMenuBarDisplayID())
+        if context.findSection(for: candidate) == effectiveNewItemsSection {
+            MenuBarItemManager.diagLog.debug("Skipping relocation for \(candidate.logString) — already in \(effectiveNewItemsSection.logString)")
+            return false
+        }
+
         MenuBarItemManager.diagLog.info(
             "Relocating new item \(candidate.logString) to \(effectiveNewItemsSection.logString)"
         )

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -3635,6 +3635,23 @@ extension MenuBarItemManager {
             return false
         }
 
+        // During startup settling, the first cache pass may have items tagged
+        // with wrong namespaces (e.g. com.apple.controlcenter when sourcePID
+        // hasn't resolved yet). Using those wrong tags to build hiddenTags /
+        // alwaysHiddenTags causes ALL items to appear as "new" on the next
+        // pass with correct sourcePIDs, triggering a destructive relocation
+        // cascade that moves every hidden/always-hidden item to visible.
+        // Seed identifiers and skip relocation; the settling-end restore pass
+        // will handle correct placement.
+        if isInStartupSettling {
+            let identifiers = items
+                .filter { !$0.isControlItem }
+                .map { "\($0.tag.namespace):\($0.tag.title)" }
+            knownItemIdentifiers.formUnion(identifiers)
+            persistKnownItemIdentifiers()
+            return false
+        }
+
         // Avoid relocating items already assigned to hidden/always-hidden sections.
         let hiddenTags = Set(itemCache[.hidden].map(\.tag))
         let alwaysHiddenTags = Set(itemCache[.alwaysHidden].map(\.tag))

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -1122,7 +1122,6 @@ extension MenuBarItemManager {
 
         var cache: ItemCache
         var temporarilyShownItems = [(MenuBarItem, MoveDestination)]()
-        var shouldClearCachedItemWindowIDs = false
         var relocatedItems = [MenuBarItem]()
 
         private(set) lazy var hiddenControlItemBounds = bestBounds(for: controlItems.hidden)
@@ -1242,8 +1241,8 @@ extension MenuBarItemManager {
             }
 
             noSectionCount += 1
-            MenuBarItemManager.diagLog.warning("Couldn't find section for caching \(item.logString) bounds=\(NSStringFromRect(item.bounds))")
-            context.shouldClearCachedItemWindowIDs = true
+            MenuBarItemManager.diagLog.warning("Couldn't find section for caching \(item.logString) bounds=\(NSStringFromRect(item.bounds)), assigning to hidden")
+            context.cache[.hidden].append(item)
         }
 
         // Count invalid items
@@ -1255,11 +1254,6 @@ extension MenuBarItemManager {
 
         for (item, destination) in context.temporarilyShownItems {
             context.cache.insert(item, at: destination)
-        }
-
-        if context.shouldClearCachedItemWindowIDs {
-            MenuBarItemManager.diagLog.info("Clearing cached menu bar item windowIDs")
-            await cacheActor.clearCachedItemWindowIDs() // Ensure next cache isn't skipped.
         }
 
         guard itemCache != context.cache else {

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -794,16 +794,50 @@ final class MenuBarItemManager: ObservableObject {
         startupSettlingTask = Task { @MainActor [weak self] in
             guard let self else { return }
             await self.initialCacheTask?.value
-            do {
-                if deadline > .now {
-                    try await Task.sleep(until: deadline, clock: .continuous)
+
+            // --- Hybrid signal + timer settling ---
+            // Instead of blindly waiting for a fixed timer, we poll until
+            // sourcePIDs have resolved (≤1 nil, which is normal for Control
+            // Center's own container). This prevents the fast-restore from
+            // running with wrong-namespace tags that cause a relocation
+            // cascade. The original deadline plus a 5-second grace period
+            // is the hard upper bound.
+            let maxDeadline = deadline.advanced(by: .seconds(5))
+            var pidsResolved = false
+
+            while !Task.isCancelled {
+                if ContinuousClock.now > maxDeadline {
+                    MenuBarItemManager.diagLog.debug(
+                        "performSetup: settling hit max deadline (\(maxDeadline)), ending with fallback"
+                    )
+                    break
                 }
-            } catch {
-                // Cancelled by a subsequent performSetup() call; exit without
-                // touching shared state — the new call manages isInStartupSettling.
-                MenuBarItemManager.diagLog.debug("performSetup: startup settling task cancelled")
+
+                await cacheItemsRegardless(skipRecentMoveCheck: true, resolveSourcePID: true)
+                let unresolved = itemCache.managedItems.filter { $0.sourcePID == nil }.count
+                if unresolved <= 1 {
+                    MenuBarItemManager.diagLog.debug(
+                        "performSetup: sourcePIDs resolved (\(unresolved) nil), ending settling early"
+                    )
+                    pidsResolved = true
+                    break
+                }
+
+                // Short sleep before next poll; exit immediately if cancelled.
+                do {
+                    try await Task.sleep(for: .milliseconds(500), tolerance: .milliseconds(100))
+                } catch is CancellationError {
+                    MenuBarItemManager.diagLog.debug("performSetup: startup settling task cancelled")
+                    return
+                } catch {
+                    return
+                }
+            }
+
+            guard !Task.isCancelled else {
                 return
             }
+
             isInStartupSettling = false
             settlingDeadline = nil
             MenuBarItemManager.diagLog.debug(

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -149,6 +149,14 @@ final class MenuBarItemManager: ObservableObject {
     private var suppressNextNewLeftmostItemRelocation = false
     /// Continuation to signal when background cache task completes.
     private var backgroundCacheContinuation: CheckedContinuation<Void, Never>?
+    /// Token bound to the current cache run. Only the task that started with
+    /// this token may resume backgroundCacheContinuation, preventing cancelled
+    /// tasks from waking waiters prematurely.
+    private var currentCacheToken: UUID = .init()
+    /// Identifiers seen during startup settling. Merged into knownItemIdentifiers
+    /// only after settling ends so true new arrivals after settling are still
+    /// recognized as new.
+    private var startupSeenIdentifiers = Set<String>()
     /// Suppresses image cache updates during layout reset to prevent stale cache during moves.
     var isResettingLayout = false
     /// Suppresses saving section order during an active order-restore pass.
@@ -851,6 +859,14 @@ final class MenuBarItemManager: ObservableObject {
             // skipRecentMoveCheck: true ensures this pass is never suppressed by the
             // 1-second recent-move cooldown stamped by the fast restore above.
             await cacheItemsRegardless(skipRecentMoveCheck: true, resolveSourcePID: true)
+            // Merge settling-time identifiers into the persistent set so they
+            // aren't treated as new on future cache passes, but only after
+            // relocation/restore has had a chance to run with correct sourcePIDs.
+            if !startupSeenIdentifiers.isEmpty {
+                knownItemIdentifiers.formUnion(startupSeenIdentifiers)
+                persistKnownItemIdentifiers()
+                startupSeenIdentifiers.removeAll()
+            }
         }
         MenuBarItemManager.diagLog.debug("performSetup: MenuBarItemManager setup complete")
     }
@@ -1319,15 +1335,20 @@ extension MenuBarItemManager {
     func cacheItemsRegardless(
         _ currentItemWindowIDs: [CGWindowID]? = nil,
         skipRecentMoveCheck: Bool = false,
-        resolveSourcePID: Bool = true
+        resolveSourcePID: Bool = true,
+        cacheToken: UUID? = nil
     ) async {
         MenuBarItemManager.diagLog.debug(
             "cacheItemsRegardless: entering (skipRecentMoveCheck=\(skipRecentMoveCheck), hasCurrentItemWindowIDs=\(currentItemWindowIDs != nil), resolveSourcePID=\(resolveSourcePID))"
         )
+        let token = cacheToken ?? UUID()
+        currentCacheToken = token
         await cacheActor.runCacheTask { [weak self] in
             defer {
-                self?.backgroundCacheContinuation?.resume()
-                self?.backgroundCacheContinuation = nil
+                if let self, self.currentCacheToken == token {
+                    self.backgroundCacheContinuation?.resume()
+                    self.backgroundCacheContinuation = nil
+                }
             }
 
             guard let self else {
@@ -3679,14 +3700,13 @@ extension MenuBarItemManager {
         // alwaysHiddenTags causes ALL items to appear as "new" on the next
         // pass with correct sourcePIDs, triggering a destructive relocation
         // cascade that moves every hidden/always-hidden item to visible.
-        // Seed identifiers and skip relocation; the settling-end restore pass
-        // will handle correct placement.
+        // Record identifiers in a temporary set instead of knownItemIdentifiers
+        // so true new arrivals after settling are still recognized as new.
         if isInStartupSettling {
             let identifiers = items
                 .filter { !$0.isControlItem }
                 .map { "\($0.tag.namespace):\($0.tag.title)" }
-            knownItemIdentifiers.formUnion(identifiers)
-            persistKnownItemIdentifiers()
+            startupSeenIdentifiers.formUnion(identifiers)
             return false
         }
 
@@ -4874,10 +4894,12 @@ extension MenuBarItemManager {
 
         await cacheActor.clearCachedItemWindowIDs()
         itemCache = ItemCache(displayID: nil)
+        let resetToken = UUID()
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
             self.backgroundCacheContinuation = continuation
+            self.currentCacheToken = resetToken
             Task { [weak self] in
-                await self?.cacheItemsRegardless(skipRecentMoveCheck: true)
+                await self?.cacheItemsRegardless(skipRecentMoveCheck: true, cacheToken: resetToken)
             }
         }
         suppressNextNewLeftmostItemRelocation = false

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -1377,8 +1377,6 @@ extension MenuBarItemManager {
             }
 
             let itemWindowIDs = currentItemWindowIDs ?? items.reversed().map { $0.windowID }
-            await cacheActor.updateCachedItemWindowIDs(itemWindowIDs)
-
             await MainActor.run {
                 MenuBarItemTag.Namespace.pruneUUIDCache(keeping: Set(itemWindowIDs))
                 self.pruneMoveOperationTimeouts(keeping: Set(items.map(\.tag)))
@@ -1460,6 +1458,7 @@ extension MenuBarItemManager {
             // load at login or restart in quick succession (app update checks).
             // A final cacheItemsRegardless() after the period ends handles restore.
             guard !isInStartupSettling else {
+                await cacheActor.updateCachedItemWindowIDs(itemWindowIDs)
                 await uncheckedCacheItems(items: items, controlItems: controlItems, displayID: displayID)
                 // Absorb items that appear during settling into the profile
                 // snapshot so they aren't treated as late arrivals afterwards.
@@ -1529,6 +1528,7 @@ extension MenuBarItemManager {
                 return
             }
 
+            await cacheActor.updateCachedItemWindowIDs(itemWindowIDs)
             await uncheckedCacheItems(items: items, controlItems: controlItems, displayID: displayID)
 
             // Reset the flag since no restore happened in this cache cycle.
@@ -3655,6 +3655,11 @@ extension MenuBarItemManager {
         previousWindowIDs: [CGWindowID]
     ) async -> Bool {
         guard appState != nil else { return false }
+
+        // If the cache is empty, the previous pass failed. Don't treat all items as new.
+        guard !itemCache.managedItems.isEmpty else {
+            return false
+        }
 
         if suppressNextNewLeftmostItemRelocation {
             // Seed known identifiers so these baseline items won't be treated as "new"


### PR DESCRIPTION
A brief description of the changes proposed in this pull request.

In certain situations icons would move position on their own.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [x] Refactor
- [x] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

## What is the current behavior?

What is happening now?
Issue Number: #462

## What is the new behavior?

What does this PR change or add?

## PR Checklist

- [x] I’ve built and run the app locally
- [ ] I’ve checked for console errors or crashes
- [ ] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

Screenshots, notes, links to related issues/PRs, or anything useful for reviewers.

### Notes for reviewers

Anything you’d like reviewers to focus on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable menu bar item startup with improved polling-based settling and a short grace window.
  * Stronger cancellation so background cache tasks don’t overlap or resume after cancellation.
  * Cache management refined to retain window assignments; unassignable items are marked hidden instead of clearing data.
  * Section snapshots and per-section lists exclude primary non-control items without sources.
  * New-leftmost relocation guarded to skip when cache is empty or move is a no-op.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->