### PR TITLE
fix(rehide): prevent appHasVisiblePopup spin on app switches

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -2954,23 +2954,26 @@ extension MenuBarItemManager {
         }
 
         /// Checks whether the item's owning application has any visible
-        /// popup, menu, or overlay window on screen.
+        /// popup-menu window on screen.
+        ///
+        /// Only matches the pop-up menu level (the level macOS uses for
+        /// menus opened from menu bar items). Status-level and main-menu
+        /// level windows are excluded because those are the menu bar items
+        /// themselves — including the temporarily-shown item we're
+        /// tracking — not popups created by clicking them. A liberal
+        /// "above normal" match was previously used as a catch-all, but
+        /// it matched floating panels, modal levels, and other unrelated
+        /// app windows, keeping `isShowingInterface` true indefinitely
+        /// and preventing rehide.
         private func appHasVisiblePopup() -> Bool {
             let windows = WindowInfo.createWindows(option: .onScreen)
+            let popUpLevel = CGWindowLevelForKey(.popUpMenuWindow)
             return windows.contains { window in
                 guard window.ownerPID == sourcePID else {
                     return false
                 }
-                // Menu-level or status-level windows are popups.
-                if window.isMenuRelated {
-                    return true
-                }
-                // Above-normal layer windows (overlays, popovers) that
-                // belong to the app also count.
-                if window.layer > CGWindowLevelForKey(.normalWindow) {
-                    return true
-                }
-                return false
+                let level = CGWindowLevel(Int32(window.layer))
+                return level == popUpLevel || level == popUpLevel - 1
             }
         }
 
@@ -3090,8 +3093,11 @@ extension MenuBarItemManager {
             }
         }
         // Also rehide when frontmost app changes (smart-ish).
+        // Debounce so rapid app switches (Cmd-Tab spam) collapse to one
+        // rehide attempt instead of queuing a separate Task per change —
+        // each rehide call can do an expensive on-screen window enumeration.
         rehideCancellable = NSWorkspace.shared.publisher(for: \.frontmostApplication)
-            .receive(on: DispatchQueue.main)
+            .debounce(for: .milliseconds(200), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self else { return }
                 Task { await self.rehideTemporarilyShownItems() }


### PR DESCRIPTION
## What does this PR do?

Fixes a high-CPU regression where `rehideTemporarilyShownItems` could pin the main thread during rapid app-switching by repeatedly enumerating every on-screen window via SkyLight and never being able to clear stuck temp-shown contexts.

## PR Type

- [x] Bugfix
- [x] Performance improvement

## Does this PR introduce a breaking change?

- [x] No

## What is the current behavior?

Issue Number: #430

`MenuBarItemManager.TemporarilyShownItemContext.appHasVisiblePopup()` is the fallback path used when `shownInterfaceWindow` was never captured (or has gone away) and the 2 s grace period has expired. Two issues compound:

1. The popup test matched any window owned by the same PID whose layer was `> normalWindow` — including the temporarily-shown item itself at status-window level. So `isShowingInterface` returned `true` forever for any context that hit the fallback path, blocking rehide and re-arming the 3 s deferral timer indefinitely.
2. `runRehideTimer` subscribes to `NSWorkspace.shared.publisher(for: \.frontmostApplication)` with no debounce, so each Cmd-Tab queues another rehide call. Each call does a fresh system-wide `SLWindowListCreateDescriptionFromArray` (~1.5 s on my machine) on the main thread.

A 10 s `sample` taken during rapid app-switching with a stuck context showed `rehideTemporarilyShownItems → appHasVisiblePopup → SLWindowListCreateDescriptionFromArray` accounting for ~97 % of main-thread CPU.

## What is the new behavior?

- `appHasVisiblePopup` matches only `kCGPopUpMenuWindowLevel` (and the `-1` variant macOS sometimes uses). Status-level and main-menu-level windows are excluded — those are menu bar items themselves, not popups. The broad `> normalWindow` catch-all is gone; it picked up floating panels and modal levels that aren't popups either.
- The `frontmostApplication` publisher is debounced 200 ms so a burst of Cmd-Tabs collapses into one rehide attempt instead of queuing a Task per change.

## PR Checklist

- [x] I've built and run the app locally
- [x] I've checked for console errors or crashes
- [ ] I've run relevant tests and they pass *(no automated tests exist for this code path)*
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (i18n/l10n changes) *(no localized strings touched)*

## Other information

### Verification

- Repro: open Thaw Bar → click a hidden item (Amphetamine in my case) → click away → Cmd-Tab through 10–15 apps.
- Before: Thaw pinned the main thread for the duration of the cycle; the stuck context survived indefinitely.
- After: rehide completes within the grace window; CPU stays flat during Cmd-Tab spam.
- Sanity checks still pass: hidden items still show in the IceBar; clicking a hidden item still opens the popup and rehides correctly afterward; Mission Control transitions still work.

### Test environment

- macOS 26.4.1 (25E253), Xcode 16.4, multi-monitor.
- Built Release with `xcodebuild ... -configuration Release`, ad-hoc signed, daily-driven for the verification window.
- `swiftformat .` + `swiftlint lint` clean on the modified file.

### Notes for reviewers

The fast path of `isShowingInterface` (lines 2925–2942) still matches `statusWindow` and `mainMenuWindow` levels for the *tracked* `shownInterfaceWindow`. I left that alone — it operates on a single specific window the click captured rather than enumerating, so it's cheap and the existing semantics there have been stable. The fix is scoped to the slow fallback path that drives the storm.

If you'd prefer a more conservative fix (e.g. just exclude `statusWindow` from the original check while keeping the `> normalWindow` catch-all), I can split this. Tightening to `popUpMenuWindow` only matches what menu bar item popups actually are on macOS — but it's a behavior narrowing for any app that puts an item-triggered overlay at a non-menu level, and I haven't audited every menu bar app for that.