### PR TITLE
Add release workflow with validation and notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
         required: true
         type: string
       dry_run:
+        description: "Build, sign, and notarize but upload as artifact instead of creating a GitHub release"
         type: boolean
         default: true
 
@@ -18,7 +19,7 @@ jobs:
   release:
     runs-on: macos-26
     permissions:
-      contents: read
+      contents: write
     env:
       PROJECT_NAME: "Thaw.xcodeproj"
       SCHEME_NAME: "Thaw"
@@ -43,10 +44,12 @@ jobs:
           fi
 
       - name: Configure signing
-        if: ${{ !inputs.dry_run }}
         env:
           APPLE_APPLICATION_CERT: ${{ secrets.APPLE_APPLICATION_CERT }}
           APPLE_APPLICATION_CERT_PASSWORD: ${{ secrets.APPLE_APPLICATION_CERT_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           keychain="$RUNNER_TEMP/buildagent.keychain"
           keychain_password="$(openssl rand -base64 32)"
@@ -60,23 +63,13 @@ jobs:
           security set-key-partition-list -S "apple-tool:,apple:,codesign:" \
             -s -k "$keychain_password" "$keychain"
           rm "$RUNNER_TEMP/cert.p12"
-
-      - name: Build (dry run)
-        if: ${{ inputs.dry_run }}
-        run: |
-          xcodebuild archive \
-            -project "${{ env.PROJECT_NAME }}" \
-            -scheme "${{ env.SCHEME_NAME }}" \
-            -destination platform=macOS \
-            -configuration Release \
-            -archivePath build/Archive.xcarchive \
-            MACOSX_DEPLOYMENT_TARGET=${{ env.MACOSX_DEPLOYMENT_TARGET }} \
-            CODE_SIGN_IDENTITY="" \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=NO
+          xcrun notarytool store-credentials "notarytool-profile" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_ID_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --keychain "$keychain"
 
       - name: Build
-        if: ${{ !inputs.dry_run }}
         run: |
           xcodebuild archive \
             -project "${{ env.PROJECT_NAME }}" \
@@ -86,52 +79,57 @@ jobs:
             -archivePath build/Archive.xcarchive \
             MACOSX_DEPLOYMENT_TARGET=${{ env.MACOSX_DEPLOYMENT_TARGET }} \
             DEVELOPMENT_TEAM=${{ secrets.APPLE_TEAM_ID }} \
+            CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Developer ID Application"
 
       - name: Export Archive
-        if: ${{ !inputs.dry_run }}
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
+          export_plist="$RUNNER_TEMP/ExportOptions.plist"
+          rm -f "$export_plist"
           /usr/libexec/PlistBuddy \
             -c "Add :method string developer-id" \
             -c "Add :teamID string $APPLE_TEAM_ID" \
-            -c "Add :signingStyle string automatic" \
+            -c "Add :signingStyle string manual" \
             -c "Add :destination string export" \
-            /tmp/ExportOptions.plist
+            "$export_plist"
 
           xcodebuild -exportArchive \
             -archivePath build/Archive.xcarchive \
             -exportPath build/Export \
-            -exportOptionsPlist /tmp/ExportOptions.plist
+            -exportOptionsPlist "$export_plist"
 
-          mkdir -p /tmp/dmg-staging
-          cp -r "build/Export/${{ env.APP_NAME }}" /tmp/dmg-staging/
-          ln -s /Applications /tmp/dmg-staging/Applications
+          dmg_staging="$RUNNER_TEMP/dmg-staging"
+          mkdir -p "$dmg_staging"
+          cp -r "build/Export/${{ env.APP_NAME }}" "$dmg_staging/"
+          ln -s /Applications "$dmg_staging/Applications"
           hdiutil create \
             -volname "Thaw" \
-            -srcfolder /tmp/dmg-staging \
+            -srcfolder "$dmg_staging" \
             -ov -format UDZO \
             "build/${{ env.DMG_NAME }}"
 
       - name: Notarize
-        if: ${{ !inputs.dry_run }}
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           xcrun notarytool submit "build/${{ env.DMG_NAME }}" \
-            --apple-id "$APPLE_ID" \
-            --password "$APPLE_ID_PASSWORD" \
-            --team-id "$APPLE_TEAM_ID" \
+            --keychain-profile "notarytool-profile" \
+            --keychain "$RUNNER_TEMP/buildagent.keychain" \
             --wait
 
           xcrun stapler staple "build/${{ env.DMG_NAME }}"
           xcrun stapler validate "build/${{ env.DMG_NAME }}"
 
+      - name: Upload notarized DMG
+        if: ${{ inputs.dry_run }}
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: Thaw-notarized-dmg
+          path: build/${{ env.DMG_NAME }}
+          retention-days: 3
+
       - name: Create GitHub Release
-        if: ${{ !inputs.dry_run }}
+        if: ${{ !inputs.dry_run || github.event_name == 'push' }}
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.tag || github.ref_name }}
@@ -140,3 +138,7 @@ jobs:
           draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cleanup keychain
+        if: always()
+        run: security delete-keychain "$RUNNER_TEMP/buildagent.keychain" || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       PROJECT_NAME: "Thaw.xcodeproj"
       SCHEME_NAME: "Thaw"
       APP_NAME: "Thaw.app"
-      ZIP_NAME: "Thaw.zip"
+      DMG_NAME: "Thaw.dmg"
       MACOSX_DEPLOYMENT_TARGET: "26.0"
     steps:
       - name: Checkout code
@@ -102,8 +102,14 @@ jobs:
             -exportPath build/Export \
             -exportOptionsPlist /tmp/ExportOptions.plist
 
-          cd build/Export
-          zip -r "../${{ env.ZIP_NAME }}" "${{ env.APP_NAME }}"
+          mkdir -p /tmp/dmg-staging
+          cp -r "build/Export/${{ env.APP_NAME }}" /tmp/dmg-staging/
+          ln -s /Applications /tmp/dmg-staging/Applications
+          hdiutil create \
+            -volname "Thaw" \
+            -srcfolder /tmp/dmg-staging \
+            -ov -format UDZO \
+            "build/${{ env.DMG_NAME }}"
 
       - name: Notarize
         if: ${{ !inputs.dry_run }}
@@ -112,23 +118,21 @@ jobs:
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          xcrun notarytool submit "build/${{ env.ZIP_NAME }}" \
+          xcrun notarytool submit "build/${{ env.DMG_NAME }}" \
             --apple-id "$APPLE_ID" \
             --password "$APPLE_ID_PASSWORD" \
             --team-id "$APPLE_TEAM_ID" \
             --wait
 
-          xcrun stapler staple "build/Export/${{ env.APP_NAME }}"
-          xcrun stapler validate "build/Export/${{ env.APP_NAME }}"
-          cd build/Export
-          zip -r "../${{ env.ZIP_NAME }}" "${{ env.APP_NAME }}"
+          xcrun stapler staple "build/${{ env.DMG_NAME }}"
+          xcrun stapler validate "build/${{ env.DMG_NAME }}"
 
       - name: Create GitHub Release
         if: ${{ !inputs.dry_run }}
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.tag || github.ref_name }}
-          files: build/${{ env.ZIP_NAME }}
+          files: build/${{ env.DMG_NAME }}
           generate_release_notes: true
           draft: true
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,15 @@
 name: Release
 
 on:
-  #   push:
-  #     tags:
-  #       - "v*"
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
+      tag:
+        description: Release tag to publish (for example, v1.2.3)
+        required: true
+        type: string
       dry_run:
         type: boolean
         default: true
@@ -27,9 +31,10 @@ jobs:
 
       - name: Validate tag name format
         id: validate
-        if: github.event_name != 'workflow_dispatch'
+        env:
+          TAG_NAME: ${{ inputs.tag || github.ref_name }}
         run: |
-          if [[ ! "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Invalid tag name format. Must be in the form v1.2.3"
             exit 1
           fi
@@ -41,7 +46,8 @@ jobs:
           APPLE_APPLICATION_CERT_PASSWORD: ${{ secrets.APPLE_APPLICATION_CERT_PASSWORD }}
         run: |
           keychain="$RUNNER_TEMP/buildagent.keychain"
-          keychain_password="password1"
+          keychain_password="$(openssl rand -base64 32)"
+
           security create-keychain -p "$keychain_password" "$keychain"
           security default-keychain -s "$keychain"
           security unlock-keychain -p "$keychain_password" "$keychain"
@@ -113,6 +119,7 @@ jobs:
             --wait
 
           xcrun stapler staple "build/Export/${{ env.APP_NAME }}"
+          xcrun stapler validate "build/Export/${{ env.APP_NAME }}"
           cd build/Export
           zip -r "../${{ env.ZIP_NAME }}" "${{ env.APP_NAME }}"
 
@@ -120,6 +127,7 @@ jobs:
         if: ${{ !inputs.dry_run }}
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
           files: build/${{ env.ZIP_NAME }}
           generate_release_notes: true
           draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ on:
 jobs:
   release:
     runs-on: macos-26
+    permissions:
+      contents: read
     env:
       PROJECT_NAME: "Thaw.xcodeproj"
       SCHEME_NAME: "Thaw"
@@ -28,6 +30,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
 
       - name: Validate tag name format
         id: validate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,127 @@
+name: Release
+
+on:
+  #   push:
+  #     tags:
+  #       - "v*"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        default: true
+
+jobs:
+  release:
+    runs-on: macos-26
+    env:
+      PROJECT_NAME: "Thaw.xcodeproj"
+      SCHEME_NAME: "Thaw"
+      APP_NAME: "Thaw.app"
+      ZIP_NAME: "Thaw.zip"
+      MACOSX_DEPLOYMENT_TARGET: "26.0"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate tag name format
+        id: validate
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          if [[ ! "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid tag name format. Must be in the form v1.2.3"
+            exit 1
+          fi
+
+      - name: Configure signing
+        if: ${{ !inputs.dry_run }}
+        env:
+          APPLE_APPLICATION_CERT: ${{ secrets.APPLE_APPLICATION_CERT }}
+          APPLE_APPLICATION_CERT_PASSWORD: ${{ secrets.APPLE_APPLICATION_CERT_PASSWORD }}
+        run: |
+          keychain="$RUNNER_TEMP/buildagent.keychain"
+          keychain_password="password1"
+          security create-keychain -p "$keychain_password" "$keychain"
+          security default-keychain -s "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          base64 -D <<<"$APPLE_APPLICATION_CERT" > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$keychain" \
+            -P "$APPLE_APPLICATION_CERT_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S "apple-tool:,apple:,codesign:" \
+            -s -k "$keychain_password" "$keychain"
+          rm "$RUNNER_TEMP/cert.p12"
+
+      - name: Build (dry run)
+        if: ${{ inputs.dry_run }}
+        run: |
+          xcodebuild archive \
+            -project "${{ env.PROJECT_NAME }}" \
+            -scheme "${{ env.SCHEME_NAME }}" \
+            -destination platform=macOS \
+            -configuration Release \
+            -archivePath build/Archive.xcarchive \
+            MACOSX_DEPLOYMENT_TARGET=${{ env.MACOSX_DEPLOYMENT_TARGET }} \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Build
+        if: ${{ !inputs.dry_run }}
+        run: |
+          xcodebuild archive \
+            -project "${{ env.PROJECT_NAME }}" \
+            -scheme "${{ env.SCHEME_NAME }}" \
+            -destination platform=macOS \
+            -configuration Release \
+            -archivePath build/Archive.xcarchive \
+            MACOSX_DEPLOYMENT_TARGET=${{ env.MACOSX_DEPLOYMENT_TARGET }} \
+            DEVELOPMENT_TEAM=${{ secrets.APPLE_TEAM_ID }} \
+            CODE_SIGN_IDENTITY="Developer ID Application"
+
+      - name: Export Archive
+        if: ${{ !inputs.dry_run }}
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          /usr/libexec/PlistBuddy \
+            -c "Add :method string developer-id" \
+            -c "Add :teamID string $APPLE_TEAM_ID" \
+            -c "Add :signingStyle string automatic" \
+            -c "Add :destination string export" \
+            /tmp/ExportOptions.plist
+
+          xcodebuild -exportArchive \
+            -archivePath build/Archive.xcarchive \
+            -exportPath build/Export \
+            -exportOptionsPlist /tmp/ExportOptions.plist
+
+          cd build/Export
+          zip -r "../${{ env.ZIP_NAME }}" "${{ env.APP_NAME }}"
+
+      - name: Notarize
+        if: ${{ !inputs.dry_run }}
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          xcrun notarytool submit "build/${{ env.ZIP_NAME }}" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_ID_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+
+          xcrun stapler staple "build/Export/${{ env.APP_NAME }}"
+          cd build/Export
+          zip -r "../${{ env.ZIP_NAME }}" "${{ env.APP_NAME }}"
+
+      - name: Create GitHub Release
+        if: ${{ !inputs.dry_run }}
+        uses: softprops/action-gh-release@v2
+        with:
+          files: build/${{ env.ZIP_NAME }}
+          generate_release_notes: true
+          draft: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

Introduce a new release workflow that automates the build, notarization, and GitHub release process, including validation of tag formats and improved keychain handling.

## PR Type

- [x] CI/CD related changes

## Does this PR introduce a breaking change?

- [x] No

## What is the current behavior?

N/A

## What is the new behavior?

This PR adds a comprehensive release workflow that includes steps for validating tag formats, building the application, notarizing it, and creating a GitHub release.

## PR Checklist

N/A

## Other information

N/A

### Notes for reviewers

Focus on the workflow steps and ensure that the notarization and release processes function as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added GitHub Actions workflow to automate macOS app releases, including code signing, notarization, and release publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->