### PR TITLE
fix: stabilize hidden menu items during capture

### DIFF
--- a/Thaw/MenuBar/IceBar/IceBar.swift
+++ b/Thaw/MenuBar/IceBar/IceBar.swift
@@ -208,7 +208,7 @@ final class IceBarPanel: NSPanel {
         cacheTask?.cancel()
         cacheTask = Task { [weak appState] in
             guard let appState else { return }
-            await appState.itemManager.rehideTemporarilyShownItems(force: true)
+            await appState.itemManager.rehideTemporarilyShownItems()
             guard !Task.isCancelled else { return }
             await appState.itemManager.cacheItemsIfNeeded()
             guard !Task.isCancelled else { return }
@@ -642,7 +642,7 @@ private struct IceBarItemView: View {
                 // item visibility. Uses KVO on isVisible so we resume as soon
                 // as the panel hides rather than busy-polling.
                 await panel.waitUntilClosed(timeout: .milliseconds(200))
-                if let liveItem = await liveOnScreenItem(matching: item, on: displayID) {
+                if let liveItem = await liveOnScreenItem(matching: item, section: section, on: displayID) {
                     try await itemManager.click(item: liveItem, with: .left)
                     let duration = Date.now.timeIntervalSince(clickStartTime)
                     IceBarItemView.diagLog.debug("leftClick: ✓ completed in \(Int(duration * 1000))ms (on-screen path)")
@@ -650,7 +650,7 @@ private struct IceBarItemView: View {
                     // temporarilyShow handles move, click, and fallback click
                     // internally so that shownInterfaceWindow is always captured
                     // regardless of which click attempt succeeds.
-                    let result = await itemManager.temporarilyShow(item: item, clickingWith: .left, on: displayID, fastPath: true)
+                    let result = await itemManager.temporarilyShow(item: item, clickingWith: .left, on: displayID)
                     let duration = Date.now.timeIntervalSince(clickStartTime)
                     IceBarItemView.diagLog.debug("leftClick: completed in \(Int(duration * 1000))ms (temp-show path, result=\(result))")
                 }
@@ -667,24 +667,35 @@ private struct IceBarItemView: View {
             menuBarManager.section(withName: section)?.hide()
             Task {
                 await panel.waitUntilClosed(timeout: .milliseconds(200))
-                if let liveItem = await liveOnScreenItem(matching: item, on: displayID) {
+                if let liveItem = await liveOnScreenItem(matching: item, section: section, on: displayID) {
                     try await itemManager.click(item: liveItem, with: .right)
                 } else {
-                    let result = await itemManager.temporarilyShow(item: item, clickingWith: .right, on: displayID, fastPath: true)
+                    let result = await itemManager.temporarilyShow(item: item, clickingWith: .right, on: displayID)
                     IceBarItemView.diagLog.debug("rightClick: temp-show result=\(result)")
                 }
             }
         }
     }
 
-    /// Re-fetches on-screen items and returns the live `MenuBarItem` whose
-    /// tag+PID matches `item`, or `nil` if the item is not currently on-screen.
+    /// Re-fetches on-screen items and returns the live `MenuBarItem` for the clicked row.
     ///
-    /// Matching by tag+PID rather than the cached `windowID` guards against
-    /// CGWindowID recycling after a long system sleep, which would otherwise
-    /// cause `isWindowOnScreen` to return a false positive for an unrelated window.
-    private func liveOnScreenItem(matching item: MenuBarItem, on displayID: CGDirectDisplayID) async -> MenuBarItem? {
+    /// Hidden and always-hidden rows must use an exact window match. Some menu
+    /// extras, especially Control Center-hosted items, share generic tag/title
+    /// data; a same-tag fallback can click an already-visible neighbor instead
+    /// of moving the hidden row out.
+    private func liveOnScreenItem(
+        matching item: MenuBarItem,
+        section: MenuBarSection.Name,
+        on displayID: CGDirectDisplayID
+    ) async -> MenuBarItem? {
         let liveItems = await MenuBarItem.getMenuBarItems(on: displayID, option: .onScreen)
+        if section != .visible {
+            guard let liveItem = liveItems.first(where: { $0.windowID == item.windowID }) else {
+                return nil
+            }
+            return Bridging.isWindowOnScreen(liveItem.windowID) ? liveItem : nil
+        }
+
         guard let liveItem = liveItems.first(where: {
             $0.tag.matchesIgnoringWindowID(item.tag) &&
                 ($0.sourcePID ?? $0.ownerPID) == (item.sourcePID ?? item.ownerPID)

--- a/Thaw/MenuBar/IceBar/IceBar.swift
+++ b/Thaw/MenuBar/IceBar/IceBar.swift
@@ -64,6 +64,12 @@ final class IceBarPanel: NSPanel {
         colorManager.performSetup(with: self)
     }
 
+    /// Clears the cached window image to force a background refresh.
+    /// Call this when menu bar items disappear to prevent stale background.
+    func clearCachedWindowImage() {
+        colorManager.clearCachedWindowImage()
+    }
+
     /// Configures the internal observers.
     private func configureCancellables() {
         var c = Set<AnyCancellable>()

--- a/Thaw/MenuBar/IceBar/IceBar.swift
+++ b/Thaw/MenuBar/IceBar/IceBar.swift
@@ -303,6 +303,7 @@ private struct IceBarContentView: View {
 
     private var items: [MenuBarItem] {
         itemManager.itemCache.managedItems(for: section)
+            .filter { !$0.tag.isTransientCaptureIndicator }
     }
 
     private var configuration: MenuBarAppearanceConfigurationV2 {

--- a/Thaw/MenuBar/IceBar/IceBar.swift
+++ b/Thaw/MenuBar/IceBar/IceBar.swift
@@ -752,6 +752,14 @@ private struct IceBarItemView: View {
                         rightClickAction: rightClickAction,
                         onHover: { hovering in
                             isHovered = hovering
+                            // When hover ends, trigger cleanup of stale transient indicators
+                            if !hovering, item.tag.isTransientCaptureIndicator {
+                                Task { @MainActor in
+                                    // Small delay to allow state to settle
+                                    try? await Task.sleep(for: .milliseconds(100))
+                                    imageCache.removeStaleTransientIndicators()
+                                }
+                            }
                         }
                     )
                 }
@@ -759,6 +767,10 @@ private struct IceBarItemView: View {
                 .accessibilityLabel(item.displayName)
                 .accessibilityAction(named: "left click", leftClickAction)
                 .accessibilityAction(named: "right click", rightClickAction)
+                // Force refresh when transient indicator state might have changed
+                .onChange(of: imageCache.images) { _ in
+                    // Trigger re-evaluation of `image` when cache changes
+                }
         }
     }
 }

--- a/Thaw/MenuBar/IceBar/IceBarColorManager.swift
+++ b/Thaw/MenuBar/IceBar/IceBarColorManager.swift
@@ -204,4 +204,10 @@ final class IceBarColorManager: ObservableObject {
         updateWindowImage(for: screen)
         updateColorInfo(with: frame, screen: screen)
     }
+
+    /// Clears the cached window image to force a refresh on next update.
+    /// Call this when menu bar items disappear to prevent stale background.
+    func clearCachedWindowImage() {
+        windowImage = nil
+    }
 }

--- a/Thaw/MenuBar/IceBar/IceBarColorManager.swift
+++ b/Thaw/MenuBar/IceBar/IceBarColorManager.swift
@@ -205,9 +205,18 @@ final class IceBarColorManager: ObservableObject {
         updateColorInfo(with: frame, screen: screen)
     }
 
-    /// Clears the cached window image to force a refresh on next update.
+    /// Clears the cached window image and color info to force a refresh on next update.
     /// Call this when menu bar items disappear to prevent stale background.
     func clearCachedWindowImage() {
         windowImage = nil
+        // Also clear colorInfo to force a complete re-capture.
+        // Otherwise the IceBar would still use the old color info with the new (stale) window image.
+        colorInfo = nil
+        
+        // Trigger an immediate update if the panel is visible.
+        // This ensures the background is re-captured without waiting for the next periodic refresh.
+        if let iceBarPanel, iceBarPanel.isVisible, let screen = iceBarPanel.screen {
+            updateAllProperties(with: iceBarPanel.frame, screen: screen)
+        }
     }
 }

--- a/Thaw/MenuBar/IceBar/IceBarColorManager.swift
+++ b/Thaw/MenuBar/IceBar/IceBarColorManager.swift
@@ -205,18 +205,8 @@ final class IceBarColorManager: ObservableObject {
         updateColorInfo(with: frame, screen: screen)
     }
 
-    /// Clears the cached window image and color info to force a refresh on next update.
-    /// Call this when menu bar items disappear to prevent stale background.
+    /// Clears the cached window image so the next normal refresh re-captures it.
     func clearCachedWindowImage() {
         windowImage = nil
-        // Also clear colorInfo to force a complete re-capture.
-        // Otherwise the IceBar would still use the old color info with the new (stale) window image.
-        colorInfo = nil
-        
-        // Trigger an immediate update if the panel is visible.
-        // This ensures the background is re-captured without waiting for the next periodic refresh.
-        if let iceBarPanel, iceBarPanel.isVisible, let screen = iceBarPanel.screen {
-            updateAllProperties(with: iceBarPanel.frame, screen: screen)
-        }
     }
 }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -359,6 +359,35 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
             }
             .store(in: &c)
 
+            // Monitor for transient capture indicators (recording icons) appearing/disappearing.
+            // These need immediate cache refresh to ensure proper display in IceBar/Search.
+            // Track the set of transient indicator tags to detect when specific indicators disappear.
+            let transientIndicatorPublisher: AnyPublisher<Set<MenuBarItemTag>, Never> = appState.itemManager.$itemCache
+                .map { cache -> Set<MenuBarItemTag> in
+                    // Get all transient indicator tags from the current items
+                    Set(cache.managedItems.filter { $0.tag.isTransientCaptureIndicator }.map { $0.tag })
+                }
+                .removeDuplicates()
+                .dropFirst() // Skip initial value to avoid refresh on startup
+                .eraseToAnyPublisher()
+
+            transientIndicatorPublisher
+            .debounce(for: .milliseconds(150), scheduler: DispatchQueue.main)
+            .sink { [weak self] currentIndicatorTags in
+                guard let self else { return }
+                // Check if any cached transient indicators are no longer present
+                let cachedIndicatorTags = Set(self.images.keys.filter { $0.isTransientCaptureIndicator })
+                let disappearedIndicators = cachedIndicatorTags.subtracting(currentIndicatorTags)
+                guard !disappearedIndicators.isEmpty else { return }
+                // Transient indicators disappeared - clean up stale entries immediately
+                MenuBarItemImageCache.diagLog.debug("Transient indicators disappeared: \(disappearedIndicators.map { $0.title }), removing from cache")
+                for tag in disappearedIndicators {
+                    self.images.removeValue(forKey: tag)
+                    self.accessTimestamps.removeValue(forKey: tag)
+                }
+            }
+            .store(in: &c)
+
             // Observe navigation state changes to start/stop live refresh
             Publishers.CombineLatest4(
                 appState.navigationState.$isIceBarPresented,
@@ -571,9 +600,63 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
                 guard !items.isEmpty else { continue }
                 await refreshImages(of: items, scale: screen.backingScaleFactor)
             }
+
+            // Clean up stale transient indicator entries every iteration.
+            // When recording stops, the indicator window disappears but its cached
+            // image entry remains. Query the actual window list directly (not itemCache
+            // which may be stale) to detect disappeared indicators.
+            let displayIDForCleanup = appState.itemManager.itemCache.displayID
+                ?? Bridging.getActiveMenuBarDisplayID()
+                ?? CGMainDisplayID()
+            let currentIndicatorTags = await getCurrentTransientIndicatorTags(on: displayIDForCleanup)
+            let cachedIndicatorTags = Set(self.images.keys.filter { $0.isTransientCaptureIndicator })
+            let staleIndicatorTags = cachedIndicatorTags.subtracting(currentIndicatorTags)
+            if !staleIndicatorTags.isEmpty {
+                MenuBarItemImageCache.diagLog.debug("Live refresh: removing \(staleIndicatorTags.count) stale transient indicator entries")
+                for tag in staleIndicatorTags {
+                    self.images.removeValue(forKey: tag)
+                    self.accessTimestamps.removeValue(forKey: tag)
+                }
+            }
+            
+            // Additional cleanup: Also remove transient indicators whose windows
+            // are no longer on screen (extra safety check for hover-stuck items)
+            let onScreenIndicatorTags = await getOnScreenTransientIndicatorTags(on: displayIDForCleanup)
+            let offScreenCachedIndicators = cachedIndicatorTags.subtracting(onScreenIndicatorTags)
+            if !offScreenCachedIndicators.isEmpty {
+                MenuBarItemImageCache.diagLog.debug("Live refresh: removing \(offScreenCachedIndicators.count) off-screen transient indicator entries")
+                for tag in offScreenCachedIndicators {
+                    self.images.removeValue(forKey: tag)
+                    self.accessTimestamps.removeValue(forKey: tag)
+                }
+            }
         }
 
         MenuBarItemImageCache.diagLog.debug("Live refresh loop stopped")
+    }
+
+    /// Queries the actual window list to get current transient indicator tags.
+    /// This bypasses the itemCache which may be stale.
+    private nonisolated func getCurrentTransientIndicatorTags(on displayID: CGDirectDisplayID) async -> Set<MenuBarItemTag> {
+        let indicators = await MenuBarItem.getMenuBarItems(
+            on: displayID,
+            option: .activeSpace,
+            resolveSourcePID: false
+        )
+        .filter { $0.tag.isTransientCaptureIndicator }
+        return Set(indicators.map { $0.tag })
+    }
+
+    /// Queries the actual window list to get on-screen transient indicator tags.
+    /// Uses .onScreen option to only get visible windows.
+    private nonisolated func getOnScreenTransientIndicatorTags(on displayID: CGDirectDisplayID) async -> Set<MenuBarItemTag> {
+        let indicators = await MenuBarItem.getMenuBarItems(
+            on: displayID,
+            option: .onScreen,
+            resolveSourcePID: false
+        )
+        .filter { $0.tag.isTransientCaptureIndicator }
+        return Set(indicators.map { $0.tag })
     }
 
     // MARK: Capturing Images
@@ -977,7 +1060,7 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
 
         guard !newImages.isEmpty, !Task.isCancelled else { return }
 
-        await MainActor.run { [newImages] in
+        await MainActor.run { [newImages, items] in
             var updatedCount = 0
             for (tag, newImage) in newImages where !CapturedImage.isVisuallyEqual(self.images[tag], newImage) {
                 self.images[tag] = newImage
@@ -1150,6 +1233,29 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
             return entry.value
         }
         return nil
+    }
+
+    /// Removes stale transient capture indicator entries from the cache.
+    /// Called when hover ends on a transient indicator to ensure it disappears
+    /// if recording has stopped.
+    @MainActor
+    func removeStaleTransientIndicators() {
+        let displayID = Bridging.getActiveMenuBarDisplayID() ?? CGMainDisplayID()
+        Task { [weak self] in
+            guard let self else { return }
+            let currentIndicators = await self.getOnScreenTransientIndicatorTags(on: displayID)
+            let cachedIndicators = Set(self.images.keys.filter { $0.isTransientCaptureIndicator })
+            let stale = cachedIndicators.subtracting(currentIndicators)
+            if !stale.isEmpty {
+                MenuBarItemImageCache.diagLog.debug("Removing \(stale.count) stale transient indicators on hover end")
+                await MainActor.run {
+                    for tag in stale {
+                        self.images.removeValue(forKey: tag)
+                        self.accessTimestamps.removeValue(forKey: tag)
+                    }
+                }
+            }
+        }
     }
 
     /// Returns the current cache size for monitoring purposes.

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -841,7 +841,9 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
         // Thaw's own control items always capture as transparent via
         // CGWindowListCreateImage, so skip them to avoid the perpetual
         // fail -> blacklist -> cooldown -> retry cycle.
-        let capturable = items.filter { !$0.isControlItem }
+        // Also skip transient capture indicators (recording/mic icons) to prevent
+        // them from appearing as stale background artifacts when recording stops.
+        let capturable = items.filter { !$0.isControlItem && !$0.tag.isTransientCaptureIndicator }
 
         // Pre-filter off-screen items: hidden section items are positioned past
         // the right edge of the screen. Including them in compositeCapture
@@ -941,11 +943,15 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
         of items: [MenuBarItem],
         scale: CGFloat
     ) async {
+        // Filter out transient capture indicators to prevent them from appearing
+        // as stale background artifacts when recording stops.
+        let filteredItems = items.filter { !$0.tag.isTransientCaptureIndicator }
+
         var windowIDs = [CGWindowID]()
         var storage = [CGWindowID: (MenuBarItem, CGRect)]()
         var boundsUnion = CGRect.null
 
-        for item in items {
+        for item in filteredItems {
             guard let bounds = Bridging.getWindowBounds(for: item.windowID) else {
                 continue
             }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -1258,6 +1258,18 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
         }
     }
 
+    /// Removes cached images for the specified tags.
+    /// Called when items disappear from the menu bar to prevent stale background.
+    @MainActor
+    func removeImages(for tags: Set<MenuBarItemTag>) {
+        guard !tags.isEmpty else { return }
+        for tag in tags {
+            images.removeValue(forKey: tag)
+            accessTimestamps.removeValue(forKey: tag)
+        }
+        MenuBarItemImageCache.diagLog.debug("Removed \(tags.count) images from cache")
+    }
+
     /// Returns the current cache size for monitoring purposes.
     var cacheSize: Int {
         images.count

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -313,16 +313,37 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
                 spaceChangePublisher,
                 screenChangePublisher,
                 colorChangePublisher,
-                itemCacheChangePublisher,
             ])
             .debounce(for: .milliseconds(200), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self else {
                     return
                 }
-                // Only trigger capture if a visible consumer exists or the settings pane
-                // has been opened at least once (itemCacheChangePublisher may indicate
-                // new items that the layout pane will need).
+                // Space/screen/color changes are noisy during Mission Control and
+                // desktop switching. Only refresh when a capture consumer is
+                // actually visible, otherwise background captures can spuriously
+                // trigger transient recording indicators on inactive desktops.
+                let nav = self.makeNavigationStateSnapshot()
+                let hasVisible = self.hasVisibleCaptureConsumer(nav: nav)
+                guard hasVisible else {
+                    return
+                }
+                self.currentUpdateTask?.cancel()
+                self.currentUpdateTask = Task { [weak self] in
+                    await self?.refreshVisibleConsumersOrPrewarmLayoutCache()
+                }
+            }
+            .store(in: &c)
+
+            itemCacheChangePublisher
+            .debounce(for: .milliseconds(200), scheduler: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self else {
+                    return
+                }
+                // Item-cache changes can indicate newly-arrived menu bar items that
+                // the layout settings pane will need even while hidden, so this is
+                // the only path allowed to prewarm in the background.
                 let nav = self.makeNavigationStateSnapshot()
                 let hasVisible = self.hasVisibleCaptureConsumer(nav: nav)
                 let settingsOpened = self.settingsPaneHasBeenOpened

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -1296,9 +1296,13 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
             return
         }
 
-        // Get the set of valid item tags from all sections to clean up stale entries
+        // Get the set of valid item tags from all sections to clean up stale entries.
+        // Exclude transient capture indicators so ephemeral recording/capture
+        // UI does not become a retained cache entry during unrelated refreshes.
         let allValidTags = Set(
-            appState.itemManager.itemCache.managedItems.map(\.tag)
+            appState.itemManager.itemCache.managedItems
+                .map(\.tag)
+                .filter { !$0.isTransientCaptureIndicator }
         )
 
         await MainActor.run { [newImages, allValidTags] in

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -661,31 +661,6 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
 
     // MARK: Capturing Images
 
-    private nonisolated func transientCaptureIndicatorBounds(on displayID: CGDirectDisplayID?) async -> [CGRect] {
-        let indicators = await MenuBarItem.getMenuBarItems(
-            on: displayID,
-            option: .activeSpace,
-            resolveSourcePID: false
-        )
-        .filter { $0.tag.isTransientCaptureIndicator }
-
-        return indicators.compactMap { item in
-            let bounds = Bridging.getWindowBounds(for: item.windowID) ?? item.bounds
-            return bounds.isNull || bounds.isEmpty ? nil : bounds
-        }
-    }
-
-    private nonisolated func isItemCaptureOccluded(
-        by transientIndicatorBounds: [CGRect],
-        item: MenuBarItem,
-        bounds: CGRect
-    ) -> Bool {
-        guard !item.tag.isTransientCaptureIndicator else {
-            return false
-        }
-        return transientIndicatorBounds.contains { $0.intersects(bounds) }
-    }
-
     /// Captures a composite image of the given items, then crops out an image
     /// for each item and returns the result.
     ///
@@ -881,23 +856,14 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
         let screenFrame = await MainActor.run {
             NSScreen.screens.first { $0.displayID == displayID }?.frame
         }
-        let transientIndicatorBounds = await transientCaptureIndicatorBounds(on: displayID)
-        guard transientIndicatorBounds.isEmpty else {
-            MenuBarItemImageCache.diagLog.debug(
-                "captureImages: transient capture indicator active, preserving existing cached images"
-            )
-            return CaptureResult()
-        }
 
         // Fetch window bounds once for all items. This single pass is reused for
         // both the off-screen filter and the subsequent compositeCapture, avoiding
         // a redundant system call and eliminating the TOCTOU race where a window
         // could move between the two lookups.
         var onScreenItemsWithBounds: [(item: MenuBarItem, bounds: CGRect)] = []
-        var individuallyCapturableItems = [MenuBarItem]()
         var offScreenCount = 0
         var nilBoundsCount = 0
-        var occludedByTransientIndicatorCount = 0
 
         for item in capturable {
             guard let bounds = Bridging.getWindowBounds(for: item.windowID) else {
@@ -906,11 +872,6 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
                 nilBoundsCount += 1
                 continue
             }
-            if isItemCaptureOccluded(by: transientIndicatorBounds, item: item, bounds: bounds) {
-                occludedByTransientIndicatorCount += 1
-                continue
-            }
-            individuallyCapturableItems.append(item)
             if let screenFrame, !screenFrame.intersects(bounds) {
                 offScreenCount += 1
             } else {
@@ -928,11 +889,6 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
                 "captureImages: \(offScreenCount)/\(capturable.count) off-screen items skipped (live refresh handles them)"
             )
         }
-        if occludedByTransientIndicatorCount > 0 {
-            MenuBarItemImageCache.diagLog.debug(
-                "captureImages: skipped \(occludedByTransientIndicatorCount)/\(capturable.count) item(s) occluded by transient capture indicator"
-            )
-        }
 
         // Use individual capture after a move operation, since composite capture
         // doesn't account for overlapping items.
@@ -940,7 +896,8 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
             within: .seconds(2)
         ) {
             MenuBarItemImageCache.diagLog.debug("Capturing individually due to recent item movement")
-            return individualCapture(individuallyCapturableItems, scale: scale)
+            let itemsToCapture = onScreenItemsWithBounds.map { $0.item }
+            return individualCapture(itemsToCapture, scale: scale)
         }
 
         guard !onScreenItemsWithBounds.isEmpty else {
@@ -987,32 +944,14 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
         var windowIDs = [CGWindowID]()
         var storage = [CGWindowID: (MenuBarItem, CGRect)]()
         var boundsUnion = CGRect.null
-        let displayID = Bridging.getActiveMenuBarDisplayID() ?? CGMainDisplayID()
-        let transientIndicatorBounds = await transientCaptureIndicatorBounds(on: displayID)
-        guard transientIndicatorBounds.isEmpty else {
-            MenuBarItemImageCache.diagLog.debug(
-                "refreshImages: transient capture indicator active, preserving existing cached images"
-            )
-            return
-        }
-        var occludedByTransientIndicatorCount = 0
 
         for item in items {
             guard let bounds = Bridging.getWindowBounds(for: item.windowID) else {
                 continue
             }
-            if isItemCaptureOccluded(by: transientIndicatorBounds, item: item, bounds: bounds) {
-                occludedByTransientIndicatorCount += 1
-                continue
-            }
             windowIDs.append(item.windowID)
             storage[item.windowID] = (item, bounds)
             boundsUnion = boundsUnion.union(bounds)
-        }
-        if occludedByTransientIndicatorCount > 0 {
-            MenuBarItemImageCache.diagLog.debug(
-                "refreshImages: skipped \(occludedByTransientIndicatorCount) item(s) occluded by transient capture indicator"
-            )
         }
 
         guard !windowIDs.isEmpty else {

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -557,6 +557,31 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
 
     // MARK: Capturing Images
 
+    private nonisolated func transientCaptureIndicatorBounds(on displayID: CGDirectDisplayID?) async -> [CGRect] {
+        let indicators = await MenuBarItem.getMenuBarItems(
+            on: displayID,
+            option: .activeSpace,
+            resolveSourcePID: false
+        )
+        .filter { $0.tag.isTransientCaptureIndicator }
+
+        return indicators.compactMap { item in
+            let bounds = Bridging.getWindowBounds(for: item.windowID) ?? item.bounds
+            return bounds.isNull || bounds.isEmpty ? nil : bounds
+        }
+    }
+
+    private nonisolated func isItemCaptureOccluded(
+        by transientIndicatorBounds: [CGRect],
+        item: MenuBarItem,
+        bounds: CGRect
+    ) -> Bool {
+        guard !item.tag.isTransientCaptureIndicator else {
+            return false
+        }
+        return transientIndicatorBounds.contains { $0.intersects(bounds) }
+    }
+
     /// Captures a composite image of the given items, then crops out an image
     /// for each item and returns the result.
     ///
@@ -739,15 +764,6 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
         // fail -> blacklist -> cooldown -> retry cycle.
         let capturable = items.filter { !$0.isControlItem }
 
-        // Use individual capture after a move operation, since composite capture
-        // doesn't account for overlapping items.
-        if await appState.itemManager.lastMoveOperationOccurred(
-            within: .seconds(2)
-        ) {
-            MenuBarItemImageCache.diagLog.debug("Capturing individually due to recent item movement")
-            return individualCapture(capturable, scale: scale)
-        }
-
         // Pre-filter off-screen items: hidden section items are positioned past
         // the right edge of the screen. Including them in compositeCapture
         // inflates boundsUnion → CGWindowListCreateImageFromArray returns an
@@ -761,14 +777,23 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
         let screenFrame = await MainActor.run {
             NSScreen.screens.first { $0.displayID == displayID }?.frame
         }
+        let transientIndicatorBounds = await transientCaptureIndicatorBounds(on: displayID)
+        guard transientIndicatorBounds.isEmpty else {
+            MenuBarItemImageCache.diagLog.debug(
+                "captureImages: transient capture indicator active, preserving existing cached images"
+            )
+            return CaptureResult()
+        }
 
         // Fetch window bounds once for all items. This single pass is reused for
         // both the off-screen filter and the subsequent compositeCapture, avoiding
         // a redundant system call and eliminating the TOCTOU race where a window
         // could move between the two lookups.
         var onScreenItemsWithBounds: [(item: MenuBarItem, bounds: CGRect)] = []
+        var individuallyCapturableItems = [MenuBarItem]()
         var offScreenCount = 0
         var nilBoundsCount = 0
+        var occludedByTransientIndicatorCount = 0
 
         for item in capturable {
             guard let bounds = Bridging.getWindowBounds(for: item.windowID) else {
@@ -777,6 +802,11 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
                 nilBoundsCount += 1
                 continue
             }
+            if isItemCaptureOccluded(by: transientIndicatorBounds, item: item, bounds: bounds) {
+                occludedByTransientIndicatorCount += 1
+                continue
+            }
+            individuallyCapturableItems.append(item)
             if let screenFrame, !screenFrame.intersects(bounds) {
                 offScreenCount += 1
             } else {
@@ -793,6 +823,20 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
             MenuBarItemImageCache.diagLog.debug(
                 "captureImages: \(offScreenCount)/\(capturable.count) off-screen items skipped (live refresh handles them)"
             )
+        }
+        if occludedByTransientIndicatorCount > 0 {
+            MenuBarItemImageCache.diagLog.debug(
+                "captureImages: skipped \(occludedByTransientIndicatorCount)/\(capturable.count) item(s) occluded by transient capture indicator"
+            )
+        }
+
+        // Use individual capture after a move operation, since composite capture
+        // doesn't account for overlapping items.
+        if await appState.itemManager.lastMoveOperationOccurred(
+            within: .seconds(2)
+        ) {
+            MenuBarItemImageCache.diagLog.debug("Capturing individually due to recent item movement")
+            return individualCapture(individuallyCapturableItems, scale: scale)
         }
 
         guard !onScreenItemsWithBounds.isEmpty else {
@@ -839,14 +883,32 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
         var windowIDs = [CGWindowID]()
         var storage = [CGWindowID: (MenuBarItem, CGRect)]()
         var boundsUnion = CGRect.null
+        let displayID = Bridging.getActiveMenuBarDisplayID() ?? CGMainDisplayID()
+        let transientIndicatorBounds = await transientCaptureIndicatorBounds(on: displayID)
+        guard transientIndicatorBounds.isEmpty else {
+            MenuBarItemImageCache.diagLog.debug(
+                "refreshImages: transient capture indicator active, preserving existing cached images"
+            )
+            return
+        }
+        var occludedByTransientIndicatorCount = 0
 
         for item in items {
             guard let bounds = Bridging.getWindowBounds(for: item.windowID) else {
                 continue
             }
+            if isItemCaptureOccluded(by: transientIndicatorBounds, item: item, bounds: bounds) {
+                occludedByTransientIndicatorCount += 1
+                continue
+            }
             windowIDs.append(item.windowID)
             storage[item.windowID] = (item, bounds)
             boundsUnion = boundsUnion.union(bounds)
+        }
+        if occludedByTransientIndicatorCount > 0 {
+            MenuBarItemImageCache.diagLog.debug(
+                "refreshImages: skipped \(occludedByTransientIndicatorCount) item(s) occluded by transient capture indicator"
+            )
         }
 
         guard !windowIDs.isEmpty else {

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -1464,6 +1464,43 @@ extension MenuBarItemManager {
         await enforceControlItemOrder(controlItems: controlItems)
 
         guard !Task.isCancelled else {
+            MenuBarItemManager.diagLog.debug("cacheItemsRegardless: cancelled before restoreItemsToSavedSections")
+            return
+        }
+
+        // Skip all restore logic during the startup settling period.
+        // The settling period prevents cascading icon moves when many apps
+        // load at login or restart in quick succession (app update checks).
+        if !isInStartupSettling {
+            // Cross-section restore: move items back to their saved section
+            // BEFORE relocateNewLeftmostItems runs. This ensures items that
+            // have saved sections are restored to their proper places before
+            // the "new item" relocation logic can move them to the default
+            // section (which is usually hidden/always-hidden).
+            isRestoringItemOrder = true
+            isRestoringItemOrderTimestamp = Date()
+            let didRestoreSections = await restoreItemsToSavedSections(
+                items,
+                controlItems: controlItems,
+                previousWindowIDs: previousWindowIDs
+            )
+            if didRestoreSections {
+                MenuBarItemManager.diagLog.debug("Restored item to saved section; scheduling recache")
+                let continuation = self.backgroundCacheContinuation
+                self.backgroundCacheContinuation = nil
+                Task { [weak self] in
+                    try? await Task.sleep(for: MenuBarItemManager.uiSettleDelay)
+                    await self?.cacheItemsRegardless(skipRecentMoveCheck: true)
+                    self?.isRestoringItemOrder = false
+                    continuation?.resume()
+                    try? await Task.sleep(for: MenuBarItemManager.uiSettleDelay)
+                    await self?.cacheItemsIfNeeded()
+                }
+                return
+            }
+        }
+
+        guard !Task.isCancelled else {
             MenuBarItemManager.diagLog.debug("cacheItemsRegardless: cancelled before relocateNewLeftmostItems")
             return
         }
@@ -1496,9 +1533,7 @@ extension MenuBarItemManager {
             return
         }
 
-        // Skip all restore logic during the startup settling period.
-        // The settling period prevents cascading icon moves when many apps
-        // load at login or restart in quick succession (app update checks).
+        // During startup settling, just cache items without restore/relocate.
         // A final cacheItemsRegardless() after the period ends handles restore.
         guard !isInStartupSettling else {
             await uncheckedCacheItems(items: items, controlItems: controlItems, displayID: displayID)
@@ -1510,32 +1545,6 @@ extension MenuBarItemManager {
                 }
             }
             MenuBarItemManager.diagLog.debug("cacheItemsRegardless: startup settling active, skipping restore")
-            return
-        }
-
-        // Cross-section restore: move items back to their saved section
-        // before restoreSavedItemOrder handles within-section reordering.
-        // Set the flag before calling so that any intermediate cache
-        // updates during move() don't overwrite the saved section order.
-        isRestoringItemOrder = true
-        isRestoringItemOrderTimestamp = Date()
-        let didRestoreSections = await restoreItemsToSavedSections(
-            items,
-            controlItems: controlItems,
-            previousWindowIDs: previousWindowIDs
-        )
-        if didRestoreSections {
-            MenuBarItemManager.diagLog.debug("Restored item to saved section; scheduling recache")
-            let continuation = self.backgroundCacheContinuation
-            self.backgroundCacheContinuation = nil
-            Task { [weak self] in
-                try? await Task.sleep(for: MenuBarItemManager.uiSettleDelay)
-                await self?.cacheItemsRegardless(skipRecentMoveCheck: true)
-                self?.isRestoringItemOrder = false
-                continuation?.resume()
-                try? await Task.sleep(for: MenuBarItemManager.uiSettleDelay)
-                await self?.cacheItemsIfNeeded()
-            }
             return
         }
         // Note: isRestoringItemOrder remains true here so that if a concurrent
@@ -2527,7 +2536,7 @@ extension MenuBarItemManager {
         MouseHelpers.hideCursor()
         defer {
             if let mouseLocation {
-                MouseHelpers.restoreCursor(to: mouseLocation)
+                MouseHelpers.warpCursor(to: mouseLocation)
             }
             MouseHelpers.showCursor()
             lastMoveOperationTimestamp = .now
@@ -2698,7 +2707,7 @@ extension MenuBarItemManager {
         let mouseLocation = try getMouseLocation()
         MouseHelpers.hideCursor(watchdogTimeout: watchdogTimeout)
         defer {
-            MouseHelpers.restoreCursor(to: mouseLocation)
+            MouseHelpers.warpCursor(to: mouseLocation)
             MouseHelpers.showCursor()
         }
 
@@ -2835,7 +2844,7 @@ extension MenuBarItemManager {
         try await Task.sleep(for: .milliseconds(10))
         MouseHelpers.hideCursor()
         defer {
-            MouseHelpers.restoreCursor(to: mouseLocation)
+            MouseHelpers.warpCursor(to: mouseLocation)
             MouseHelpers.showCursor()
         }
 
@@ -2918,7 +2927,6 @@ extension MenuBarItemManager {
             do {
                 let clickStartTime = Date.now
                 try await postClickEvents(item: item, mouseButton: mouseButton)
-                scheduleImageCacheRefreshAfterMenuDismissal(appState: appState)
                 let clickDuration = Date.now.timeIntervalSince(clickStartTime)
                 MenuBarItemManager.diagLog.debug("Attempt \(n) succeeded in \(Int(clickDuration * 1000))ms, finished with click")
                 return
@@ -2937,54 +2945,6 @@ extension MenuBarItemManager {
         }
     }
 
-    /// Waits for a clicked menu extra to open and then dismiss its menu,
-    /// refreshing the off-screen image cache once the pressed background
-    /// should no longer be captured.
-    private func scheduleImageCacheRefreshAfterMenuDismissal(appState: AppState) {
-        Task { [weak self, weak appState] in
-            guard let self, let appState else {
-                return
-            }
-
-            let menuOpenPollInterval: Duration = .milliseconds(75)
-            let menuClosePollInterval: Duration = .milliseconds(125)
-            let menuOpenDeadline = ContinuousClock.now + .milliseconds(500)
-
-            var sawMenuOpen = false
-            while ContinuousClock.now < menuOpenDeadline {
-                if await self.isAnyMenuBarItemMenuOpen() {
-                    sawMenuOpen = true
-                    break
-                }
-                try? await Task.sleep(for: menuOpenPollInterval)
-            }
-
-            guard sawMenuOpen else {
-                return
-            }
-
-            let menuCloseDeadline = ContinuousClock.now + .seconds(8)
-            while ContinuousClock.now < menuCloseDeadline {
-                try? await Task.sleep(for: menuClosePollInterval)
-                guard !Task.isCancelled else {
-                    return
-                }
-                if await !self.isAnyMenuBarItemMenuOpen() {
-                    await self.cacheItemsIfNeeded()
-                    guard !Task.isCancelled else {
-                        return
-                    }
-                    await appState.imageCache.updateCacheWithoutChecks(
-                        sections: MenuBarSection.Name.allCases
-                    )
-                    MenuBarItemManager.diagLog.debug(
-                        "Refreshed item image cache after menu dismissal"
-                    )
-                    return
-                }
-            }
-        }
-    }
 }
 
 // MARK: - Temporarily Showing Items
@@ -3023,9 +2983,6 @@ extension MenuBarItemManager {
         /// The window of the item's shown interface.
         var shownInterfaceWindow: WindowInfo?
 
-        /// The bounds of the item while it is temporarily shown.
-        var shownItemBounds: CGRect?
-
         /// The number of attempts that have been made to rehide the item.
         var rehideAttempts = 0
 
@@ -3046,16 +3003,15 @@ extension MenuBarItemManager {
         /// A Boolean value that indicates whether the menu bar item's
         /// interface is showing.
         var isShowingInterface: Bool {
-            // First check the tracked popup window — this is the most
-            // reliable signal when available.
             if let window = shownInterfaceWindow,
                let current = WindowInfo(windowID: window.windowID)
             {
-                if Self.isMenuInterfaceWindow(current) {
-                    guard let shownItemBounds else {
-                        return current.isOnScreen
-                    }
-                    return current.isOnScreen && Self.isPopupWindow(current, near: shownItemBounds)
+                if current.layer == CGWindowLevelForKey(.popUpMenuWindow)
+                    || current.layer == CGWindowLevelForKey(.popUpMenuWindow) - 1
+                    || current.layer == CGWindowLevelForKey(.statusWindow)
+                    || current.layer == CGWindowLevelForKey(.mainMenuWindow)
+                {
+                    return current.isOnScreen
                 }
                 if let app = current.owningApplication {
                     return app.isActive && current.isOnScreen
@@ -3076,46 +3032,27 @@ extension MenuBarItemManager {
         }
 
         /// Checks whether the item's owning application has any visible
-        /// popup/menu window on screen.
+        /// popup-menu window on screen.
         ///
-        /// macOS 26 can host menu extra popups in Control Center or Window
-        /// Server windows instead of the source app's PID. To avoid hiding the
-        /// temporary item while its menu is still open, accept menu-like
-        /// windows that are spatially attached to the shown menu bar item.
+        /// Only matches the pop-up menu level (the level macOS uses for
+        /// menus opened from menu bar items). Status-level and main-menu
+        /// level windows are excluded because those are the menu bar items
+        /// themselves — including the temporarily-shown item we're
+        /// tracking — not popups created by clicking them. A liberal
+        /// "above normal" match was previously used as a catch-all, but
+        /// it matched floating panels, modal levels, and other unrelated
+        /// app windows, keeping `isShowingInterface` true indefinitely
+        /// and preventing rehide.
         private func appHasVisiblePopup() -> Bool {
             let windows = WindowInfo.createWindows(option: .onScreen)
+            let popUpLevel = CGWindowLevelForKey(.popUpMenuWindow)
             return windows.contains { window in
-                guard Self.isMenuInterfaceWindow(window) else {
+                guard window.ownerPID == sourcePID else {
                     return false
                 }
-                guard let shownItemBounds else {
-                    return window.ownerPID == sourcePID
-                }
-                return Self.isPopupWindow(window, near: shownItemBounds)
+                let level = CGWindowLevel(Int32(window.layer))
+                return level == popUpLevel || level == popUpLevel - 1
             }
-        }
-
-        static func isMenuInterfaceWindow(_ window: WindowInfo) -> Bool {
-            let level = CGWindowLevel(Int32(window.layer))
-            return level == CGWindowLevelForKey(.popUpMenuWindow) ||
-                level == CGWindowLevelForKey(.popUpMenuWindow) - 1 ||
-                level == CGWindowLevelForKey(.mainMenuWindow)
-        }
-
-        static func isPopupWindow(_ window: WindowInfo, near itemBounds: CGRect) -> Bool {
-            let horizontalPadding: CGFloat = 180
-            let verticalPadding: CGFloat = 48
-            let isTallerThanStatusItem = window.bounds.height > itemBounds.height + 8
-            guard isTallerThanStatusItem else {
-                return false
-            }
-            let expandedItemBounds = itemBounds.insetBy(
-                dx: -horizontalPadding,
-                dy: -verticalPadding
-            )
-            let horizontallyNear = window.bounds.maxX >= itemBounds.minX - horizontalPadding &&
-                window.bounds.minX <= itemBounds.maxX + horizontalPadding
-            return expandedItemBounds.intersects(window.bounds) || horizontallyNear
         }
 
         init(
@@ -3504,8 +3441,6 @@ extension MenuBarItemManager {
 
         let idsBeforeClick = Set(Bridging.getWindowList(option: .onScreen))
         let clickPID = clickItem.sourcePID ?? clickItem.ownerPID
-        let clickItemBounds = Bridging.getWindowBounds(for: clickItem.windowID) ?? clickItem.bounds
-        context.shownItemBounds = clickItemBounds
 
         do {
             // Single attempt: the item is already at a known-good position with
@@ -3543,19 +3478,7 @@ extension MenuBarItemManager {
         let windowsAfterClick = WindowInfo.createWindows(option: .onScreen)
 
         context.shownInterfaceWindow = windowsAfterClick.first { window in
-            guard !idsBeforeClick.contains(window.windowID) else {
-                return false
-            }
-            guard TemporarilyShownItemContext.isMenuInterfaceWindow(window) else {
-                return false
-            }
-            guard TemporarilyShownItemContext.isPopupWindow(window, near: clickItemBounds) else {
-                return false
-            }
-            if window.ownerPID == clickPID {
-                return true
-            }
-            return true
+            window.ownerPID == clickPID && !idsBeforeClick.contains(window.windowID)
         }
 
         return .movedAndClicked

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -1326,8 +1326,6 @@ extension MenuBarItemManager {
         if !disappearedTags.isEmpty {
             MenuBarItemManager.diagLog.debug("Clearing image cache for \(disappearedTags.count) disappeared items")
             appState?.imageCache.removeImages(for: disappearedTags)
-            // Also clear the IceBar's cached window image to force background refresh
-            appState?.menuBarManager.iceBarPanel.clearCachedWindowImage()
         }
 
         // Reset isRestoringItemOrder if it's been stuck for too long (10 seconds).

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -1318,14 +1318,17 @@ extension MenuBarItemManager {
         let oldTags = Set(itemCache.managedItems.map(\.tag))
         let newTags = Set(context.cache.managedItems.map(\.tag))
         let disappearedTags = oldTags.subtracting(newTags)
+
+        // IMPORTANT: Update itemCache FIRST before clearing images/window cache.
+        // This ensures the IceBar renders with the updated item list, not the old one.
+        itemCache = context.cache
+
         if !disappearedTags.isEmpty {
             MenuBarItemManager.diagLog.debug("Clearing image cache for \(disappearedTags.count) disappeared items")
             appState?.imageCache.removeImages(for: disappearedTags)
             // Also clear the IceBar's cached window image to force background refresh
             appState?.menuBarManager.iceBarPanel.clearCachedWindowImage()
         }
-
-        itemCache = context.cache
 
         // Reset isRestoringItemOrder if it's been stuck for too long (10 seconds).
         // This prevents stale flags from blocking saves after user manual moves.

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -1313,6 +1313,18 @@ extension MenuBarItemManager {
             return
         }
 
+        // Clear image cache entries for items that disappeared (in old cache but not new).
+        // This prevents stale background clipping when apps close.
+        let oldTags = Set(itemCache.managedItems.map(\.tag))
+        let newTags = Set(context.cache.managedItems.map(\.tag))
+        let disappearedTags = oldTags.subtracting(newTags)
+        if !disappearedTags.isEmpty {
+            MenuBarItemManager.diagLog.debug("Clearing image cache for \(disappearedTags.count) disappeared items")
+            appState?.imageCache.removeImages(for: disappearedTags)
+            // Also clear the IceBar's cached window image to force background refresh
+            appState?.menuBarManager.iceBarPanel.clearCachedWindowImage()
+        }
+
         itemCache = context.cache
 
         // Reset isRestoringItemOrder if it's been stuck for too long (10 seconds).

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -1720,20 +1720,59 @@ extension MenuBarItemManager {
         await task.value
     }
 
-    /// Returns the current bounds for the given item, with a refresh fallback if the window is missing.
+    /// Returns whether two menu bar item snapshots represent the same app-owned item.
+    private nonisolated func isSameMenuBarItemInstance(_ lhs: MenuBarItem, as rhs: MenuBarItem) -> Bool {
+        lhs.tag.matchesIgnoringWindowID(rhs.tag) &&
+            (lhs.sourcePID ?? lhs.ownerPID) == (rhs.sourcePID ?? rhs.ownerPID)
+    }
+
+    /// Returns whether cached bounds are plausible on a visible display.
+    ///
+    /// Hidden menu bar items are moved far off-screen horizontally, while live
+    /// menu bar items still intersect their owning display. When Window Server
+    /// briefly fails to resolve a window ID after a move, a recent on-screen
+    /// snapshot is safer than falling through to an unrelated same-tag item.
+    private nonisolated func hasVisibleDisplayIntersection(_ bounds: CGRect) -> Bool {
+        NSScreen.screens.contains { screen in
+            screen.frame.intersects(bounds)
+        }
+    }
+
+    /// Returns the current bounds for the given item, with a guarded refresh fallback if the window is missing.
     private nonisolated func getCurrentBounds(for item: MenuBarItem) async throws -> CGRect {
         // First attempt: current windowID.
         if let bounds = Bridging.getWindowBounds(for: item.windowID) {
             return bounds
         }
 
-        // Fallback: refresh on-screen items and pick the matching tag (prefer same windowID, then non-clone).
+        // If the caller already passed a live on-screen snapshot, prefer that
+        // over a broad same-tag lookup. Generic Control Center item titles can
+        // otherwise resolve to a neighboring system item, such as the language
+        // input menu, when a moved item's window ID is momentarily unavailable.
+        if item.isOnScreen, hasVisibleDisplayIntersection(item.bounds) {
+            return item.bounds
+        }
+
+        // Fallback: refresh on-screen items and only accept candidates that
+        // match both tag and source/owner PID. If there are multiple possible
+        // matches, fail rather than risk clicking the wrong menu bar item.
         let refreshed = await MenuBarItem.getMenuBarItems(option: .onScreen)
-        if let refreshedItem = refreshed.first(where: { $0.windowID == item.windowID && $0.tag == item.tag }) ??
-            refreshed.first(where: { $0.tag.matchesIgnoringWindowID(item.tag) && !$0.isSystemClone }) ??
-            refreshed.first(where: { $0.tag.matchesIgnoringWindowID(item.tag) })
-        {
+        if let refreshedItem = refreshed.first(where: {
+            $0.windowID == item.windowID && isSameMenuBarItemInstance($0, as: item)
+        }) {
             return refreshedItem.bounds
+        }
+
+        let matchingCandidates = refreshed.filter { candidate in
+            isSameMenuBarItemInstance(candidate, as: item) && !candidate.isSystemClone
+        }
+        if matchingCandidates.count == 1, let refreshedItem = matchingCandidates.first {
+            return refreshedItem.bounds
+        }
+        if matchingCandidates.count > 1 {
+            MenuBarItemManager.diagLog.warning(
+                "Ambiguous bounds fallback for \(item.logString): \(matchingCandidates.count) same-tag/same-PID candidates"
+            )
         }
 
         throw EventError.missingItemBounds(item)
@@ -2461,7 +2500,7 @@ extension MenuBarItemManager {
         MouseHelpers.hideCursor()
         defer {
             if let mouseLocation {
-                MouseHelpers.warpCursor(to: mouseLocation)
+                MouseHelpers.restoreCursor(to: mouseLocation)
             }
             MouseHelpers.showCursor()
             lastMoveOperationTimestamp = .now
@@ -2632,7 +2671,7 @@ extension MenuBarItemManager {
         let mouseLocation = try getMouseLocation()
         MouseHelpers.hideCursor(watchdogTimeout: watchdogTimeout)
         defer {
-            MouseHelpers.warpCursor(to: mouseLocation)
+            MouseHelpers.restoreCursor(to: mouseLocation)
             MouseHelpers.showCursor()
         }
 
@@ -2769,7 +2808,7 @@ extension MenuBarItemManager {
         try await Task.sleep(for: .milliseconds(10))
         MouseHelpers.hideCursor()
         defer {
-            MouseHelpers.warpCursor(to: mouseLocation)
+            MouseHelpers.restoreCursor(to: mouseLocation)
             MouseHelpers.showCursor()
         }
 
@@ -2907,6 +2946,9 @@ extension MenuBarItemManager {
         /// The window of the item's shown interface.
         var shownInterfaceWindow: WindowInfo?
 
+        /// The bounds of the item while it is temporarily shown.
+        var shownItemBounds: CGRect?
+
         /// The number of attempts that have been made to rehide the item.
         var rehideAttempts = 0
 
@@ -2932,12 +2974,11 @@ extension MenuBarItemManager {
             if let window = shownInterfaceWindow,
                let current = WindowInfo(windowID: window.windowID)
             {
-                if current.layer == CGWindowLevelForKey(.popUpMenuWindow)
-                    || current.layer == CGWindowLevelForKey(.popUpMenuWindow) - 1
-                    || current.layer == CGWindowLevelForKey(.statusWindow)
-                    || current.layer == CGWindowLevelForKey(.mainMenuWindow)
-                {
-                    return current.isOnScreen
+                if Self.isMenuInterfaceWindow(current) {
+                    guard let shownItemBounds else {
+                        return current.isOnScreen
+                    }
+                    return current.isOnScreen && Self.isPopupWindow(current, near: shownItemBounds)
                 }
                 if let app = current.owningApplication {
                     return app.isActive && current.isOnScreen
@@ -2958,27 +2999,46 @@ extension MenuBarItemManager {
         }
 
         /// Checks whether the item's owning application has any visible
-        /// popup-menu window on screen.
+        /// popup/menu window on screen.
         ///
-        /// Only matches the pop-up menu level (the level macOS uses for
-        /// menus opened from menu bar items). Status-level and main-menu
-        /// level windows are excluded because those are the menu bar items
-        /// themselves — including the temporarily-shown item we're
-        /// tracking — not popups created by clicking them. A liberal
-        /// "above normal" match was previously used as a catch-all, but
-        /// it matched floating panels, modal levels, and other unrelated
-        /// app windows, keeping `isShowingInterface` true indefinitely
-        /// and preventing rehide.
+        /// macOS 26 can host menu extra popups in Control Center or Window
+        /// Server windows instead of the source app's PID. To avoid hiding the
+        /// temporary item while its menu is still open, accept menu-like
+        /// windows that are spatially attached to the shown menu bar item.
         private func appHasVisiblePopup() -> Bool {
             let windows = WindowInfo.createWindows(option: .onScreen)
-            let popUpLevel = CGWindowLevelForKey(.popUpMenuWindow)
             return windows.contains { window in
-                guard window.ownerPID == sourcePID else {
+                guard Self.isMenuInterfaceWindow(window) else {
                     return false
                 }
-                let level = CGWindowLevel(Int32(window.layer))
-                return level == popUpLevel || level == popUpLevel - 1
+                guard let shownItemBounds else {
+                    return window.ownerPID == sourcePID
+                }
+                return Self.isPopupWindow(window, near: shownItemBounds)
             }
+        }
+
+        static func isMenuInterfaceWindow(_ window: WindowInfo) -> Bool {
+            let level = CGWindowLevel(Int32(window.layer))
+            return level == CGWindowLevelForKey(.popUpMenuWindow) ||
+                level == CGWindowLevelForKey(.popUpMenuWindow) - 1 ||
+                level == CGWindowLevelForKey(.mainMenuWindow)
+        }
+
+        static func isPopupWindow(_ window: WindowInfo, near itemBounds: CGRect) -> Bool {
+            let horizontalPadding: CGFloat = 180
+            let verticalPadding: CGFloat = 48
+            let isTallerThanStatusItem = window.bounds.height > itemBounds.height + 8
+            guard isTallerThanStatusItem else {
+                return false
+            }
+            let expandedItemBounds = itemBounds.insetBy(
+                dx: -horizontalPadding,
+                dy: -verticalPadding
+            )
+            let horizontallyNear = window.bounds.maxX >= itemBounds.minX - horizontalPadding &&
+                window.bounds.minX <= itemBounds.maxX + horizontalPadding
+            return expandedItemBounds.intersects(window.bounds) || horizontallyNear
         }
 
         init(
@@ -3199,6 +3259,16 @@ extension MenuBarItemManager {
         // Fetch items specifically for the display where the item lives.
         let items = await MenuBarItem.getMenuBarItems(on: resolvedDisplayID, option: .activeSpace)
 
+        if items.contains(where: { $0.tag.isTransientCaptureIndicator }) {
+            MenuBarItemManager.diagLog.info(
+                """
+                temporarilyShow: deferring \(item.logString) because a transient \
+                capture indicator is present on display \(resolvedDisplayID)
+                """
+            )
+            return .showFailed
+        }
+
         guard let returnInfo = getReturnDestination(for: item, in: items) else {
             MenuBarItemManager.diagLog.error("No return destination for \(item.logString) on display \(resolvedDisplayID)")
             return .showFailed
@@ -3357,6 +3427,8 @@ extension MenuBarItemManager {
 
         let idsBeforeClick = Set(Bridging.getWindowList(option: .onScreen))
         let clickPID = clickItem.sourcePID ?? clickItem.ownerPID
+        let clickItemBounds = Bridging.getWindowBounds(for: clickItem.windowID) ?? clickItem.bounds
+        context.shownItemBounds = clickItemBounds
 
         do {
             // Single attempt: the item is already at a known-good position with
@@ -3394,7 +3466,19 @@ extension MenuBarItemManager {
         let windowsAfterClick = WindowInfo.createWindows(option: .onScreen)
 
         context.shownInterfaceWindow = windowsAfterClick.first { window in
-            window.ownerPID == clickPID && !idsBeforeClick.contains(window.windowID)
+            guard !idsBeforeClick.contains(window.windowID) else {
+                return false
+            }
+            guard TemporarilyShownItemContext.isMenuInterfaceWindow(window) else {
+                return false
+            }
+            guard TemporarilyShownItemContext.isPopupWindow(window, near: clickItemBounds) else {
+                return false
+            }
+            if window.ownerPID == clickPID {
+                return true
+            }
+            return true
         }
 
         return .movedAndClicked
@@ -3778,12 +3862,14 @@ extension MenuBarItemManager {
             return true
         }
 
-        // Non-hideable system items (screen recording, mic, camera indicators)
-        // must always appear in the visible section. If macOS placed one to the
-        // left of our hidden control item, move it back immediately — no
-        // newness check needed since these items should never be in a hidden
-        // section.
-        if let systemItem = leftmostItems.first(where: { !$0.canBeHidden }) {
+        // Durable non-hideable system items must always appear in the visible
+        // section. Transient capture indicators are intentionally excluded:
+        // moving them while active can leave macOS's recording icon stranded
+        // next to Thaw's expand icon after capture ends.
+        if let skippedIndicator = leftmostItems.first(where: { $0.tag.isTransientCaptureIndicator }) {
+            MenuBarItemManager.diagLog.debug("Skipping relocation for transient capture indicator \(skippedIndicator.logString)")
+        }
+        if let systemItem = leftmostItems.first(where: { !$0.canBeHidden && !$0.tag.isTransientCaptureIndicator }) {
             MenuBarItemManager.diagLog.info("Relocating non-hideable system item \(systemItem.logString) to visible section")
             do {
                 try await move(

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -2891,6 +2891,7 @@ extension MenuBarItemManager {
             do {
                 let clickStartTime = Date.now
                 try await postClickEvents(item: item, mouseButton: mouseButton)
+                scheduleImageCacheRefreshAfterMenuDismissal(appState: appState)
                 let clickDuration = Date.now.timeIntervalSince(clickStartTime)
                 MenuBarItemManager.diagLog.debug("Attempt \(n) succeeded in \(Int(clickDuration * 1000))ms, finished with click")
                 return
@@ -2905,6 +2906,55 @@ extension MenuBarItemManager {
                     throw error
                 }
                 throw EventError.cannotComplete
+            }
+        }
+    }
+
+    /// Waits for a clicked menu extra to open and then dismiss its menu,
+    /// refreshing the off-screen image cache once the pressed background
+    /// should no longer be captured.
+    private func scheduleImageCacheRefreshAfterMenuDismissal(appState: AppState) {
+        Task { [weak self, weak appState] in
+            guard let self, let appState else {
+                return
+            }
+
+            let menuOpenPollInterval: Duration = .milliseconds(75)
+            let menuClosePollInterval: Duration = .milliseconds(125)
+            let menuOpenDeadline = ContinuousClock.now + .milliseconds(500)
+
+            var sawMenuOpen = false
+            while ContinuousClock.now < menuOpenDeadline {
+                if await self.isAnyMenuBarItemMenuOpen() {
+                    sawMenuOpen = true
+                    break
+                }
+                try? await Task.sleep(for: menuOpenPollInterval)
+            }
+
+            guard sawMenuOpen else {
+                return
+            }
+
+            let menuCloseDeadline = ContinuousClock.now + .seconds(8)
+            while ContinuousClock.now < menuCloseDeadline {
+                try? await Task.sleep(for: menuClosePollInterval)
+                guard !Task.isCancelled else {
+                    return
+                }
+                if await !self.isAnyMenuBarItemMenuOpen() {
+                    await self.cacheItemsIfNeeded()
+                    guard !Task.isCancelled else {
+                        return
+                    }
+                    await appState.imageCache.updateCacheWithoutChecks(
+                        sections: MenuBarSection.Name.allCases
+                    )
+                    MenuBarItemManager.diagLog.debug(
+                        "Refreshed item image cache after menu dismissal"
+                    )
+                    return
+                }
             }
         }
     }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -3260,16 +3260,6 @@ extension MenuBarItemManager {
         // Fetch items specifically for the display where the item lives.
         let items = await MenuBarItem.getMenuBarItems(on: resolvedDisplayID, option: .activeSpace)
 
-        if items.contains(where: { $0.tag.isTransientCaptureIndicator }) {
-            MenuBarItemManager.diagLog.info(
-                """
-                temporarilyShow: deferring \(item.logString) because a transient \
-                capture indicator is present on display \(resolvedDisplayID)
-                """
-            )
-            return .showFailed
-        }
-
         guard let returnInfo = getReturnDestination(for: item, in: items) else {
             MenuBarItemManager.diagLog.error("No return destination for \(item.logString) on display \(resolvedDisplayID)")
             return .showFailed

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -1464,43 +1464,6 @@ extension MenuBarItemManager {
         await enforceControlItemOrder(controlItems: controlItems)
 
         guard !Task.isCancelled else {
-            MenuBarItemManager.diagLog.debug("cacheItemsRegardless: cancelled before restoreItemsToSavedSections")
-            return
-        }
-
-        // Skip all restore logic during the startup settling period.
-        // The settling period prevents cascading icon moves when many apps
-        // load at login or restart in quick succession (app update checks).
-        if !isInStartupSettling {
-            // Cross-section restore: move items back to their saved section
-            // BEFORE relocateNewLeftmostItems runs. This ensures items that
-            // have saved sections are restored to their proper places before
-            // the "new item" relocation logic can move them to the default
-            // section (which is usually hidden/always-hidden).
-            isRestoringItemOrder = true
-            isRestoringItemOrderTimestamp = Date()
-            let didRestoreSections = await restoreItemsToSavedSections(
-                items,
-                controlItems: controlItems,
-                previousWindowIDs: previousWindowIDs
-            )
-            if didRestoreSections {
-                MenuBarItemManager.diagLog.debug("Restored item to saved section; scheduling recache")
-                let continuation = self.backgroundCacheContinuation
-                self.backgroundCacheContinuation = nil
-                Task { [weak self] in
-                    try? await Task.sleep(for: MenuBarItemManager.uiSettleDelay)
-                    await self?.cacheItemsRegardless(skipRecentMoveCheck: true)
-                    self?.isRestoringItemOrder = false
-                    continuation?.resume()
-                    try? await Task.sleep(for: MenuBarItemManager.uiSettleDelay)
-                    await self?.cacheItemsIfNeeded()
-                }
-                return
-            }
-        }
-
-        guard !Task.isCancelled else {
             MenuBarItemManager.diagLog.debug("cacheItemsRegardless: cancelled before relocateNewLeftmostItems")
             return
         }
@@ -1533,7 +1496,9 @@ extension MenuBarItemManager {
             return
         }
 
-        // During startup settling, just cache items without restore/relocate.
+        // Skip all restore logic during the startup settling period.
+        // The settling period prevents cascading icon moves when many apps
+        // load at login or restart in quick succession (app update checks).
         // A final cacheItemsRegardless() after the period ends handles restore.
         guard !isInStartupSettling else {
             await uncheckedCacheItems(items: items, controlItems: controlItems, displayID: displayID)
@@ -1547,10 +1512,32 @@ extension MenuBarItemManager {
             MenuBarItemManager.diagLog.debug("cacheItemsRegardless: startup settling active, skipping restore")
             return
         }
-        // Note: isRestoringItemOrder remains true here so that if a concurrent
-        // cache call occurs (e.g., from app launch notification), it won't
-        // prematurely reset the flag and allow saveSectionOrder to run while
-        // we're still in the cooldown period from previous moves.
+
+        // Cross-section restore: move items back to their saved section
+        // before restoreSavedItemOrder handles within-section reordering.
+        // Set the flag before calling so that any intermediate cache
+        // updates during move() don't overwrite the saved section order.
+        isRestoringItemOrder = true
+        isRestoringItemOrderTimestamp = Date()
+        let didRestoreSections = await restoreItemsToSavedSections(
+            items,
+            controlItems: controlItems,
+            previousWindowIDs: previousWindowIDs
+        )
+        if didRestoreSections {
+            MenuBarItemManager.diagLog.debug("Restored item to saved section; scheduling recache")
+            let continuation = self.backgroundCacheContinuation
+            self.backgroundCacheContinuation = nil
+            Task { [weak self] in
+                try? await Task.sleep(for: MenuBarItemManager.uiSettleDelay)
+                await self?.cacheItemsRegardless(skipRecentMoveCheck: true)
+                self?.isRestoringItemOrder = false
+                continuation?.resume()
+                try? await Task.sleep(for: MenuBarItemManager.uiSettleDelay)
+                await self?.cacheItemsIfNeeded()
+            }
+            return
+        }
 
         let didRestoreOrder = await restoreSavedItemOrder(
             items,

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -3891,9 +3891,31 @@ extension MenuBarItemManager {
             // Only treat as "new" if we don't have a saved section for this item.
             // Items with saved sections should be handled by restoreItemsToSavedSections,
             // not by the "new item" relocation logic.
+            //
+            // We check multiple forms of the identifier to handle instanceIndex changes
+            // and different identifier formats:
+            // 1. Base identifier (namespace:title)
+            // 2. uniqueIdentifier (namespace:title:instanceIndex if > 0)
+            // 3. Namespace-only lookup for dynamic-title apps
             let hasSavedSection = savedSectionForIdentifier[identifier] != nil ||
                 savedSectionForIdentifier[item.uniqueIdentifier] != nil
-            guard !hasSavedSection else { return false }
+
+            // Additional check: look for any saved identifier with the same base namespace:title
+            // This handles cases where instanceIndex changes between app restarts
+            let baseIdentifier = identifier
+            let hasSavedSectionWithSameBase = savedSectionForIdentifier.contains { savedID, _ in
+                let savedBase = savedID.split(separator: ":", maxSplits: 2).prefix(2).joined(separator: ":")
+                return savedBase == baseIdentifier
+            }
+
+            guard !hasSavedSection, !hasSavedSectionWithSameBase else {
+                if hasSavedSection {
+                    MenuBarItemManager.diagLog.debug("Skipping relocation for \(item.logString) - has saved section")
+                } else {
+                    MenuBarItemManager.diagLog.debug("Skipping relocation for \(item.logString) - has saved section with same base identifier")
+                }
+                return false
+            }
 
             // Also skip items from bundle IDs that have explicitly saved sections in
             // hidden/always-hidden. This protects multi-icon apps (Stats, Hammerspoon,

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -902,7 +902,22 @@ final class MenuBarItemManager: ObservableObject {
         .sink { [weak self] _ in
             guard let self else { return }
             MenuBarItemManager.diagLog.debug("App terminated, refreshing cache")
-            Task {
+            Task { [weak self] in
+                guard let self else { return }
+                // Some apps tear down their NSStatusItem asynchronously after
+                // didTerminate fires, so one pass is not enough to drop the
+                // stale cached imagery. Re-check a few times after the process
+                // exit until the window list has actually settled.
+                //
+                // NOTE: We avoid calling performCacheCleanup between cache passes
+                // because it can remove image cache entries for items that are
+                // about to be restored by restoreItemsToSavedSections when the
+                // app quickly relaunches. Let the normal cache update logic handle
+                // cleanup to preserve images during the restore window.
+                await self.cacheItemsRegardless(skipRecentMoveCheck: true)
+                try? await Task.sleep(for: .milliseconds(500))
+                await self.cacheItemsIfNeeded()
+                try? await Task.sleep(for: .seconds(1.5))
                 await self.cacheItemsIfNeeded()
             }
         }
@@ -4200,16 +4215,25 @@ extension MenuBarItemManager {
     ) async -> Bool {
         guard !savedSectionOrder.isEmpty else { return false }
         guard !suppressNextNewLeftmostItemRelocation else { return false }
-        // 5 s cooldown (up from 2 s) gives more time for the system to settle after a
-        // restore before another one can start, preventing cascading icon moves when
-        // multiple apps restart in quick succession (e.g. app update checks).
-        guard !lastMoveOperationOccurred(within: .seconds(5)) else { return false }
 
         let currentWindowIDSet = Set(items.map(\.windowID))
         let previousWindowIDSet = Set(previousWindowIDs)
 
         // Detect actual window ID changes (some windows disappeared = app restart).
         let windowIDsChanged = !previousWindowIDSet.isEmpty && !previousWindowIDSet.isSubset(of: currentWindowIDSet)
+
+        // 5 s cooldown gives more time for the system to settle after a restore before
+        // another one can start, preventing cascading icon moves when multiple apps
+        // restart in quick succession (e.g. app update checks).
+        // Bypass the cooldown when there's clear evidence of an app restart (window ID
+        // changes), as this indicates a new app launch that needs immediate restoration.
+        if lastMoveOperationOccurred(within: .seconds(5)) {
+            guard windowIDsChanged else {
+                MenuBarItemManager.diagLog.debug("restoreItemsToSavedSections: within 5s cooldown and no window ID changes, skipping")
+                return false
+            }
+            MenuBarItemManager.diagLog.debug("restoreItemsToSavedSections: within 5s cooldown but window IDs changed, proceeding with restore")
+        }
 
         // Get current item tags and check if any saved items are present.
         let currentTags = Set(items.map { "\($0.tag.namespace):\($0.tag.title)" })

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemTag.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemTag.swift
@@ -69,6 +69,14 @@ struct MenuBarItemTag: Hashable, CustomStringConvertible {
         namespace.isUUID && title == "System Status Item Clone"
     }
 
+    /// A Boolean value that indicates whether the item is a transient system
+    /// indicator shown while screen, camera, or microphone capture is active.
+    var isTransientCaptureIndicator: Bool {
+        self == Self.audioVideoModule ||
+            self == Self.screenCaptureUI ||
+            (namespace.isUUID && title == Self.audioVideoModule.title)
+    }
+
     /// A textual representation of the tag.
     var description: String {
         var result = String(describing: namespace)

--- a/Thaw/Utilities/MouseHelpers.swift
+++ b/Thaw/Utilities/MouseHelpers.swift
@@ -137,23 +137,39 @@ enum MouseHelpers {
         let result = CGWarpMouseCursorPosition(point)
         if result != .success {
             diagLog.warning("CGWarpMouseCursorPosition failed (error: \(result.rawValue)), falling back to CGEvent mouseMoved")
-            // Posting a mouseMoved event is more reliable than warp when a
-            // menu is tracking the cursor — the event updates the cursor
-            // position in the Window Server even if warp is blocked.
-            guard
-                let source = CGEventSource(stateID: .hidSystemState),
-                let event = CGEvent(
-                    mouseEventSource: source,
-                    mouseType: .mouseMoved,
-                    mouseCursorPosition: point,
-                    mouseButton: .left
-                )
-            else {
-                diagLog.error("Failed to create fallback mouseMoved event")
-                return
-            }
-            event.post(tap: .cghidEventTap)
+            postMouseMoved(to: point)
         }
+    }
+
+    /// Restores the cursor to a point and reinforces the move shortly after.
+    ///
+    /// Menus and system capture indicators can briefly block or overwrite a
+    /// single cursor warp. Posting a mouse-moved event plus a delayed second
+    /// warp keeps synthetic menu bar interactions from leaving the user's
+    /// cursor at the drag or click endpoint.
+    static func restoreCursor(to point: CGPoint) {
+        warpCursor(to: point)
+        postMouseMoved(to: point)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            warpCursor(to: point)
+            postMouseMoved(to: point)
+        }
+    }
+
+    private static func postMouseMoved(to point: CGPoint) {
+        guard
+            let source = CGEventSource(stateID: .hidSystemState),
+            let event = CGEvent(
+                mouseEventSource: source,
+                mouseType: .mouseMoved,
+                mouseCursorPosition: point,
+                mouseButton: .left
+            )
+        else {
+            diagLog.error("Failed to create fallback mouseMoved event")
+            return
+        }
+        event.post(tap: .cghidEventTap)
     }
 
     /// Connects or disconnects the positions of the mouse and cursor.

--- a/Thaw/Utilities/MouseHelpers.swift
+++ b/Thaw/Utilities/MouseHelpers.swift
@@ -137,39 +137,23 @@ enum MouseHelpers {
         let result = CGWarpMouseCursorPosition(point)
         if result != .success {
             diagLog.warning("CGWarpMouseCursorPosition failed (error: \(result.rawValue)), falling back to CGEvent mouseMoved")
-            postMouseMoved(to: point)
+            // Posting a mouseMoved event is more reliable than warp when a
+            // menu is tracking the cursor — the event updates the cursor
+            // position in the Window Server even if warp is blocked.
+            guard
+                let source = CGEventSource(stateID: .hidSystemState),
+                let event = CGEvent(
+                    mouseEventSource: source,
+                    mouseType: .mouseMoved,
+                    mouseCursorPosition: point,
+                    mouseButton: .left
+                )
+            else {
+                diagLog.error("Failed to create fallback mouseMoved event")
+                return
+            }
+            event.post(tap: .cghidEventTap)
         }
-    }
-
-    /// Restores the cursor to a point and reinforces the move shortly after.
-    ///
-    /// Menus and system capture indicators can briefly block or overwrite a
-    /// single cursor warp. Posting a mouse-moved event plus a delayed second
-    /// warp keeps synthetic menu bar interactions from leaving the user's
-    /// cursor at the drag or click endpoint.
-    static func restoreCursor(to point: CGPoint) {
-        warpCursor(to: point)
-        postMouseMoved(to: point)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-            warpCursor(to: point)
-            postMouseMoved(to: point)
-        }
-    }
-
-    private static func postMouseMoved(to point: CGPoint) {
-        guard
-            let source = CGEventSource(stateID: .hidSystemState),
-            let event = CGEvent(
-                mouseEventSource: source,
-                mouseType: .mouseMoved,
-                mouseCursorPosition: point,
-                mouseButton: .left
-            )
-        else {
-            diagLog.error("Failed to create fallback mouseMoved event")
-            return
-        }
-        event.post(tap: .cghidEventTap)
     }
 
     /// Connects or disconnects the positions of the mouse and cursor.

--- a/ThawTests/MenuBarItemTagTests.swift
+++ b/ThawTests/MenuBarItemTagTests.swift
@@ -326,6 +326,29 @@ final class MenuBarItemTagTests: XCTestCase {
         XCTAssertFalse(tag.canBeHidden)
     }
 
+    // MARK: - Transient Capture Indicator Tests
+
+    func testAudioVideoModuleIsTransientCaptureIndicator() {
+        XCTAssertTrue(MenuBarItemTag.audioVideoModule.isTransientCaptureIndicator)
+    }
+
+    func testScreenCaptureUIIsTransientCaptureIndicator() {
+        XCTAssertTrue(MenuBarItemTag.screenCaptureUI.isTransientCaptureIndicator)
+    }
+
+    func testUUIDAudioVideoModuleIsTransientCaptureIndicator() {
+        let tag = MenuBarItemTag(
+            namespace: .uuid(UUID()),
+            title: "AudioVideoModule"
+        )
+
+        XCTAssertTrue(tag.isTransientCaptureIndicator)
+    }
+
+    func testFaceTimeIsNotTransientCaptureIndicator() {
+        XCTAssertFalse(MenuBarItemTag.faceTime.isTransientCaptureIndicator)
+    }
+
     // MARK: - Control Item Tests
 
     func testHiddenControlItemIsControlItem() {


### PR DESCRIPTION
## Summary
- classify transient macOS capture indicators and avoid moving or capturing over them
- tighten hidden Ice Bar click targeting so hidden rows are moved out instead of clicking same-looking visible items
- improve temporary menu popup detection and cursor restoration around synthetic menu bar interactions

## Root Cause
macOS capture indicators and Control Center-hosted menu extras can appear with transient or generic menu bar window metadata. Thaw could move/click/capture while those windows overlapped the hidden-section controls, leaving stale cached backgrounds or clicking the wrong visible menu item.

## Validation
- xcodebuild test -project Thaw.xcodeproj -scheme Thaw -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:ThawTests/MenuBarItemTagTests\n