### PR TITLE
fix(itemManager): restore profile layout after settling and on app relaunch

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -1657,6 +1657,35 @@ extension MenuBarItemManager {
         if activeProfileLayout != nil,
            !activeProfileItemIdentifiers.isEmpty
         {
+            // App-relaunch detection: uniqueIdentifier is namespace:title
+            // (windowID-independent and stable across restarts), so a
+            // relaunched app keeps the same identifier and would be filtered
+            // out of newProfileItems by profileSortedItemIdentifiers below.
+            // A fresh windowID for a profile-tracked item means the app
+            // re-registered its NSStatusItem at whatever position macOS
+            // chose, which is usually not the saved profile position. Drop
+            // such identifiers from the sorted snapshot so the existing
+            // late-arrival path picks them up.
+            let previousWindowIDSet = Set(previousWindowIDs)
+            if !previousWindowIDSet.isEmpty {
+                let relaunchedIdentifiers = Set(
+                    items
+                        .filter { item in
+                            !item.isControlItem
+                                && !previousWindowIDSet.contains(item.windowID)
+                                && activeProfileItemIdentifiers.contains(item.uniqueIdentifier)
+                        }
+                        .map(\.uniqueIdentifier)
+                )
+                if !relaunchedIdentifiers.isEmpty {
+                    let staleSorted = relaunchedIdentifiers.intersection(profileSortedItemIdentifiers)
+                    if !staleSorted.isEmpty {
+                        MenuBarItemManager.diagLog.info("Profile re-sort: detected \(staleSorted.count) relaunched profile item(s) with fresh windowID: \(staleSorted.sorted())")
+                        profileSortedItemIdentifiers.subtract(staleSorted)
+                    }
+                }
+            }
+
             await MainActor.run {
                 guard profileResortTask == nil,
                       !isApplyingProfileLayout
@@ -4924,6 +4953,19 @@ extension MenuBarItemManager {
         itemSectionMap: [String: String],
         itemOrder: [String: [String]]
     ) async {
+        // Wait for the startup settling period to end before applying the
+        // profile. During settling, cacheItemsRegardless skips restore and
+        // absorbs every current item into profileSortedItemIdentifiers; a
+        // layout applied here has its moves silently shadowed and the
+        // late-arrival re-sort path is broken for items that appeared
+        // inside the window.
+        if let settlingTask = startupSettlingTask, isInStartupSettling {
+            MenuBarItemManager.diagLog.debug(
+                "applyProfileLayout: waiting for startup settling to end"
+            )
+            await settlingTask.value
+        }
+
         // Directly set in-memory state (avoids cache cycle race).
         pinnedHiddenBundleIDs = pinnedHidden
         pinnedAlwaysHiddenBundleIDs = pinnedAlwaysHidden

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -1562,6 +1562,40 @@ extension MenuBarItemManager {
             return
         }
 
+        // App-relaunch detection: uniqueIdentifier is namespace:title
+        // (windowID-independent and stable across restarts), so a
+        // relaunched app keeps the same identifier and would be filtered
+        // out of newProfileItems by profileSortedItemIdentifiers in the
+        // late-arrival check below. A windowID not in previousWindowIDs
+        // for a profile-tracked item means the app re-registered its
+        // NSStatusItem at whatever position macOS chose, which is
+        // usually not the saved profile position. Drop such identifiers
+        // from the sorted snapshot so the late-arrival path picks them
+        // up. Run this BEFORE the relocate/restore early returns: those
+        // paths schedule a recache after which previousWindowIDs already
+        // contains the freshly registered windowID, and the signal would
+        // be lost.
+        if activeProfileLayout != nil,
+           !activeProfileItemIdentifiers.isEmpty,
+           !previousWindowIDs.isEmpty
+        {
+            let previousWindowIDSet = Set(previousWindowIDs)
+            let relaunchedIdentifiers = Set(
+                items
+                    .filter { item in
+                        !item.isControlItem
+                            && !previousWindowIDSet.contains(item.windowID)
+                            && activeProfileItemIdentifiers.contains(item.uniqueIdentifier)
+                    }
+                    .map(\.uniqueIdentifier)
+            )
+            let staleSorted = relaunchedIdentifiers.intersection(profileSortedItemIdentifiers)
+            if !staleSorted.isEmpty {
+                MenuBarItemManager.diagLog.info("Profile re-sort: detected \(staleSorted.count) relaunched profile item(s) with fresh windowID: \(staleSorted.sorted())")
+                profileSortedItemIdentifiers.subtract(staleSorted)
+            }
+        }
+
         if await relocateNewLeftmostItems(
             items,
             controlItems: controlItems,
@@ -1657,35 +1691,6 @@ extension MenuBarItemManager {
         if activeProfileLayout != nil,
            !activeProfileItemIdentifiers.isEmpty
         {
-            // App-relaunch detection: uniqueIdentifier is namespace:title
-            // (windowID-independent and stable across restarts), so a
-            // relaunched app keeps the same identifier and would be filtered
-            // out of newProfileItems by profileSortedItemIdentifiers below.
-            // A fresh windowID for a profile-tracked item means the app
-            // re-registered its NSStatusItem at whatever position macOS
-            // chose, which is usually not the saved profile position. Drop
-            // such identifiers from the sorted snapshot so the existing
-            // late-arrival path picks them up.
-            let previousWindowIDSet = Set(previousWindowIDs)
-            if !previousWindowIDSet.isEmpty {
-                let relaunchedIdentifiers = Set(
-                    items
-                        .filter { item in
-                            !item.isControlItem
-                                && !previousWindowIDSet.contains(item.windowID)
-                                && activeProfileItemIdentifiers.contains(item.uniqueIdentifier)
-                        }
-                        .map(\.uniqueIdentifier)
-                )
-                if !relaunchedIdentifiers.isEmpty {
-                    let staleSorted = relaunchedIdentifiers.intersection(profileSortedItemIdentifiers)
-                    if !staleSorted.isEmpty {
-                        MenuBarItemManager.diagLog.info("Profile re-sort: detected \(staleSorted.count) relaunched profile item(s) with fresh windowID: \(staleSorted.sorted())")
-                        profileSortedItemIdentifiers.subtract(staleSorted)
-                    }
-                }
-            }
-
             await MainActor.run {
                 guard profileResortTask == nil,
                       !isApplyingProfileLayout
@@ -4954,12 +4959,18 @@ extension MenuBarItemManager {
         itemOrder: [String: [String]]
     ) async {
         // Wait for the startup settling period to end before applying the
-        // profile. During settling, cacheItemsRegardless skips restore and
-        // absorbs every current item into profileSortedItemIdentifiers; a
-        // layout applied here has its moves silently shadowed and the
+        // profile. During settling, cacheItemsRegardless skips restore
+        // and absorbs every current item into profileSortedItemIdentifiers;
+        // a layout applied here has its moves silently shadowed and the
         // late-arrival re-sort path is broken for items that appeared
-        // inside the window.
-        if let settlingTask = startupSettlingTask, isInStartupSettling {
+        // inside the window. Loop in case performSetup re-enters while
+        // we are awaiting (e.g. a permission re-grant during login):
+        // re-entry cancels the captured task and starts a new settling
+        // window, so resuming on a single captured task could land us
+        // back inside an active window. Re-check isInStartupSettling
+        // after each await and pick up the current startupSettlingTask.
+        while isInStartupSettling {
+            guard let settlingTask = startupSettlingTask else { break }
             MenuBarItemManager.diagLog.debug(
                 "applyProfileLayout: waiting for startup settling to end"
             )


### PR DESCRIPTION
## What does this PR do?

Fixes two related bugs that left menu bar icons in the wrong section or order: (1) on initial launch of Thaw the saved profile layout was not applied because `applyProfileLayout` raced the startup settling period, and (2) when an app whose icon belongs to the active profile was quit and relaunched, its icon was not moved back to the saved profile position.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

N/A

## What is the current behavior?

Issue Number: N/A

On initial launch, `applyProfileLayout` was dispatched immediately by `ProfileManager.performSetup` and ran while `isInStartupSettling` was `true`. Concurrent `cacheItemsRegardless` cycles took the settling guard branch, skipped restore, and absorbed every current item into `profileSortedItemIdentifiers`. The LCS move loop's effects were silently shadowed and the post-settling late-arrival re-sort path then filtered those items out as already sorted, so the saved profile layout was never actually applied for items present at startup. Separately, because `uniqueIdentifier` is `namespace:title` (windowID-independent so persisted custom names survive restarts), a relaunched app reused the same identifier and was filtered out of `newProfileItems` by the subtraction against `profileSortedItemIdentifiers`, so `scheduleProfileResort` never fired even though the `NSStatusItem` had been freshly registered at a position that did not match the saved profile.

## What is the new behavior?

`applyProfileLayout` now awaits `startupSettlingTask.value` before touching any state, so it runs once against the settled cache produced by the final `cacheItemsRegardless` passes; `activeProfileLayout` stays `nil` for the duration of settling, making the absorb branch a no-op. `cacheItemsRegardless` now also detects relaunched profile items by scanning for items whose `windowID` is absent from `previousWindowIDs` and whose `uniqueIdentifier` is in `activeProfileItemIdentifiers`, and drops those identifiers from `profileSortedItemIdentifiers` so the existing late-arrival check picks them up and triggers `scheduleProfileResort`. Manual drags via Layout Bar continue to persist because their `windowID` does not change.

## PR Checklist

- [x] I've built and run the app locally
- [x] I've checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

Diagnostic log lines to watch when reproducing: `applyProfileLayout: waiting for startup settling to end` on cold start (only when settling is still active at apply time), and `Profile re-sort: detected N relaunched profile item(s) with fresh windowID: [...]` followed by `Profile re-sort: re-applying layout for late-arriving items` when a profiled app is quit and relaunched.

### Notes for reviewers

Two focused changes in `Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift`: a six-line settling gate at the top of `applyProfileLayout`, and a pre-check inside `cacheItemsRegardless` that prunes stale entries from `profileSortedItemIdentifiers` for items whose `windowID` just appeared. The absorb branch at the existing settling guard is now a no-op under normal flow but is intentionally left in place as a defensive guard against future call paths that might set `activeProfileLayout` outside `applyProfileLayout`. No changes to `ProfileManager` were required because gating inside `applyProfileLayout` covers all entry points (initial launch, display switch, focus filter, manual profile switch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate re-sorting of menu bar items after app relaunch by distinguishing relaunch-induced changes from genuinely new items.
  * Improved reliability of profile layout application by blocking profile changes until startup settling finishes, avoiding intermittent or premature layout restores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->