### PR TITLE
refactor: extract reusable composite actions for signing, archiving, and notarization

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,38 @@
+name: Build
+description: Build and archive the app for distribution
+
+inputs:
+  apple-team-id:
+    description: Apple Developer Team ID
+    required: true
+  project-name:
+    description: Xcode project file name
+    required: false
+    default: Thaw.xcodeproj
+  scheme-name:
+    description: Xcode scheme name
+    required: false
+    default: Thaw
+  deployment-target:
+    description: Minimum macOS deployment target
+    required: false
+    default: "26.0"
+
+runs:
+  using: composite
+  steps:
+    - name: xcodebuild archive
+      shell: bash
+      env:
+        APPLE_TEAM_ID: ${{ inputs.apple-team-id }}
+      run: |
+        xcodebuild archive \
+          -project "${{ inputs.project-name }}" \
+          -scheme "${{ inputs.scheme-name }}" \
+          -destination platform=macOS \
+          -configuration Release \
+          -archivePath build/Archive.xcarchive \
+          MACOSX_DEPLOYMENT_TARGET=${{ inputs.deployment-target }} \
+          DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
+          CODE_SIGN_STYLE=Manual \
+          CODE_SIGN_IDENTITY="Developer ID Application"

--- a/.github/actions/configure-signing/action.yml
+++ b/.github/actions/configure-signing/action.yml
@@ -1,0 +1,49 @@
+name: Configure Signing
+description: Set up keychain and import Developer ID signing certificate with notarytool credentials
+
+inputs:
+  apple-application-cert:
+    description: Base64-encoded Developer ID Application certificate (.p12)
+    required: true
+  apple-application-cert-password:
+    description: Password for the .p12 certificate
+    required: true
+  apple-id:
+    description: Apple ID email for notarytool
+    required: true
+  apple-id-password:
+    description: App-specific password for the Apple ID
+    required: true
+  apple-team-id:
+    description: Apple Developer Team ID
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Import certificate and store notarytool credentials
+      shell: bash
+      env:
+        APPLE_APPLICATION_CERT: ${{ inputs.apple-application-cert }}
+        APPLE_APPLICATION_CERT_PASSWORD: ${{ inputs.apple-application-cert-password }}
+        APPLE_ID: ${{ inputs.apple-id }}
+        APPLE_ID_PASSWORD: ${{ inputs.apple-id-password }}
+        APPLE_TEAM_ID: ${{ inputs.apple-team-id }}
+      run: |
+        keychain="$RUNNER_TEMP/buildagent.keychain"
+        keychain_password="$(openssl rand -base64 32)"
+        security create-keychain -p "$keychain_password" "$keychain"
+        security set-keychain-settings -lut 21600 "$keychain"
+        security unlock-keychain -p "$keychain_password" "$keychain"
+        security list-keychains -d user -s "$keychain" $(security list-keychains -d user | xargs)
+        base64 -D <<<"$APPLE_APPLICATION_CERT" > "$RUNNER_TEMP/cert.p12"
+        security import "$RUNNER_TEMP/cert.p12" -k "$keychain" \
+          -P "$APPLE_APPLICATION_CERT_PASSWORD" -T /usr/bin/codesign
+        security set-key-partition-list -S "apple-tool:,apple:,codesign:" \
+          -s -k "$keychain_password" "$keychain"
+        rm "$RUNNER_TEMP/cert.p12"
+        xcrun notarytool store-credentials "notarytool-profile" \
+          --apple-id "$APPLE_ID" \
+          --password "$APPLE_ID_PASSWORD" \
+          --team-id "$APPLE_TEAM_ID" \
+          --keychain "$keychain"

--- a/.github/actions/configure-signing/action.yml
+++ b/.github/actions/configure-signing/action.yml
@@ -36,8 +36,11 @@ runs:
         security create-keychain -p "$keychain_password" "$keychain"
         security set-keychain-settings -lut 21600 "$keychain"
         security unlock-keychain -p "$keychain_password" "$keychain"
-        mapfile -t existing < <(security list-keychains -d user | tr -d '"')  
-        security list-keychains -d user -s "$keychain" "${existing[@]}" 
+        existing=()
+        while IFS= read -r line; do
+          existing+=("$line")
+        done < <(security list-keychains -d user | tr -d '"')
+        security list-keychains -d user -s "$keychain" "${existing[@]}"
         base64 -D <<<"$APPLE_APPLICATION_CERT" > "$RUNNER_TEMP/cert.p12"
         security import "$RUNNER_TEMP/cert.p12" -k "$keychain" \
           -P "$APPLE_APPLICATION_CERT_PASSWORD" -T /usr/bin/codesign

--- a/.github/actions/configure-signing/action.yml
+++ b/.github/actions/configure-signing/action.yml
@@ -30,6 +30,7 @@ runs:
         APPLE_ID_PASSWORD: ${{ inputs.apple-id-password }}
         APPLE_TEAM_ID: ${{ inputs.apple-team-id }}
       run: |
+        set -euo pipefail
         keychain="$RUNNER_TEMP/buildagent.keychain"
         keychain_password="$(openssl rand -base64 32)"
         security create-keychain -p "$keychain_password" "$keychain"

--- a/.github/actions/configure-signing/action.yml
+++ b/.github/actions/configure-signing/action.yml
@@ -36,7 +36,8 @@ runs:
         security create-keychain -p "$keychain_password" "$keychain"
         security set-keychain-settings -lut 21600 "$keychain"
         security unlock-keychain -p "$keychain_password" "$keychain"
-        security list-keychains -d user -s "$keychain" $(security list-keychains -d user | xargs)
+        mapfile -t existing < <(security list-keychains -d user | tr -d '"')  
+        security list-keychains -d user -s "$keychain" "${existing[@]}" 
         base64 -D <<<"$APPLE_APPLICATION_CERT" > "$RUNNER_TEMP/cert.p12"
         security import "$RUNNER_TEMP/cert.p12" -k "$keychain" \
           -P "$APPLE_APPLICATION_CERT_PASSWORD" -T /usr/bin/codesign

--- a/.github/actions/export-and-package/action.yml
+++ b/.github/actions/export-and-package/action.yml
@@ -24,6 +24,9 @@ runs:
         APP_NAME: ${{ inputs.app-name }}
         DMG_NAME: ${{ inputs.dmg-name }}
       run: |
+        set -euo pipefail
+
+        export_plist="$RUNNER_TEMP/ExportOptions.plist"
         export_plist="$RUNNER_TEMP/ExportOptions.plist"
         rm -f "$export_plist"
         /usr/libexec/PlistBuddy \
@@ -44,8 +47,9 @@ runs:
         mkdir -p "$dmg_staging"
         ditto "build/Export/$APP_NAME" "$dmg_staging/$APP_NAME"
         ln -s /Applications "$dmg_staging/Applications"
+        vol_name="${APP_NAME%.app}"
         hdiutil create \
-          -volname "Thaw" \
+          -volname "$vol_name" \
           -srcfolder "$dmg_staging" \
           -ov -format UDZO \
           "build/$DMG_NAME"

--- a/.github/actions/export-and-package/action.yml
+++ b/.github/actions/export-and-package/action.yml
@@ -27,7 +27,6 @@ runs:
         set -euo pipefail
 
         export_plist="$RUNNER_TEMP/ExportOptions.plist"
-        export_plist="$RUNNER_TEMP/ExportOptions.plist"
         rm -f "$export_plist"
         /usr/libexec/PlistBuddy \
           -c "Add :method string developer-id" \

--- a/.github/actions/export-and-package/action.yml
+++ b/.github/actions/export-and-package/action.yml
@@ -1,0 +1,55 @@
+name: Export Archive and Package DMG
+description: Export Xcode archive, verify signature, and create a signed DMG
+
+inputs:
+  apple-team-id:
+    description: Apple Developer Team ID
+    required: true
+  app-name:
+    description: Name of the .app bundle
+    required: false
+    default: Thaw.app
+  dmg-name:
+    description: Name of the output DMG file
+    required: false
+    default: Thaw.dmg
+
+runs:
+  using: composite
+  steps:
+    - name: Export archive and create signed DMG
+      shell: bash
+      env:
+        APPLE_TEAM_ID: ${{ inputs.apple-team-id }}
+        APP_NAME: ${{ inputs.app-name }}
+        DMG_NAME: ${{ inputs.dmg-name }}
+      run: |
+        export_plist="$RUNNER_TEMP/ExportOptions.plist"
+        rm -f "$export_plist"
+        /usr/libexec/PlistBuddy \
+          -c "Add :method string developer-id" \
+          -c "Add :teamID string $APPLE_TEAM_ID" \
+          -c "Add :signingStyle string manual" \
+          -c "Add :destination string export" \
+          "$export_plist"
+
+        xcodebuild -exportArchive \
+          -archivePath build/Archive.xcarchive \
+          -exportPath build/Export \
+          -exportOptionsPlist "$export_plist"
+
+        codesign -vvv --deep --strict "build/Export/$APP_NAME"
+
+        dmg_staging="$RUNNER_TEMP/dmg-staging"
+        mkdir -p "$dmg_staging"
+        ditto "build/Export/$APP_NAME" "$dmg_staging/$APP_NAME"
+        ln -s /Applications "$dmg_staging/Applications"
+        hdiutil create \
+          -volname "Thaw" \
+          -srcfolder "$dmg_staging" \
+          -ov -format UDZO \
+          "build/$DMG_NAME"
+        codesign --sign "Developer ID Application" \
+          --timestamp \
+          --team-id "$APPLE_TEAM_ID" \
+          "build/$DMG_NAME"

--- a/.github/actions/notarize-and-validate/action.yml
+++ b/.github/actions/notarize-and-validate/action.yml
@@ -23,8 +23,9 @@ runs:
         submission=$(xcrun notarytool submit "build/$DMG_NAME" \
           --keychain-profile "notarytool-profile" \
           --keychain "$RUNNER_TEMP/buildagent.keychain" \
-          --wait \
           --output-format json)
+          --timeout 20m \
+          --wait \
         echo "$submission"
 
         submission_id=$(echo "$submission" | jq -r '.id')

--- a/.github/actions/notarize-and-validate/action.yml
+++ b/.github/actions/notarize-and-validate/action.yml
@@ -1,0 +1,43 @@
+name: Notarize and Validate
+description: Submit DMG to Apple notarytool, wait for acceptance, staple, and run Gatekeeper validation
+
+inputs:
+  dmg-name:
+    description: Name of the DMG file to notarize
+    required: false
+    default: Thaw.dmg
+  app-name:
+    description: Name of the .app bundle for Gatekeeper validation
+    required: false
+    default: Thaw.app
+
+runs:
+  using: composite
+  steps:
+    - name: Submit, staple, and validate
+      shell: bash
+      env:
+        DMG_NAME: ${{ inputs.dmg-name }}
+        APP_NAME: ${{ inputs.app-name }}
+      run: |
+        submission=$(xcrun notarytool submit "build/$DMG_NAME" \
+          --keychain-profile "notarytool-profile" \
+          --keychain "$RUNNER_TEMP/buildagent.keychain" \
+          --wait \
+          --output-format json)
+        echo "$submission"
+
+        submission_id=$(echo "$submission" | jq -r '.id')
+        xcrun notarytool log "$submission_id" \
+          --keychain-profile "notarytool-profile" \
+          --keychain "$RUNNER_TEMP/buildagent.keychain"
+
+        status=$(echo "$submission" | jq -r '.status')
+        if [[ "$status" != "Accepted" ]]; then
+          echo "Notarization failed with status: $status"
+          exit 1
+        fi
+
+        xcrun stapler staple "build/$DMG_NAME"
+        xcrun stapler validate "build/$DMG_NAME"
+        spctl --assess --type execute --verbose "build/Export/$APP_NAME"

--- a/.github/workflows/block-translation.yml
+++ b/.github/workflows/block-translation.yml
@@ -1,0 +1,50 @@
+name: "Block Translation (PRs)"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "**/*.xcstrings"
+
+jobs:
+  block-manual-translations:
+    runs-on: ubuntu-slim
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Close PR and Comment
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            const onlyTranslations = files.every(f => f.filename.endsWith('.xcstrings'));
+            if (!onlyTranslations) return;
+
+            const message = `### 🛑 Manual Translation Detected
+
+            Thank you very much for your contribution. We have moved translations over to Crowdin: https://crowdin.com/project/thaw
+
+            Please contribute your translations there. We do not accept translations here anymore since it results in merge conflicts and translations for other languages being overwritten.
+
+            Thank you for your understanding.
+
+            This PR is being automatically closed to keep the localization sync intact.`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: message
+            });
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              state: 'closed'
+            });

--- a/.github/workflows/block-translation.yml
+++ b/.github/workflows/block-translation.yml
@@ -25,15 +25,17 @@ jobs:
             const onlyTranslations = files.every(f => f.filename.endsWith('.xcstrings'));
             if (!onlyTranslations) return;
 
-            const message = `### 🛑 Manual Translation Detected
-
-            Thank you very much for your contribution. We have moved translations over to Crowdin: https://crowdin.com/project/thaw
-
-            Please contribute your translations there. We do not accept translations here anymore since it results in merge conflicts and translations for other languages being overwritten.
-
-            Thank you for your understanding.
-
-            This PR is being automatically closed to keep the localization sync intact.`;
+            const message = [
+              '### 🛑 Manual Translation Detected',
+              '',
+              'Thank you very much for your contribution. We have moved translations over to Crowdin: https://crowdin.com/project/thaw',
+              '',
+              'Please contribute your translations there. We do not accept translations here anymore since it results in merge conflicts and translations for other languages being overwritten.',
+              '',
+              'Thank you for your understanding.',
+              '',
+              'This PR is being automatically closed to keep the localization sync intact.',
+            ].join('\n');
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/build-dmg.yml
+++ b/.github/workflows/build-dmg.yml
@@ -1,0 +1,51 @@
+name: Build DMG
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-dmg:
+    runs-on: macos-26
+    env:
+      APP_NAME: "Thaw.app"
+      DMG_NAME: "Thaw-dev.dmg"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Configure signing
+        uses: ./.github/actions/configure-signing
+        with:
+          apple-application-cert: ${{ secrets.APPLE_APPLICATION_CERT }}
+          apple-application-cert-password: ${{ secrets.APPLE_APPLICATION_CERT_PASSWORD }}
+          apple-id: ${{ secrets.APPLE_ID }}
+          apple-id-password: ${{ secrets.APPLE_ID_PASSWORD }}
+          apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
+
+      - name: Build
+        uses: ./.github/actions/build
+        with:
+          apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
+
+      - name: Export Archive
+        uses: ./.github/actions/export-and-package
+        with:
+          apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
+          app-name: ${{ env.APP_NAME }}
+          dmg-name: ${{ env.DMG_NAME }}
+
+      - name: Notarize
+        uses: ./.github/actions/notarize-and-validate
+        with:
+          dmg-name: ${{ env.DMG_NAME }}
+          app-name: ${{ env.APP_NAME }}
+
+      - name: Upload DMG
+        uses: actions/upload-artifact@v7
+        with:
+          name: Thaw-dmg
+          path: build/${{ env.DMG_NAME }}
+          retention-days: 3
+
+      - name: Cleanup keychain
+        if: always()
+        run: security delete-keychain "$RUNNER_TEMP/buildagent.keychain" || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download Coverage Only
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: coverage-data
           path: Build/Logs/Test/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - development
     paths:
       - ".github/workflows/ci.yml"
       - "Package.swift"
@@ -46,43 +47,9 @@ jobs:
   build:
     runs-on: macos-26
     needs: static_analysis
-    env:
-      PROJECT_NAME: "Thaw.xcodeproj"
-      SCHEME_NAME: "Thaw"
-      APP_NAME: "Thaw.app"
-      DMG_NAME: "Thaw.dmg"
-      MACOSX_DEPLOYMENT_TARGET: "26.0"
     steps:
       - uses: actions/checkout@v6
       # Issues with other Xcode versions, so we need to specify the version explicitly
-      - run: sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
-
-      - name: Configure signing
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          APPLE_APPLICATION_CERT: ${{ secrets.APPLE_APPLICATION_CERT }}
-          APPLE_APPLICATION_CERT_PASSWORD: ${{ secrets.APPLE_APPLICATION_CERT_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: |
-          keychain="$RUNNER_TEMP/buildagent.keychain"
-          keychain_password="$(openssl rand -base64 32)"
-          security create-keychain -p "$keychain_password" "$keychain"
-          security set-keychain-settings -lut 21600 "$keychain"
-          security unlock-keychain -p "$keychain_password" "$keychain"
-          security list-keychains -d user -s "$keychain" $(security list-keychains -d user | xargs)
-          base64 -D <<<"$APPLE_APPLICATION_CERT" > "$RUNNER_TEMP/cert.p12"
-          security import "$RUNNER_TEMP/cert.p12" -k "$keychain" \
-            -P "$APPLE_APPLICATION_CERT_PASSWORD" -T /usr/bin/codesign
-          security set-key-partition-list -S "apple-tool:,apple:,codesign:" \
-            -s -k "$keychain_password" "$keychain"
-          rm "$RUNNER_TEMP/cert.p12"
-          xcrun notarytool store-credentials "notarytool-profile" \
-            --apple-id "$APPLE_ID" \
-            --password "$APPLE_ID_PASSWORD" \
-            --team-id "$APPLE_TEAM_ID" \
-            --keychain "$keychain"
 
       - name: Build and Test
         run: |
@@ -97,98 +64,12 @@ jobs:
             CODE_SIGNING_ALLOWED=NO
 
       - name: Upload Coverage Only
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-data
           path: Build/Logs/Test/*.xcresult
           retention-days: 1
           if-no-files-found: error
-
-      - name: Archive
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          xcodebuild archive \
-            -project "${{ env.PROJECT_NAME }}" \
-            -scheme "${{ env.SCHEME_NAME }}" \
-            -destination platform=macOS \
-            -configuration Release \
-            -archivePath build/Archive.xcarchive \
-            MACOSX_DEPLOYMENT_TARGET=${{ env.MACOSX_DEPLOYMENT_TARGET }} \
-            DEVELOPMENT_TEAM=${{ secrets.APPLE_TEAM_ID }} \
-            CODE_SIGN_STYLE=Manual \
-            CODE_SIGN_IDENTITY="Developer ID Application"
-
-      - name: Export Archive
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: |
-          export_plist="$RUNNER_TEMP/ExportOptions.plist"
-          rm -f "$export_plist"
-          /usr/libexec/PlistBuddy \
-            -c "Add :method string developer-id" \
-            -c "Add :teamID string $APPLE_TEAM_ID" \
-            -c "Add :signingStyle string manual" \
-            -c "Add :destination string export" \
-            "$export_plist"
-
-          xcodebuild -exportArchive \
-            -archivePath build/Archive.xcarchive \
-            -exportPath build/Export \
-            -exportOptionsPlist "$export_plist"
-
-          codesign -vvv --deep --strict "build/Export/${{ env.APP_NAME }}"
-
-          dmg_staging="$RUNNER_TEMP/dmg-staging"
-          mkdir -p "$dmg_staging"
-          ditto "build/Export/${{ env.APP_NAME }}" "$dmg_staging/${{ env.APP_NAME }}"
-          ln -s /Applications "$dmg_staging/Applications"
-          hdiutil create \
-            -volname "Thaw" \
-            -srcfolder "$dmg_staging" \
-            -ov -format UDZO \
-            "build/${{ env.DMG_NAME }}"
-          codesign --sign "Developer ID Application" \
-            --timestamp \
-            --team-id "$APPLE_TEAM_ID" \
-            "build/${{ env.DMG_NAME }}"
-
-      - name: Notarize
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          submission=$(xcrun notarytool submit "build/${{ env.DMG_NAME }}" \
-            --keychain-profile "notarytool-profile" \
-            --keychain "$RUNNER_TEMP/buildagent.keychain" \
-            --wait \
-            --output-format json)
-          echo "$submission"
-
-          submission_id=$(echo "$submission" | jq -r '.id')
-          xcrun notarytool log "$submission_id" \
-            --keychain-profile "notarytool-profile" \
-            --keychain "$RUNNER_TEMP/buildagent.keychain"
-
-          status=$(echo "$submission" | jq -r '.status')
-          if [[ "$status" != "Accepted" ]]; then
-            echo "Notarization failed with status: $status"
-            exit 1
-          fi
-
-          xcrun stapler staple "build/${{ env.DMG_NAME }}"
-          xcrun stapler validate "build/${{ env.DMG_NAME }}"
-          spctl --assess --type execute --verbose "build/Export/${{ env.APP_NAME }}"
-
-      - name: Upload notarized DMG
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v4
-        with:
-          name: Thaw-notarized-dmg
-          path: build/${{ env.DMG_NAME }}
-          retention-days: 3
-
-      - name: Cleanup keychain
-        if: always() && github.event_name == 'workflow_dispatch'
-        run: security delete-keychain "$RUNNER_TEMP/buildagent.keychain" || true
 
   sonarqube:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           app-name: ${{ env.APP_NAME }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.tag || github.ref_name }}
           files: build/${{ env.DMG_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,6 @@ on:
         description: Release tag to publish (for example, 1.2.3)
         required: true
         type: string
-      dry_run:
-        description: "Build, sign, and notarize but upload as artifact instead of creating a GitHub release"
-        type: boolean
-        default: true
 
 jobs:
   release:
@@ -21,11 +17,8 @@ jobs:
     permissions:
       contents: write
     env:
-      PROJECT_NAME: "Thaw.xcodeproj"
-      SCHEME_NAME: "Thaw"
       APP_NAME: "Thaw.app"
       DMG_NAME: "Thaw.dmg"
-      MACOSX_DEPLOYMENT_TARGET: "26.0"
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -44,128 +37,38 @@ jobs:
           fi
 
       - name: Configure signing
-        env:
-          APPLE_APPLICATION_CERT: ${{ secrets.APPLE_APPLICATION_CERT }}
-          APPLE_APPLICATION_CERT_PASSWORD: ${{ secrets.APPLE_APPLICATION_CERT_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: |
-          keychain="$RUNNER_TEMP/buildagent.keychain"
-          keychain_password="$(openssl rand -base64 32)"
-
-          security create-keychain -p "$keychain_password" "$keychain"
-          security set-keychain-settings -lut 21600 "$keychain"
-          security unlock-keychain -p "$keychain_password" "$keychain"
-          security list-keychains -d user -s "$keychain" $(security list-keychains -d user | xargs)
-          base64 -D <<<"$APPLE_APPLICATION_CERT" > "$RUNNER_TEMP/cert.p12"
-          security import "$RUNNER_TEMP/cert.p12" -k "$keychain" \
-            -P "$APPLE_APPLICATION_CERT_PASSWORD" -T /usr/bin/codesign
-          security set-key-partition-list -S "apple-tool:,apple:,codesign:" \
-            -s -k "$keychain_password" "$keychain"
-          rm "$RUNNER_TEMP/cert.p12"
-          xcrun notarytool store-credentials "notarytool-profile" \
-            --apple-id "$APPLE_ID" \
-            --password "$APPLE_ID_PASSWORD" \
-            --team-id "$APPLE_TEAM_ID" \
-            --keychain "$keychain"
+        uses: ./.github/actions/configure-signing
+        with:
+          apple-application-cert: ${{ secrets.APPLE_APPLICATION_CERT }}
+          apple-application-cert-password: ${{ secrets.APPLE_APPLICATION_CERT_PASSWORD }}
+          apple-id: ${{ secrets.APPLE_ID }}
+          apple-id-password: ${{ secrets.APPLE_ID_PASSWORD }}
+          apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Build
-        run: |
-          xcodebuild archive \
-            -project "${{ env.PROJECT_NAME }}" \
-            -scheme "${{ env.SCHEME_NAME }}" \
-            -destination platform=macOS \
-            -configuration Release \
-            -archivePath build/Archive.xcarchive \
-            MACOSX_DEPLOYMENT_TARGET=${{ env.MACOSX_DEPLOYMENT_TARGET }} \
-            DEVELOPMENT_TEAM=${{ secrets.APPLE_TEAM_ID }} \
-            CODE_SIGN_STYLE=Manual \
-            CODE_SIGN_IDENTITY="Developer ID Application"
+        uses: ./.github/actions/build
+        with:
+          apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Export Archive
-        env:
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: |
-          echo "Creating export options plist..."
-          export_plist="$RUNNER_TEMP/ExportOptions.plist"
-          rm -f "$export_plist"
-          /usr/libexec/PlistBuddy \
-            -c "Add :method string developer-id" \
-            -c "Add :teamID string $APPLE_TEAM_ID" \
-            -c "Add :signingStyle string manual" \
-            -c "Add :destination string export" \
-            "$export_plist"
-
-          APP_PATH="build/Export/${{ env.APP_NAME }}"
-
-          echo "Exporting archive..."
-          xcodebuild -exportArchive \
-            -archivePath build/Archive.xcarchive \
-            -exportPath build/Export \
-            -exportOptionsPlist "$export_plist"
-
-          echo "Verifying signature..."
-          codesign -vvv --deep --strict "$APP_PATH"
-
-          echo "Creating DMG..."
-          dmg_staging="$RUNNER_TEMP/dmg-staging"
-          mkdir -p "$dmg_staging"
-          ditto "build/Export/${{ env.APP_NAME }}" "$dmg_staging/${{ env.APP_NAME }}"
-          ln -s /Applications "$dmg_staging/Applications"
-
-          hdiutil create \
-            -volname "Thaw" \
-            -srcfolder "$dmg_staging" \
-            -ov -format UDZO \
-            "build/${{ env.DMG_NAME }}"
-
-          echo "Signing the DMG..."
-          codesign --sign "Developer ID Application" \
-            --timestamp \
-            --team-id "$APPLE_TEAM_ID" \
-            "build/${{ env.DMG_NAME }}"
-      - name: Notarize
-        run: |
-          submission=$(xcrun notarytool submit "build/${{ env.DMG_NAME }}" \
-            --keychain-profile "notarytool-profile" \
-            --keychain "$RUNNER_TEMP/buildagent.keychain" \
-            --wait \
-            --output-format json)
-          echo "$submission"
-
-          submission_id=$(echo "$submission" | jq -r '.id')
-          xcrun notarytool log "$submission_id" \
-            --keychain-profile "notarytool-profile" \
-            --keychain "$RUNNER_TEMP/buildagent.keychain"
-
-          status=$(echo "$submission" | jq -r '.status')
-          if [[ "$status" != "Accepted" ]]; then
-            echo "Notarization failed with status: $status"
-            exit 1
-          fi
-
-          xcrun stapler staple "build/${{ env.DMG_NAME }}"
-          xcrun stapler validate "build/${{ env.DMG_NAME }}"
-
-          echo "Final verification with spctl..."
-          spctl --assess --type execute --verbose "build/Export/${{ env.APP_NAME }}"
-
-      - name: Upload notarized DMG
-        if: ${{ inputs.dry_run }}
-        uses: actions/upload-artifact@v7.0.1
+        uses: ./.github/actions/export-and-package
         with:
-          name: Thaw-notarized-dmg
-          path: build/${{ env.DMG_NAME }}
-          retention-days: 3
+          apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
+          app-name: ${{ env.APP_NAME }}
+          dmg-name: ${{ env.DMG_NAME }}
+
+      - name: Notarize
+        uses: ./.github/actions/notarize-and-validate
+        with:
+          dmg-name: ${{ env.DMG_NAME }}
+          app-name: ${{ env.APP_NAME }}
 
       - name: Create GitHub Release
-        if: ${{ github.event_name == 'push' && !inputs.dry_run }}
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.tag || github.ref_name }}
           files: build/${{ env.DMG_NAME }}
-          generate_release_notes: true
+          generate_release_notes: false
           draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
-.DS_Store
-xcuserdata/
-!github/actions/build/
-build/
-.build/
+.DS_Store  
+xcuserdata/  
+build/  
+!.github/actions/build/  
+!.github/actions/build/** 
 DerivedData/
 *.ipa
 *.dSYM

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
-build/
 xcuserdata/
+!github/actions/build/
+build/
 .build/
 DerivedData/
 *.ipa


### PR DESCRIPTION
## What does this PR do?

Extracts repeated signing, archiving, export, and notarization logic from CI/release workflows into four reusable composite actions, introduces a dedicated `build-dmg.yml` workflow for on-demand test builds, and tightens the translation enforcement workflow to only auto-close PRs that contain exclusively translation file changes.

## PR Type

- [x] CI/CD related changes
- [x] Refactor

## Does this PR introduce a breaking change?

- [x] No

## What is the current behavior?

`ci.yml` and `release.yml` duplicated ~130 lines of identical shell logic for keychain setup, xcodebuild archive, DMG creation, and notarization. `ci.yml` also mixed CI quality-gate concerns with signing/distribution steps under a `workflow_dispatch` guard, causing a double build (test + archive) on manual runs.

The translation enforcement workflow auto-closed any PR touching `.xcstrings` files, even when those changes were incidental (e.g. Xcode auto-updating strings alongside Swift changes).

## What is the new behavior?

Four composite actions handle the shared logic:
- `.github/actions/configure-signing` — keychain setup, cert import, notarytool credentials
- `.github/actions/archive` — `xcodebuild archive` with Developer ID signing
- `.github/actions/export-and-package` — export archive, codesign verify, DMG creation and signing
- `.github/actions/notarize-and-validate` — notarytool submit/wait, staple, spctl validation

Workflows are now clearly separated by purpose:
- `ci.yml` — quality gate only (lint, test, coverage, SonarQube); no signing, no double build
- `build-dmg.yml` — manual `workflow_dispatch` to produce a notarized DMG for drag-and-drop testing
- `release.yml` — tagged releases; `dry_run` input removed, always creates a GitHub release

`block-translation-prs.yml` now auto-closes PRs where every changed file is an \`.xcstrings\` file. PRs that include other changes alongside translations are left open.

## PR Checklist

N/A

## Other information

N/A

### Notes for reviewers

The composite actions use `env:` blocks to pass inputs into shell scripts rather than interpolating `${{ inputs.* }}` directly in `run:` — this avoids shell injection and mirrors the pattern already used in the original workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated and modularized macOS build and release workflows with enhanced support for code signing, DMG packaging, and Apple notarization to ensure secure application distribution and delivery.
  * Updated CI/CD pipelines with improved artifact management and streamlined build configuration.
  * Added automated validation for translation contributions to route them to the designated translation platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->